### PR TITLE
Prepare search results for map view

### DIFF
--- a/src/controllers/searchController.js
+++ b/src/controllers/searchController.js
@@ -757,7 +757,6 @@ const searchController = {
 
       // ========== TEAM DATA QUERY ==========
       let teamDistanceSelect = "";
-      let teamDistanceGroupBy = "";
       if (
         userLocation &&
         ((sort === "proximity" && direction !== "REMOTE") ||
@@ -777,15 +776,12 @@ const searchController = {
                 )
               )
             END as distance_km`;
-          teamDistanceGroupBy = ", t.latitude, t.longitude";
         } else if (userLocation.hasPostalCode) {
           teamDistanceSelect = `,
             ${searchController.buildPostalCodeDistanceSQL(userLocation.postal_code, "t")} as distance_km`;
-          teamDistanceGroupBy = ", t.postal_code";
         } else if (userLocation.hasCity) {
           teamDistanceSelect = `,
             ${searchController.buildCityDistanceSQL(userLocation.city, "t")} as distance_km`;
-          teamDistanceGroupBy = ", t.city";
         }
       }
 
@@ -802,6 +798,12 @@ const searchController = {
           t.created_at,
           t.updated_at,
           t.is_remote,
+          t.postal_code,
+          t.city,
+          t.state,
+          t.country,
+          t.latitude,
+          t.longitude,
           COALESCE(COUNT(DISTINCT tm.user_id), 0) as current_members_count,
           CASE
             WHEN t.max_members IS NULL THEN NULL
@@ -993,7 +995,7 @@ ${teamDistanceSelect}
 
       teamQuery += `
         GROUP BY
-          t.id, t.name, t.description, t.is_public, t.is_synthetic, t.max_members, t.owner_id, t.teamavatar_url, t.created_at, t.updated_at, t.is_remote${teamDistanceGroupBy}
+          t.id, t.name, t.description, t.is_public, t.is_synthetic, t.max_members, t.owner_id, t.teamavatar_url, t.created_at, t.updated_at, t.is_remote, t.postal_code, t.city, t.state, t.country, t.latitude, t.longitude
         ORDER BY ${teamOrderBy}
       `;
 
@@ -1402,11 +1404,14 @@ ${teamDistanceSelect}
       const teamsWithFixedVisibility = teamResults.rows.map((team) => ({
         ...team,
         is_public: team.is_public === true || team.is_public === "true",
+        is_remote: team.is_remote === true || team.is_remote === "true",
         tags: normalizeJsonArray(team.tags),
         available_capacity:
           team.available_capacity !== null
             ? parseInt(team.available_capacity, 10)
             : null,
+        latitude: normalizeNullableNumber(team.latitude),
+        longitude: normalizeNullableNumber(team.longitude),
         distance_km:
           team.distance_km !== undefined && team.distance_km !== null
             ? parseFloat(Number(team.distance_km).toFixed(1))
@@ -1891,7 +1896,6 @@ ${teamDistanceSelect}
 
       // ========== TEAM DATA QUERY ==========
       let teamDistanceSelect = "";
-      let teamDistanceGroupBy = "";
       if (
         userLocation &&
         ((sort === "proximity" && direction !== "REMOTE") ||
@@ -1911,11 +1915,9 @@ ${teamDistanceSelect}
                 )
               )
             END as distance_km`;
-          teamDistanceGroupBy = ", t.latitude, t.longitude";
         } else if (userLocation.hasPostalCode) {
           teamDistanceSelect = `,
             ${searchController.buildPostalCodeDistanceSQL(userLocation.postal_code, "t")} as distance_km`;
-          teamDistanceGroupBy = ", t.postal_code";
         } else if (userLocation.hasCity) {
           teamDistanceSelect = `, 999999 as distance_km`;
         }
@@ -1934,6 +1936,12 @@ ${teamDistanceSelect}
           t.created_at,
           t.updated_at,
           t.is_remote,
+          t.postal_code,
+          t.city,
+          t.state,
+          t.country,
+          t.latitude,
+          t.longitude,
           COALESCE(COUNT(DISTINCT tm.user_id), 0) as current_members_count,
           CASE
             WHEN t.max_members IS NULL THEN NULL
@@ -2114,7 +2122,7 @@ ${teamDistanceSelect}
 
       teamQuery += `
         GROUP BY
-          t.id, t.name, t.description, t.is_public, t.is_synthetic, t.max_members, t.owner_id, t.teamavatar_url, t.created_at, t.updated_at, t.is_remote${teamDistanceGroupBy}
+          t.id, t.name, t.description, t.is_public, t.is_synthetic, t.max_members, t.owner_id, t.teamavatar_url, t.created_at, t.updated_at, t.is_remote, t.postal_code, t.city, t.state, t.country, t.latitude, t.longitude
         ORDER BY ${teamOrderBy}
       `;
 
@@ -2478,11 +2486,14 @@ ${teamDistanceSelect}
       const teamsWithFixedVisibility = teamResults.rows.map((team) => ({
         ...team,
         is_public: team.is_public === true || team.is_public === "true",
+        is_remote: team.is_remote === true || team.is_remote === "true",
         tags: normalizeJsonArray(team.tags),
         available_capacity:
           team.available_capacity !== null
             ? parseInt(team.available_capacity, 10)
             : null,
+        latitude: normalizeNullableNumber(team.latitude),
+        longitude: normalizeNullableNumber(team.longitude),
         distance_km:
           team.distance_km !== undefined && team.distance_km !== null
             ? parseFloat(Number(team.distance_km).toFixed(1))

--- a/test/searchController.test.js
+++ b/test/searchController.test.js
@@ -33,6 +33,12 @@ function createTeam(id, name) {
     created_at: new Date("2026-01-01T00:00:00.000Z").toISOString(),
     updated_at: new Date("2026-01-02T00:00:00.000Z").toISOString(),
     is_remote: false,
+    postal_code: id === 1 ? "55116" : null,
+    city: id === 1 ? "Mainz" : null,
+    state: id === 1 ? "Rhineland-Palatinate" : null,
+    country: "DE",
+    latitude: id === 1 ? "49.999" : null,
+    longitude: id === 1 ? "8.271" : null,
     current_members_count: "2",
     available_capacity: "3",
     open_role_count: "1",
@@ -591,6 +597,36 @@ test("globalSearch ignores excludeOwnTeams for unauthenticated requests", async 
   assert.equal(res.body.pagination.totalTeams, 2);
   assert.equal(res.body.pagination.totalUsers, 2);
   assert.equal(hasTeamExclusion(calls), false);
+});
+
+test("search team results include normalized map location fields", async () => {
+  const { query } = buildQueryStub();
+  db.pool.query = query;
+
+  const req = {
+    query: {
+      query: "de",
+      page: "1",
+      limit: "10",
+      searchType: "teams",
+    },
+    user: null,
+  };
+  const res = createResponse();
+
+  await searchController.globalSearch(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.data.teams.length, 2);
+
+  const team = res.body.data.teams[0];
+  assert.equal(team.postal_code, "55116");
+  assert.equal(team.city, "Mainz");
+  assert.equal(team.state, "Rhineland-Palatinate");
+  assert.equal(team.country, "DE");
+  assert.equal(team.latitude, 49.999);
+  assert.equal(team.longitude, 8.271);
+  assert.equal(team.is_remote, false);
 });
 
 test("getAllUsersAndTeams with includeDemoData=false excludes synthetic rows", async () => {


### PR DESCRIPTION
## Summary

This PR prepares the backend search response contract for the upcoming Search Page Map View.

The frontend map needs each searchable entity to expose consistent location fields. Users and vacant roles already returned most of the required data, but team search results were missing map-ready location fields. This PR adds those fields to team results across the existing search endpoints.

## Changes

- Added map-ready team location fields to search results:
  - `postal_code`
  - `city`
  - `state`
  - `country`
  - `latitude`
  - `longitude`
  - normalized `is_remote`
- Updated both backend search paths used by the frontend:
  - `globalSearch`
  - `getAllUsersAndTeams`
- Normalized team `latitude` and `longitude` to numbers in the response mapper.
- Added a regression test confirming team search results include normalized map location fields, using `55116 Mainz` as the example postal-code location.

## Why

The upcoming frontend Map View will use the search results directly to place teams, users, and open roles on a map. With this change, teams now expose the same core map data shape as users and roles, so the frontend does not need extra detail fetches per marker.

## Verification

- `node --test test/searchController.test.js` passed
- `git diff --check` passed

## Notes

The full backend test suite currently has unrelated existing failures in `userController.deleteUser.test.js` due to stale SQL stubs expecting an older user deletion query. The search controller tests relevant to this PR pass.
