### PR TITLE
Inherit owner synthetic flag on team creation

### DIFF
--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -231,6 +231,12 @@ const createTeam = async (req, res) => {
 
     await client.query("BEGIN");
 
+    const ownerSyntheticResult = await client.query(
+      `SELECT is_synthetic FROM users WHERE id = $1`,
+      [ownerId],
+    );
+    const isOwnerSynthetic = ownerSyntheticResult.rows[0].is_synthetic;
+
     // Ensure is_public is a proper boolean
     const isPublicBoolean =
       value.is_public === true ||
@@ -252,8 +258,9 @@ const createTeam = async (req, res) => {
     country,
     latitude,
     longitude,
-    teamavatar_url
-  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+    teamavatar_url,
+    is_synthetic
+  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
   RETURNING *
   `,
       [
@@ -270,6 +277,7 @@ const createTeam = async (req, res) => {
         value.is_remote ? null : (value.latitude ?? null), // $11
         value.is_remote ? null : (value.longitude ?? null), // $12
         value.teamavatar_url ?? null, // $13
+        isOwnerSynthetic, // $14
       ],
     );
 

--- a/src/models/teamModel.js
+++ b/src/models/teamModel.js
@@ -27,11 +27,12 @@ const teamModel = {
     is_remote,
     postal_code,
     city,
-    country
-  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+    country,
+    is_synthetic
+  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
   RETURNING
     id, name, description, is_public, max_members,
-    teamavatar_url, is_remote, postal_code, city, country
+    teamavatar_url, is_remote, postal_code, city, country, is_synthetic
 `,
         [
           teamDetails.name,
@@ -43,6 +44,7 @@ const teamModel = {
           teamDetails.is_remote ? null : (teamDetails.postal_code ?? null),
           teamDetails.is_remote ? null : (teamDetails.city ?? null),
           teamDetails.is_remote ? null : (teamDetails.country ?? null),
+          teamDetails.is_synthetic,
         ],
       );
 


### PR DESCRIPTION
This PR ensures newly created teams inherit the is_synthetic flag from the user who creates them.

Changes
In src/controllers/teamController.js

After reading ownerId from req.user.id, the controller now queries users.is_synthetic for that owner
The result is stored as isOwnerSynthetic
The INSERT INTO teams query now includes is_synthetic and passes isOwnerSynthetic
In src/models/teamModel.js

The createTeam insert now includes is_synthetic
The value is taken from teamDetails.is_synthetic
The RETURNING clause now includes is_synthetic
Why
We want teams created by synthetic/demo users to also be marked as synthetic, so downstream team behavior and UI logic can treat them consistently.

Scope
This change is intentionally narrow:

No auth logic changed
No validation logic changed
No other team creation behavior changed
Only the is_synthetic field was added to the create flow
Verification
node --check src/controllers/teamController.js
node --check src/models/teamModel.js