### PR TITLE
Security/ratelimiting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.3.2",
         "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.2",
@@ -908,6 +909,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
@@ -1299,6 +1318,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.3.2",
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.2",

--- a/src/app.js
+++ b/src/app.js
@@ -1,10 +1,15 @@
 const express = require("express");
 const cors = require("cors");
 const dotenv = require("dotenv");
+const { generalApiLimiter } = require("./middlewares/rateLimiter");
 
 dotenv.config();
 
 const app = express();
+
+if (process.env.NODE_ENV === "production") {
+  app.set("trust proxy", 1);
+}
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
@@ -80,6 +85,7 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 const apiRoutes = require("./routes");
+app.use("/api", generalApiLimiter);
 app.use("/api", apiRoutes);
 
 app.get("/", (req, res) => {

--- a/src/app.js
+++ b/src/app.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const cors = require("cors");
 const dotenv = require("dotenv");
-const { generalApiLimiter } = require("./middlewares/rateLimiter");
 
 dotenv.config();
 
@@ -85,7 +84,6 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 const apiRoutes = require("./routes");
-app.use("/api", generalApiLimiter);
 app.use("/api", apiRoutes);
 
 app.get("/", (req, res) => {

--- a/src/middlewares/rateLimiter.js
+++ b/src/middlewares/rateLimiter.js
@@ -28,14 +28,7 @@ const registerLimiter = createRateLimiter({
   message: "Too many registration attempts. Please try again later.",
 });
 
-const generalApiLimiter = createRateLimiter({
-  windowMs: 15 * 60 * 1000,
-  max: 500,
-  message: "Too many requests. Please slow down.",
-});
-
 module.exports = {
   authLimiter,
   registerLimiter,
-  generalApiLimiter,
 };

--- a/src/middlewares/rateLimiter.js
+++ b/src/middlewares/rateLimiter.js
@@ -30,7 +30,7 @@ const registerLimiter = createRateLimiter({
 
 const generalApiLimiter = createRateLimiter({
   windowMs: 15 * 60 * 1000,
-  max: 150,
+  max: 500,
   message: "Too many requests. Please slow down.",
 });
 

--- a/src/middlewares/rateLimiter.js
+++ b/src/middlewares/rateLimiter.js
@@ -1,0 +1,41 @@
+const rateLimit = require("express-rate-limit");
+
+const createRateLimiter = ({ windowMs, max, message }) =>
+  rateLimit({
+    windowMs,
+    max,
+    message,
+    statusCode: 429,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (req, res, next, options) => {
+      res.status(options.statusCode).json({
+        success: false,
+        message: options.message,
+      });
+    },
+  });
+
+const authLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 8,
+  message: "Too many attempts. Please try again in 15 minutes.",
+});
+
+const registerLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  message: "Too many registration attempts. Please try again later.",
+});
+
+const generalApiLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 150,
+  message: "Too many requests. Please slow down.",
+});
+
+module.exports = {
+  authLimiter,
+  registerLimiter,
+  generalApiLimiter,
+};

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -3,24 +3,34 @@ const router = express.Router();
 
 const authController = require("../controllers/authController");
 const auth = require("../middlewares/auth");
+const { authLimiter, registerLimiter } = require("../middlewares/rateLimiter");
 const upload = require("../middlewares/uploadMiddleware");
 
 // Register a new user (with optional avatar upload)
-router.post("/register", upload.single("avatar"), authController.register);
+router.post(
+  "/register",
+  registerLimiter,
+  upload.single("avatar"),
+  authController.register,
+);
 
 // Login existing user
-router.post("/login", authController.login);
+router.post("/login", authLimiter, authController.login);
 
 // Email verification routes (query-param based: /verify-email?token=...)
 router.get("/verify-email", authController.verifyEmail);
-router.post("/resend-verification", authController.resendVerification);
+router.post(
+  "/resend-verification",
+  authLimiter,
+  authController.resendVerification,
+);
 
 // Get current user (requires token)
 router.get("/me", auth.authenticateToken, authController.getCurrentUser);
 
 // Password reset routes
-router.post("/forgot-password", authController.forgotPassword);
-router.post("/reset-password", authController.resetPassword);
+router.post("/forgot-password", authLimiter, authController.forgotPassword);
+router.post("/reset-password", authLimiter, authController.resetPassword);
 
 // Change password (authenticated)
 router.put(


### PR DESCRIPTION
## Summary
Adds targeted rate limiting to high-risk auth endpoints to help protect the public Render deployment against brute-force attempts and registration spam.

## Changes
- Added `express-rate-limit` with a dedicated `rateLimiter` middleware
- Applied `registerLimiter` to `POST /register` before `upload.single("avatar")`
- Applied `authLimiter` to:
  - `POST /login`
  - `POST /forgot-password`
  - `POST /reset-password`
  - `POST /resend-verification`
- Returns consistent `429` JSON responses in the format `{ success: false, message: "..." }`
- Enables standard `RateLimit-*` headers and disables legacy `X-RateLimit-*` headers
- Sets `trust proxy` in production so rate limiting uses the correct client IP behind Render

## Notes
- No controller logic, route handlers, or CORS configuration were changed
- Auth-protected routes such as `/me`, `/change-password`, and `/change-email` were left untouched

## Verification
- `node --check src/middlewares/rateLimiter.js`
- `node --check src/routes/authRoutes.js`
- `node --check src/app.js`
