### PR TITLE
security: tighten CORS to only allow Lomir Vercel domains

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -42,7 +42,9 @@ const isAllowedOrigin = (origin) => {
     if (
       url.protocol === "https:" &&
       (url.hostname === "lomir-frontend.vercel.app" ||
-        url.hostname.endsWith(".vercel.app"))
+        /^lomir-frontend-[a-z0-9]+-juliabaurs-projects\.vercel\.app$/.test(
+          url.hostname
+        ))
     ) {
       return true;
     }


### PR DESCRIPTION
This PR tightens the CORS origin check in src/app.js.

Previously, the backend allowed any hostname ending in .vercel.app, which was too broad and could permit authenticated requests from unrelated Vercel apps. This change narrows the allowlist to only:

lomir-frontend.vercel.app
preview deployments matching lomir-frontend-*-juliabaurs-projects.vercel.app
No other CORS settings were changed.

Verification
node --check src/app.js