### PR TITLE
Fix ImageKit file deletion across all paths

### DIFF
--- a/scripts/add-avatar-file-id-columns.sql
+++ b/scripts/add-avatar-file-id-columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_file_id TEXT;
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS teamavatar_file_id TEXT;

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -1,4 +1,8 @@
 const db = require("../config/database");
+const {
+  deleteImageKitFile,
+  isImageKitUrl,
+} = require("../utils/imagekitUtils");
 
 const getUnreadCount = async (req, res) => {
   try {
@@ -651,7 +655,7 @@ const deleteMessage = async (req, res) => {
 
     // 1) Fetch message first (so we know whether it’s team or direct + room ids)
     const msgResult = await db.query(
-      `SELECT id, sender_id, receiver_id, team_id
+      `SELECT id, sender_id, receiver_id, team_id, image_url, file_url
        FROM messages
        WHERE id = $1`,
       [messageId],
@@ -668,6 +672,16 @@ const deleteMessage = async (req, res) => {
       return res
         .status(403)
         .json({ message: "Not authorized to delete this message" });
+    }
+
+    const imageUrl = msg.image_url;
+    const fileUrl = msg.file_url;
+
+    if (imageUrl && isImageKitUrl(imageUrl)) {
+      await deleteImageKitFile(imageUrl);
+    }
+    if (fileUrl && isImageKitUrl(fileUrl)) {
+      await deleteImageKitFile(fileUrl);
     }
 
     // 3) SOFT DELETE (matches your UI + your getMessages already returns deleted_at/deleted_by)

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -21,11 +21,12 @@ const permanentlyDeleteTeam = async (teamId) => {
 
     // Fetch team avatar URL before deleting
     const teamResult = await client.query(
-      `SELECT teamavatar_url FROM teams WHERE id = $1`,
+      `SELECT teamavatar_url, teamavatar_file_id FROM teams WHERE id = $1`,
       [teamId],
     );
 
     const teamAvatarUrl = teamResult.rows[0]?.teamavatar_url;
+    const teamAvatarFileId = teamResult.rows[0]?.teamavatar_file_id;
 
     // Delete all related data in order...
     await client.query("DELETE FROM messages WHERE team_id = $1", [teamId]);
@@ -47,8 +48,8 @@ const permanentlyDeleteTeam = async (teamId) => {
 
     // Delete avatar from ImageKit AFTER successful database deletion
     // This is done outside the transaction to prevent rollback issues
-    if (teamAvatarUrl) {
-      await deleteImageKitFile(teamAvatarUrl);
+    if (teamAvatarUrl || teamAvatarFileId) {
+      await deleteImageKitFile(teamAvatarUrl, teamAvatarFileId);
     }
 
     return true;
@@ -93,7 +94,7 @@ const deleteTeamAvatar = async (req, res) => {
     // Check if team exists and user is the owner or admin
     const teamCheck = await db.pool.query(
       `
-      SELECT t.teamavatar_url, tm.role
+      SELECT t.teamavatar_url, t.teamavatar_file_id, tm.role
       FROM teams t
       JOIN team_members tm ON t.id = tm.team_id
       WHERE t.id = $1 
@@ -112,15 +113,16 @@ const deleteTeamAvatar = async (req, res) => {
     }
 
     const currentAvatarUrl = teamCheck.rows[0].teamavatar_url;
+    const currentAvatarFileId = teamCheck.rows[0].teamavatar_file_id;
 
     // Delete from ImageKit if it exists
-    if (currentAvatarUrl) {
-      await deleteImageKitFile(currentAvatarUrl);
+    if (currentAvatarUrl || currentAvatarFileId) {
+      await deleteImageKitFile(currentAvatarUrl, currentAvatarFileId);
     }
 
     // Update database to remove avatar URL
     const result = await db.pool.query(
-      "UPDATE teams SET teamavatar_url = NULL, updated_at = NOW() WHERE id = $1 RETURNING id, teamavatar_url",
+      "UPDATE teams SET teamavatar_url = NULL, teamavatar_file_id = NULL, updated_at = NOW() WHERE id = $1 RETURNING id, teamavatar_url",
       [teamId],
     );
 
@@ -1007,6 +1009,7 @@ const updateTeam = async (req, res) => {
     // Get current team data to access old avatar URL
     const currentTeam = teamCheck.rows[0];
     const oldAvatarUrl = currentTeam.teamavatar_url;
+    const oldAvatarFileId = currentTeam.teamavatar_file_id;
 
     // Create validation schema for update (similar to creation but all fields optional)
     const updateSchema = Joi.object({
@@ -1030,6 +1033,7 @@ const updateTeam = async (req, res) => {
       status: Joi.string().valid("active", "inactive"),
 
       teamavatar_url: Joi.string().uri().allow(null, ""),
+      teamavatar_file_id: Joi.string().allow(null, ""),
 
       tags: Joi.array().items(
         Joi.object({
@@ -1294,6 +1298,7 @@ const updateTeam = async (req, res) => {
     if (value.city === "") value.city = null;
     if (value.state === "") value.state = null;
     if (value.country === "") value.country = null;
+    if (value.teamavatar_file_id === "") value.teamavatar_file_id = null;
 
     // Geocode if location changed and not remote
     if (!isRemote && (value.postal_code || value.city) && value.country) {
@@ -1335,9 +1340,16 @@ const updateTeam = async (req, res) => {
         queryParams.push(value.teamavatar_url);
         paramCounter++;
 
+        updateFields.push(`teamavatar_file_id = $${paramCounter}`);
+        queryParams.push(value.teamavatar_file_id ?? null);
+        paramCounter++;
+
         // Delete old image from ImageKit if it exists and is different from the new one
-        if (oldAvatarUrl && oldAvatarUrl !== value.teamavatar_url) {
-          await deleteImageKitFile(oldAvatarUrl);
+        if (
+          (oldAvatarUrl || oldAvatarFileId) &&
+          oldAvatarUrl !== value.teamavatar_url
+        ) {
+          await deleteImageKitFile(oldAvatarUrl, oldAvatarFileId);
         }
       }
 
@@ -1491,7 +1503,7 @@ const updateTeam = async (req, res) => {
         [teamId],
       );
 
-      const updatedTeam = updatedTeamResult.rows[0];
+      const { teamavatar_file_id, ...updatedTeam } = updatedTeamResult.rows[0];
 
       res.status(200).json({
         success: true,

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -257,7 +257,7 @@ const updateUser = async (req, res) => {
 
     // First, get the current user data to access the old avatar URL and location
     const currentUserResult = await pool.query(
-      "SELECT avatar_url, postal_code, city, country, state, latitude, longitude FROM users WHERE id = $1",
+      "SELECT avatar_url, avatar_file_id, postal_code, city, country, state, latitude, longitude FROM users WHERE id = $1",
       [userId],
     );
 
@@ -270,6 +270,7 @@ const updateUser = async (req, res) => {
 
     const currentUser = currentUserResult.rows[0];
     const oldAvatarUrl = currentUser.avatar_url;
+    const oldAvatarFileId = currentUser.avatar_file_id;
 
     // Extract all relevant fields from request body
     const {
@@ -282,8 +283,11 @@ const updateUser = async (req, res) => {
       city,
       country,
       avatar_url,
+      avatar_file_id,
       is_public,
     } = req.body;
+    const nextAvatarFileId =
+      avatar_file_id === "" ? null : (avatar_file_id ?? null);
 
     // Build SET clause dynamically
     const updateFields = [];
@@ -365,13 +369,17 @@ const updateUser = async (req, res) => {
       queryParams.push(avatar_url);
       paramPosition++;
 
+      updateFields.push(`avatar_file_id = $${paramPosition}`);
+      queryParams.push(nextAvatarFileId);
+      paramPosition++;
+
       // Delete old image from ImageKit if it exists and is different from the new one
-      if (oldAvatarUrl && oldAvatarUrl !== avatar_url) {
+      if ((oldAvatarUrl || oldAvatarFileId) && oldAvatarUrl !== avatar_url) {
         if (process.env.NODE_ENV !== "production") {
           console.log(`Attempting to delete old avatar from ImageKit: ${oldAvatarUrl}`);
         }
 
-        await deleteImageKitFile(oldAvatarUrl);
+        await deleteImageKitFile(oldAvatarUrl, oldAvatarFileId);
       }
     }
 
@@ -505,7 +513,7 @@ const deleteAvatar = async (req, res) => {
 
     // Get the current avatar URL
     const userResult = await pool.query(
-      "SELECT avatar_url FROM users WHERE id = $1",
+      "SELECT avatar_url, avatar_file_id FROM users WHERE id = $1",
       [userId],
     );
 
@@ -517,19 +525,20 @@ const deleteAvatar = async (req, res) => {
     }
 
     const currentAvatarUrl = userResult.rows[0].avatar_url;
+    const currentAvatarFileId = userResult.rows[0].avatar_file_id;
 
     // Delete from ImageKit if it exists
-    if (currentAvatarUrl) {
+    if (currentAvatarUrl || currentAvatarFileId) {
       if (process.env.NODE_ENV !== "production") {
         console.log(`Deleting avatar from ImageKit: ${currentAvatarUrl}`);
       }
 
-      await deleteImageKitFile(currentAvatarUrl);
+      await deleteImageKitFile(currentAvatarUrl, currentAvatarFileId);
     }
 
     // Clear the avatar_url in the database
     await pool.query(
-      "UPDATE users SET avatar_url = NULL, updated_at = NOW() WHERE id = $1",
+      "UPDATE users SET avatar_url = NULL, avatar_file_id = NULL, updated_at = NOW() WHERE id = $1",
       [userId],
     );
 
@@ -556,6 +565,7 @@ const deleteUser = async (req, res) => {
   let client = null;
   let transactionOpen = false;
   let avatarUrl = null;
+  let avatarFileId = null;
   let teamIdsForSockets = [];
   let dmPartnerIds = [];
   let ownershipTransferEvents = [];
@@ -620,7 +630,7 @@ const deleteUser = async (req, res) => {
     logDeletionPhase("Phase A - gather context", { userId });
 
     const userResult = await client.query(
-      `SELECT id, first_name, last_name, username, avatar_url, password_hash
+      `SELECT id, first_name, last_name, username, avatar_url, avatar_file_id, password_hash
        FROM users
        WHERE id = $1`,
       [userId],
@@ -644,6 +654,7 @@ const deleteUser = async (req, res) => {
     }
 
     avatarUrl = user.avatar_url;
+    avatarFileId = user.avatar_file_id;
 
     const fullName = [user.first_name, user.last_name].filter(Boolean).join(" ");
     const userDisplayName = fullName || user.username;
@@ -1103,8 +1114,8 @@ const deleteUser = async (req, res) => {
     });
 
     try {
-      if (avatarUrl) {
-        await deleteImageKitFile(avatarUrl);
+      if (avatarUrl || avatarFileId) {
+        await deleteImageKitFile(avatarUrl, avatarFileId);
       }
 
       const io =

--- a/src/middlewares/uploadMiddleware.js
+++ b/src/middlewares/uploadMiddleware.js
@@ -8,7 +8,7 @@ const uploadToImageKit = async (
   fileName,
   folder = "lomir/avatars",
 ) => {
-  const response = await imagekit.upload({
+  const response = await imagekit.files.upload({
     file: fileBuffer.toString("base64"),
     fileName,
     folder,

--- a/src/utils/fileCleanup.js
+++ b/src/utils/fileCleanup.js
@@ -1,9 +1,8 @@
 // Utilities for cleaning up expired chat files
 
 const db = require("../config/database");
-const imagekit = require("../config/imagekit");
 const {
-  extractImageKitFilename,
+  deleteImageKitFile,
   isImageKitUrl,
 } = require("./imagekitUtils");
 
@@ -13,47 +12,7 @@ const {
  * @returns {Promise<boolean>} - Success status
  */
 const deleteFromImageKit = async (url) => {
-  try {
-    if (!isImageKitUrl(url)) {
-      return false;
-    }
-
-    const filename = extractImageKitFilename(url);
-
-    if (!filename) {
-      return false;
-    }
-
-    const response = await fetch(
-      `https://api.imagekit.io/v1/files?searchQuery=${encodeURIComponent(`name="${filename}"`)}`,
-      {
-        headers: {
-          Authorization:
-            "Basic " +
-            Buffer.from(`${process.env.IMAGEKIT_PRIVATE_KEY}:`).toString(
-              "base64",
-            ),
-        },
-      },
-    );
-
-    if (!response.ok) {
-      console.error("[CLEANUP] Search API error:", response.status);
-      return false;
-    }
-
-    const files = await response.json();
-
-    if (!Array.isArray(files) || files.length === 0) {
-      return false;
-    }
-
-    await imagekit.files.delete(files[0].fileId);
-    return true;
-  } catch (error) {
-    console.error(`[CLEANUP] Error deleting from ImageKit:`, error);
-    return false;
-  }
+  return await deleteImageKitFile(url);
 };
 
 /**

--- a/src/utils/fileCleanup.js
+++ b/src/utils/fileCleanup.js
@@ -14,22 +14,42 @@ const {
  */
 const deleteFromImageKit = async (url) => {
   try {
+    if (!isImageKitUrl(url)) {
+      return false;
+    }
+
     const filename = extractImageKitFilename(url);
 
     if (!filename) {
       return false;
     }
 
-    const files = await imagekit.listFiles({
-      searchQuery: `name="${filename}"`,
-    });
+    const response = await fetch(
+      `https://api.imagekit.io/v1/files?searchQuery=${encodeURIComponent(`name="${filename}"`)}`,
+      {
+        headers: {
+          Authorization:
+            "Basic " +
+            Buffer.from(`${process.env.IMAGEKIT_PRIVATE_KEY}:`).toString(
+              "base64",
+            ),
+        },
+      },
+    );
 
-    if (Array.isArray(files) && files.length > 0) {
-      await imagekit.deleteFile(files[0].fileId);
-      return true;
+    if (!response.ok) {
+      console.error("[CLEANUP] Search API error:", response.status);
+      return false;
     }
 
-    return false;
+    const files = await response.json();
+
+    if (!Array.isArray(files) || files.length === 0) {
+      return false;
+    }
+
+    await imagekit.files.delete(files[0].fileId);
+    return true;
   } catch (error) {
     console.error(`[CLEANUP] Error deleting from ImageKit:`, error);
     return false;

--- a/src/utils/imagekitUtils.js
+++ b/src/utils/imagekitUtils.js
@@ -21,27 +21,53 @@ const extractImageKitFilename = (url) => {
   }
 };
 
-const deleteImageKitFile = async (url) => {
-  if (!isImageKitUrl(url)) {
+const deleteImageKitFile = async (url, fileId = null) => {
+  if (!url && !fileId) {
     return false;
   }
 
   try {
-    const filename = extractImageKitFilename(url);
+    let resolvedFileId = fileId;
 
-    if (!filename) {
-      return false;
+    if (!resolvedFileId) {
+      if (!isImageKitUrl(url)) {
+        return false;
+      }
+
+      const filename = extractImageKitFilename(url);
+
+      if (!filename) {
+        return false;
+      }
+
+      const response = await fetch(
+        `https://api.imagekit.io/v1/files?searchQuery=${encodeURIComponent(`name="${filename}"`)}`,
+        {
+          headers: {
+            Authorization:
+              "Basic " +
+              Buffer.from(`${process.env.IMAGEKIT_PRIVATE_KEY}:`).toString(
+                "base64",
+              ),
+          },
+        },
+      );
+
+      if (!response.ok) {
+        console.error("[ImageKit] Search API error:", response.status);
+        return false;
+      }
+
+      const files = await response.json();
+
+      if (!Array.isArray(files) || files.length === 0) {
+        return false;
+      }
+
+      resolvedFileId = files[0].fileId;
     }
 
-    const files = await imagekit.listFiles({
-      searchQuery: `name="${filename}"`,
-    });
-
-    if (!Array.isArray(files) || files.length === 0) {
-      return false;
-    }
-
-    await imagekit.deleteFile(files[0].fileId);
+    await imagekit.files.delete(resolvedFileId);
     return true;
   } catch (error) {
     console.error("[ImageKit] Error deleting file:", error);


### PR DESCRIPTION
# Fix ImageKit file deletion across all paths

## Summary

ImageKit files (avatars, team avatars, chat images/files) were never being deleted due to SDK method mismatches and missing infrastructure. This PR fixes all three deletion paths: avatar replacement, message deletion, and the 60-day expiration cron job.

## Root Cause

The backend uses `@imagekit/nodejs` v7.4.0, but the deletion utilities were calling methods from the old SDK that don't exist in v7:
- `imagekit.listFiles()` → does not exist
- `imagekit.deleteFile()` → does not exist
- `imagekit.upload()` → does not exist

These calls threw `TypeError`, which was silently caught, so every deletion returned `false` and no files were ever removed from ImageKit.

## Changes

### SDK method fixes
- **`src/utils/imagekitUtils.js`** — Rewrote `deleteImageKitFile` to accept an optional `fileId` parameter for direct deletion via `imagekit.files.delete()`. Added REST API fallback (search by filename) for legacy data without a stored fileId.
- **`src/utils/fileCleanup.js`** — Replaced the duplicated `deleteFromImageKit` function with a delegation to the shared `deleteImageKitFile` from imagekitUtils. Removed unused direct SDK import.
- **`src/middlewares/uploadMiddleware.js`** — Changed `imagekit.upload()` to `imagekit.files.upload()`.

### FileId storage for direct deletion
- **Database migration** (`scripts/add-avatar-file-id-columns.sql`) — Added `avatar_file_id` column to `users` and `teamavatar_file_id` column to `teams`.
- **`src/controllers/userController.js`** — `updateUser`, `deleteAvatar`, and `deleteUser` now store, read, and pass `avatar_file_id` to `deleteImageKitFile` for direct deletion.
- **`src/controllers/teamController.js`** — `updateTeam`, `deleteTeamAvatar`, and `permanentlyDeleteTeam` now store, read, and pass `teamavatar_file_id` to `deleteImageKitFile` for direct deletion.

### Chat message file deletion
- **`src/controllers/messageController.js`** — `deleteMessage` (soft delete) now deletes the associated ImageKit files before nulling `image_url` and `file_url` in the database. Previously these URLs were set to NULL without removing the actual files, creating permanent orphans on ImageKit.

## Deletion paths now working

| Trigger | What happens |
|---------|-------------|
| User changes/removes avatar | Old file deleted via stored fileId (or REST API fallback) |
| Team avatar changed/removed | Same as above with `teamavatar_file_id` |
| User deletes a chat message | Attached image/file deleted from ImageKit before soft delete |
| 60-day file expiration | Cron job (daily 2:00 AM) finds expired files and deletes via REST API fallback |

## Migration required

Run before deploying:

```sql
ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_file_id TEXT;
ALTER TABLE teams ADD COLUMN IF NOT EXISTS teamavatar_file_id TEXT;
```

## Notes

- Existing avatars uploaded before this PR won't have a stored fileId. The REST API fallback handles these by searching ImageKit by filename.
- No API response shapes were changed. Frontend compatibility is maintained.