### PR TITLE
Expose synthetic flags in invitation, application, and badge responses

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -499,6 +499,7 @@ const getUserBadges = async (req, res) => {
         ba.project_name,
         ba.team_id,
         COALESCE(t.name, ba.custom_team_name) AS team_name,
+        t.is_synthetic AS team_is_synthetic,
         ba.tag_id,
         tag.name AS tag_name,
         tag.category AS tag_category,

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -3383,6 +3383,7 @@ const getTeamBadgeAwards = async (req, res) => {
         ba.custom_team_name,
         ba.team_id,
         COALESCE(t_ctx.name, ba.custom_team_name) AS team_name,
+        t_ctx.is_synthetic AS team_is_synthetic,
         ba.tag_id,
         tag.name AS tag_name,
         tag.category AS tag_category,


### PR DESCRIPTION
This PR adds synthetic metadata to backend responses so the frontend can reliably identify synthetic users and teams.

Changes
getTeamSentInvitations

Adds u.is_synthetic to the query
Returns invitee.is_synthetic in the response
getTeamApplications

Adds u.is_synthetic to the query
Returns applicant.is_synthetic in the response
getUserBadges

Adds t.is_synthetic AS team_is_synthetic to the query
getTeamBadgeAwards

Adds t_ctx.is_synthetic AS team_is_synthetic to the query
Why
The frontend needs these fields to distinguish synthetic users and synthetic team context when rendering invitations, applications, and badge-related data.

Scope
This change is intentionally minimal:

No auth logic changed
No JOIN/WHERE behavior changed
Only SELECT fields and response payload fields were added
Verification
node --check src/controllers/invitationController.js
node --check src/controllers/teamController.js
node --check src/controllers/badgeController.js