### PR TITLE
Fix ImageKit file deletion across all paths

### DIFF
--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -1,4 +1,8 @@
 const db = require("../config/database");
+const {
+  deleteImageKitFile,
+  isImageKitUrl,
+} = require("../utils/imagekitUtils");
 
 const getUnreadCount = async (req, res) => {
   try {
@@ -651,7 +655,7 @@ const deleteMessage = async (req, res) => {
 
     // 1) Fetch message first (so we know whether it’s team or direct + room ids)
     const msgResult = await db.query(
-      `SELECT id, sender_id, receiver_id, team_id
+      `SELECT id, sender_id, receiver_id, team_id, image_url, file_url
        FROM messages
        WHERE id = $1`,
       [messageId],
@@ -668,6 +672,16 @@ const deleteMessage = async (req, res) => {
       return res
         .status(403)
         .json({ message: "Not authorized to delete this message" });
+    }
+
+    const imageUrl = msg.image_url;
+    const fileUrl = msg.file_url;
+
+    if (imageUrl && isImageKitUrl(imageUrl)) {
+      await deleteImageKitFile(imageUrl);
+    }
+    if (fileUrl && isImageKitUrl(fileUrl)) {
+      await deleteImageKitFile(fileUrl);
     }
 
     // 3) SOFT DELETE (matches your UI + your getMessages already returns deleted_at/deleted_by)

--- a/src/utils/fileCleanup.js
+++ b/src/utils/fileCleanup.js
@@ -1,9 +1,8 @@
 // Utilities for cleaning up expired chat files
 
 const db = require("../config/database");
-const imagekit = require("../config/imagekit");
 const {
-  extractImageKitFilename,
+  deleteImageKitFile,
   isImageKitUrl,
 } = require("./imagekitUtils");
 
@@ -13,47 +12,7 @@ const {
  * @returns {Promise<boolean>} - Success status
  */
 const deleteFromImageKit = async (url) => {
-  try {
-    if (!isImageKitUrl(url)) {
-      return false;
-    }
-
-    const filename = extractImageKitFilename(url);
-
-    if (!filename) {
-      return false;
-    }
-
-    const response = await fetch(
-      `https://api.imagekit.io/v1/files?searchQuery=${encodeURIComponent(`name="${filename}"`)}`,
-      {
-        headers: {
-          Authorization:
-            "Basic " +
-            Buffer.from(`${process.env.IMAGEKIT_PRIVATE_KEY}:`).toString(
-              "base64",
-            ),
-        },
-      },
-    );
-
-    if (!response.ok) {
-      console.error("[CLEANUP] Search API error:", response.status);
-      return false;
-    }
-
-    const files = await response.json();
-
-    if (!Array.isArray(files) || files.length === 0) {
-      return false;
-    }
-
-    await imagekit.files.delete(files[0].fileId);
-    return true;
-  } catch (error) {
-    console.error(`[CLEANUP] Error deleting from ImageKit:`, error);
-    return false;
-  }
+  return await deleteImageKitFile(url);
 };
 
 /**


### PR DESCRIPTION
# Fix ImageKit file deletion across all paths

## Summary

ImageKit files (avatars, team avatars, chat images/files) were never being deleted due to SDK method mismatches and missing infrastructure. This PR fixes all three deletion paths: avatar replacement, message deletion, and the 60-day expiration cron job.

## Root Cause

The backend uses `@imagekit/nodejs` v7.4.0, but the deletion utilities were calling methods from the old SDK that don't exist in v7:
- `imagekit.listFiles()` → does not exist
- `imagekit.deleteFile()` → does not exist
- `imagekit.upload()` → does not exist

These calls threw `TypeError`, which was silently caught, so every deletion returned `false` and no files were ever removed from ImageKit.

## Changes

### SDK method fixes
- **`src/utils/imagekitUtils.js`** — Rewrote `deleteImageKitFile` to accept an optional `fileId` parameter for direct deletion via `imagekit.files.delete()`. Added REST API fallback (search by filename) for legacy data without a stored fileId.
- **`src/utils/fileCleanup.js`** — Replaced the duplicated `deleteFromImageKit` function with a delegation to the shared `deleteImageKitFile` from imagekitUtils. Removed unused direct SDK import.
- **`src/middlewares/uploadMiddleware.js`** — Changed `imagekit.upload()` to `imagekit.files.upload()`.

### FileId storage for direct deletion
- **Database migration** (`scripts/add-avatar-file-id-columns.sql`) — Added `avatar_file_id` column to `users` and `teamavatar_file_id` column to `teams`.
- **`src/controllers/userController.js`** — `updateUser`, `deleteAvatar`, and `deleteUser` now store, read, and pass `avatar_file_id` to `deleteImageKitFile` for direct deletion.
- **`src/controllers/teamController.js`** — `updateTeam`, `deleteTeamAvatar`, and `permanentlyDeleteTeam` now store, read, and pass `teamavatar_file_id` to `deleteImageKitFile` for direct deletion.

### Chat message file deletion
- **`src/controllers/messageController.js`** — `deleteMessage` (soft delete) now deletes the associated ImageKit files before nulling `image_url` and `file_url` in the database. Previously these URLs were set to NULL without removing the actual files, creating permanent orphans on ImageKit.

## Deletion paths now working

| Trigger | What happens |
|---------|-------------|
| User changes/removes avatar | Old file deleted via stored fileId (or REST API fallback) |
| Team avatar changed/removed | Same as above with `teamavatar_file_id` |
| User deletes a chat message | Attached image/file deleted from ImageKit before soft delete |
| 60-day file expiration | Cron job (daily 2:00 AM) finds expired files and deletes via REST API fallback |

## Migration required

Run before deploying:

```sql
ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_file_id TEXT;
ALTER TABLE teams ADD COLUMN IF NOT EXISTS teamavatar_file_id TEXT;
```

## Notes

- Existing avatars uploaded before this PR won't have a stored fileId. The REST API fallback handles these by searching ImageKit by filename.
- No API response shapes were changed. Frontend compatibility is maintained.