### PR TITLE
fix: Include is_public field in search API responses for user visibility

### DIFF
--- a/src/controllers/searchController.js
+++ b/src/controllers/searchController.js
@@ -1,7 +1,6 @@
-const db = require('../config/database');
+const db = require("../config/database");
 
 const searchController = {
-
   async globalSearch(req, res) {
     try {
       const { query, authenticated } = req.query;
@@ -17,12 +16,12 @@ const searchController = {
       if (!query || query.trim().length < 2) {
         return res.status(400).json({
           success: false,
-          message: 'Search query must be at least 2 characters long'
+          message: "Search query must be at least 2 characters long",
         });
       }
 
       const searchTerm = `%${query.trim()}%`;
-      
+
       // Base team query with parameter placeholders
       let teamQuery = `
         SELECT
@@ -45,10 +44,10 @@ const searchController = {
           )
           AND t.archived_at IS NULL
       `;
-      
+
       // Initialize parameters array with the search term
       const teamParams = [searchTerm];
-      
+
       // Add visibility condition based on authentication
       if (userId) {
         // For authenticated users: show public teams OR teams they created OR teams they're a member of
@@ -67,7 +66,7 @@ const searchController = {
         // For non-authenticated users: show only public teams
         teamQuery += ` AND t.is_public = TRUE`;
       }
-      
+
       // Add group by and limit
       teamQuery += `
         GROUP BY
@@ -75,7 +74,7 @@ const searchController = {
         LIMIT 20
       `;
 
-      // User query with parameter placeholders
+      // User query with parameter placeholders - UPDATED TO INCLUDE is_public
       let userQuery = `
         SELECT
           u.id,
@@ -85,6 +84,7 @@ const searchController = {
           u.bio,
           u.postal_code,
           u.avatar_url,
+          u.is_public,
           (SELECT STRING_AGG(t.name, ', ')
             FROM user_tags ut
             JOIN tags t ON ut.tag_id = t.id
@@ -100,10 +100,10 @@ const searchController = {
             t.name ILIKE $1
         )
       `;
-      
+
       // Initialize parameters array with the search term
       const userParams = [searchTerm];
-      
+
       // Add visibility condition based on authentication
       if (userId) {
         // For authenticated users: show public profiles OR their own profile
@@ -118,11 +118,11 @@ const searchController = {
         // For non-authenticated users: show only public profiles
         userQuery += ` AND u.is_public = TRUE`;
       }
-      
-      // Add group by and limit
+
+      // Add group by and limit - UPDATED TO INCLUDE is_public
       userQuery += `
         GROUP BY
-          u.id, u.username, u.first_name, u.last_name, u.bio, u.postal_code, u.avatar_url
+          u.id, u.username, u.first_name, u.last_name, u.bio, u.postal_code, u.avatar_url, u.is_public
         LIMIT 20
       `;
 
@@ -132,31 +132,36 @@ const searchController = {
 
       const [teamResults, userResults] = await Promise.all([
         db.pool.query(teamQuery, teamParams),
-        db.pool.query(userQuery, userParams)
+        db.pool.query(userQuery, userParams),
       ]);
 
       console.log(`Final team results:`, teamResults.rows);
       console.log(`Final user results:`, userResults.rows);
 
       // Ensure boolean values are correctly represented
-      const teamsWithFixedVisibility = teamResults.rows.map(team => ({
+      const teamsWithFixedVisibility = teamResults.rows.map((team) => ({
         ...team,
-        is_public: team.is_public === true
+        is_public: team.is_public === true,
+      }));
+
+      const usersWithFixedVisibility = userResults.rows.map((user) => ({
+        ...user,
+        is_public: user.is_public === true,
       }));
 
       res.status(200).json({
         success: true,
         data: {
           teams: teamsWithFixedVisibility,
-          users: userResults.rows
-        }
+          users: usersWithFixedVisibility,
+        },
       });
     } catch (error) {
-      console.error('Search error:', error);
+      console.error("Search error:", error);
       res.status(500).json({
         success: false,
-        message: 'Error performing search',
-        error: error.message
+        message: "Error performing search",
+        error: error.message,
       });
     }
   },
@@ -181,10 +186,10 @@ const searchController = {
         LEFT JOIN team_members tm ON t.id = tm.team_id
         WHERE t.archived_at IS NULL
       `;
-      
+
       // Initialize parameters array
       const teamParams = [];
-      
+
       // Add visibility condition based on authentication
       if (userId) {
         // For authenticated users: show public teams OR teams they created OR teams they're a member of
@@ -203,7 +208,7 @@ const searchController = {
         // For non-authenticated users: show only public teams
         teamQuery += ` AND t.is_public = TRUE`;
       }
-      
+
       // Add group by and limit
       teamQuery += `
         GROUP BY
@@ -211,7 +216,7 @@ const searchController = {
         LIMIT 20
       `;
 
-      // User query with parameter placeholders
+      // User query with parameter placeholders - UPDATED TO INCLUDE is_public
       let userQuery = `
         SELECT
           u.id,
@@ -221,6 +226,7 @@ const searchController = {
           u.bio,
           u.postal_code,
           u.avatar_url,
+          u.is_public,
           (SELECT STRING_AGG(t.name, ', ')
             FROM user_tags ut
             JOIN tags t ON ut.tag_id = t.id
@@ -228,10 +234,10 @@ const searchController = {
         FROM users u
         WHERE 1=1
       `;
-      
+
       // Initialize parameters array
       const userParams = [];
-      
+
       // Add visibility condition based on authentication
       if (userId) {
         // For authenticated users: show public profiles OR their own profile
@@ -246,37 +252,42 @@ const searchController = {
         // For non-authenticated users: show only public profiles
         userQuery += ` AND u.is_public = TRUE`;
       }
-      
-      // Add group by and limit
+
+      // Add group by and limit - UPDATED TO INCLUDE is_public
       userQuery += `
         GROUP BY
-          u.id, u.username, u.first_name, u.last_name, u.bio, u.postal_code, u.avatar_url
+          u.id, u.username, u.first_name, u.last_name, u.bio, u.postal_code, u.avatar_url, u.is_public
         LIMIT 20
       `;
 
       const [teamResults, userResults] = await Promise.all([
         db.pool.query(teamQuery, teamParams),
-        db.pool.query(userQuery, userParams)
+        db.pool.query(userQuery, userParams),
       ]);
 
-      const teamsWithFixedVisibility = teamResults.rows.map(team => ({
+      const teamsWithFixedVisibility = teamResults.rows.map((team) => ({
         ...team,
-        is_public: team.is_public === true
+        is_public: team.is_public === true,
+      }));
+
+      const usersWithFixedVisibility = userResults.rows.map((user) => ({
+        ...user,
+        is_public: user.is_public === true,
       }));
 
       res.status(200).json({
         success: true,
         data: {
           teams: teamsWithFixedVisibility,
-          users: userResults.rows
-        }
+          users: usersWithFixedVisibility,
+        },
       });
     } catch (error) {
-      console.error('Error fetching all users and teams:', error);
+      console.error("Error fetching all users and teams:", error);
       res.status(500).json({
         success: false,
-        message: 'Error fetching data',
-        error: error.message
+        message: "Error fetching data",
+        error: error.message,
       });
     }
   },
@@ -285,7 +296,7 @@ const searchController = {
     try {
       const { query, tags, location, distance } = req.query;
       const userId = req.user?.id;
-      
+
       // Build dynamic search query with parameter placeholders
       let searchQuery = `
         SELECT
@@ -299,7 +310,7 @@ const searchController = {
         FROM teams t
         LEFT JOIN team_members tm ON t.id = tm.team_id
       `;
-        
+
       // Add tag joins if searching by tags
       if (tags) {
         searchQuery += `
@@ -307,14 +318,14 @@ const searchController = {
           JOIN tags tag ON tt.tag_id = tag.id
         `;
       }
-        
+
       // Start WHERE clause
       searchQuery += ` WHERE t.archived_at IS NULL `;
-      
+
       // Initialize parameters array
       const queryParams = [];
       let paramIndex = 1;
-      
+
       // Add visibility condition based on authentication
       if (userId) {
         // For authenticated users: show public teams OR teams they created OR teams they're a member of
@@ -334,56 +345,58 @@ const searchController = {
         // For non-authenticated users: show only public teams
         searchQuery += ` AND t.is_public = TRUE`;
       }
-      
+
       // Add search term condition if query is provided
       if (query) {
         searchQuery += ` AND (t.name ILIKE $${paramIndex} OR t.description ILIKE $${paramIndex}) `;
         queryParams.push(`%${query}%`);
         paramIndex++;
       }
-      
+
       // Add tag condition if tags are provided
       if (tags) {
         const tagIds = Array.isArray(tags) ? tags : [tags];
-        const tagPlaceholders = tagIds.map((_, i) => `$${paramIndex + i}`).join(',');
+        const tagPlaceholders = tagIds
+          .map((_, i) => `$${paramIndex + i}`)
+          .join(",");
         searchQuery += ` AND tag.id IN (${tagPlaceholders}) `;
         queryParams.push(...tagIds);
         paramIndex += tagIds.length;
       }
-      
+
       // Add location condition if location is provided
       if (location) {
         searchQuery += ` AND t.postal_code = $${paramIndex} `;
         queryParams.push(location);
         paramIndex++;
       }
-      
+
       // Group by and limit
       searchQuery += `
         GROUP BY t.id, t.name, t.description, t.is_public, t.max_members, t.creator_id
         LIMIT 20
       `;
-      
+
       const result = await db.pool.query(searchQuery, queryParams);
-      
+
       // Ensure proper boolean values for is_public in teams
-      const teamsWithFixedVisibility = result.rows.map(team => ({
+      const teamsWithFixedVisibility = result.rows.map((team) => ({
         ...team,
-        is_public: team.is_public === true
+        is_public: team.is_public === true,
       }));
-      
+
       res.status(200).json({
         success: true,
         data: {
-          results: teamsWithFixedVisibility
-        }
+          results: teamsWithFixedVisibility,
+        },
       });
     } catch (error) {
-      console.error('Error during search:', error);
+      console.error("Error during search:", error);
       res.status(500).json({
         success: false,
-        message: 'Error during search',
-        error: error.message
+        message: "Error during search",
+        error: error.message,
       });
     }
   },
@@ -392,7 +405,7 @@ const searchController = {
     try {
       const tagId = req.params.tagId;
       const userId = req.user?.id;
-      
+
       // Define the query to get teams with the specified tag
       let query = `
         SELECT 
@@ -409,10 +422,10 @@ const searchController = {
           tt.tag_id = $1
           AND t.archived_at IS NULL
       `;
-      
+
       const queryParams = [tagId];
       let paramIndex = 2;
-      
+
       // Add visibility condition based on authentication
       if (userId) {
         // For authenticated users: show public teams OR teams they created OR teams they're a member of
@@ -432,33 +445,33 @@ const searchController = {
         // For non-authenticated users: show only public teams
         query += ` AND t.is_public = TRUE`;
       }
-      
+
       // Add group by and limit
       query += `
         GROUP BY t.id, t.name, t.description, t.is_public, t.max_members
         LIMIT 20
       `;
-      
+
       const result = await db.pool.query(query, queryParams);
-      
+
       // Ensure proper boolean values for is_public in teams
-      const teamsWithFixedVisibility = result.rows.map(team => ({
+      const teamsWithFixedVisibility = result.rows.map((team) => ({
         ...team,
-        is_public: team.is_public === true
+        is_public: team.is_public === true,
       }));
-      
+
       res.status(200).json({
         success: true,
         data: {
-          results: teamsWithFixedVisibility
-        }
+          results: teamsWithFixedVisibility,
+        },
       });
     } catch (error) {
       console.error(`Error searching by tag ${req.params.tagId}:`, error);
       res.status(500).json({
         success: false,
-        message: 'Error during tag search',
-        error: error.message
+        message: "Error during tag search",
+        error: error.message,
       });
     }
   },
@@ -467,14 +480,14 @@ const searchController = {
     try {
       const { postalCode, distance } = req.query;
       const userId = req.user?.id;
-      
+
       if (!postalCode) {
         return res.status(400).json({
           success: false,
-          message: 'Postal code is required for location search'
+          message: "Postal code is required for location search",
         });
       }
-      
+
       // A simple implementation - in a real-world scenario, you would use
       // geospatial queries with coordinates and distance calculations
       let query = `
@@ -491,10 +504,10 @@ const searchController = {
           t.postal_code = $1
           AND t.archived_at IS NULL
       `;
-      
+
       const queryParams = [postalCode];
       let paramIndex = 2;
-      
+
       // Add visibility condition based on authentication
       if (userId) {
         // For authenticated users: show public teams OR teams they created OR teams they're a member of
@@ -514,36 +527,36 @@ const searchController = {
         // For non-authenticated users: show only public teams
         query += ` AND t.is_public = TRUE`;
       }
-      
+
       // Add group by and limit
       query += `
         GROUP BY t.id, t.name, t.description, t.is_public, t.max_members
         LIMIT 20
       `;
-      
+
       const result = await db.pool.query(query, queryParams);
-      
+
       // Ensure proper boolean values for is_public in teams
-      const teamsWithFixedVisibility = result.rows.map(team => ({
+      const teamsWithFixedVisibility = result.rows.map((team) => ({
         ...team,
-        is_public: team.is_public === true
+        is_public: team.is_public === true,
       }));
-      
+
       res.status(200).json({
         success: true,
         data: {
-          results: teamsWithFixedVisibility
-        }
+          results: teamsWithFixedVisibility,
+        },
       });
     } catch (error) {
-      console.error('Error during location search:', error);
+      console.error("Error during location search:", error);
       res.status(500).json({
         success: false,
-        message: 'Error during location search',
-        error: error.message
+        message: "Error during location search",
+        error: error.message,
       });
     }
-  }
+  },
 };
 
 module.exports = searchController;


### PR DESCRIPTION
- Add u.is_public to SELECT clause in globalSearch and getAllUsersAndTeams methods
- Add u.is_public to GROUP BY clause to prevent SQL aggregation errors
- Add usersWithFixedVisibility processing to ensure proper boolean values
- Maintain existing visibility filtering logic (show public profiles OR own profile for authenticated users)
- Fix missing user profile visibility data in search results

Files updated:
- src/controllers/searchController.js: Updated user queries in globalSearch() and getAllUsersAndTeams()