### PR TITLE
Improve proximity sorting in search

### DIFF
--- a/src/controllers/searchController.js
+++ b/src/controllers/searchController.js
@@ -11,7 +11,7 @@ const {
 } = require("../utils/matchingScorer");
 
 const VALID_SEARCH_TYPES = ["all", "teams", "users", "roles"];
-const VALID_ROLE_SORTS = ["recent", "newest", "name", "match"];
+const VALID_ROLE_SORTS = ["recent", "newest", "name", "match", "proximity"];
 
 function parseSearchType(value) {
   if (typeof value !== "string") return "all";
@@ -36,6 +36,10 @@ function parseRoleSort(value) {
 }
 
 function getRolesSortDir(sort, direction) {
+  if (sort === "proximity") {
+    return direction === "REMOTE" ? "remote" : "asc";
+  }
+
   if (sort === "name") {
     return direction === "DESC" ? "desc" : "asc";
   }
@@ -70,25 +74,77 @@ function normalizeJsonArray(value) {
 }
 
 function normalizeRoleSearchRow(role) {
+  const distanceKm = normalizeNullableNumber(role.distance_km);
+
   return {
     ...role,
     latitude: normalizeNullableNumber(role.latitude),
     longitude: normalizeNullableNumber(role.longitude),
     max_distance_km: normalizeNullableNumber(role.max_distance_km),
+    distance_km:
+      distanceKm !== null ? parseFloat(Number(distanceKm).toFixed(1)) : null,
     is_remote: role.is_remote === true || role.is_remote === "true",
     team_is_remote:
       role.team_is_remote === true || role.team_is_remote === "true",
   };
 }
 
-function buildRoleOrderBy(sort, direction) {
+function buildRoleNearestPrioritySQL(userLocation) {
+  if (userLocation?.hasCoordinates) {
+    return "(CASE WHEN vr.is_remote IS TRUE THEN 2 WHEN vr.latitude IS NULL OR vr.longitude IS NULL THEN 1 ELSE 0 END)";
+  }
+
+  if (userLocation?.hasPostalCode) {
+    return "(CASE WHEN vr.is_remote IS TRUE THEN 2 WHEN vr.postal_code IS NULL OR vr.postal_code = '' THEN 1 ELSE 0 END)";
+  }
+
+  if (userLocation?.hasCity) {
+    return "(CASE WHEN vr.is_remote IS TRUE THEN 2 WHEN vr.city IS NULL OR vr.city = '' THEN 1 ELSE 0 END)";
+  }
+
+  return "(CASE WHEN vr.is_remote IS TRUE THEN 1 ELSE 0 END)";
+}
+
+function buildRoleOrderBy(sort, direction, userLocation) {
   if (sort === "name") {
     return direction === "DESC"
       ? "vr.role_name DESC, vr.created_at DESC"
       : "vr.role_name ASC, vr.created_at DESC";
   }
 
+  if (sort === "proximity") {
+    if (direction === "REMOTE" && userLocation) {
+      return "(CASE WHEN vr.is_remote IS TRUE THEN 0 ELSE 1 END) ASC, distance_km DESC, vr.role_name ASC";
+    }
+
+    if (direction === "REMOTE") {
+      return "(CASE WHEN vr.is_remote IS TRUE THEN 0 ELSE 1 END) ASC, vr.role_name ASC";
+    }
+
+    if (userLocation) {
+      return `${buildRoleNearestPrioritySQL(userLocation)} ASC, distance_km ASC, vr.role_name ASC`;
+    }
+
+    return "(CASE WHEN vr.is_remote IS TRUE THEN 1 ELSE 0 END) ASC, vr.role_name ASC";
+  }
+
   return "vr.created_at DESC";
+}
+
+function buildTeamNearestPrioritySQL(userLocation) {
+  if (userLocation?.hasCoordinates) {
+    return "(CASE WHEN t.is_remote IS TRUE THEN 2 WHEN t.latitude IS NULL OR t.longitude IS NULL THEN 1 ELSE 0 END)";
+  }
+
+  if (userLocation?.hasPostalCode) {
+    return "(CASE WHEN t.is_remote IS TRUE THEN 2 WHEN t.postal_code IS NULL OR t.postal_code = '' THEN 1 ELSE 0 END)";
+  }
+
+  if (userLocation?.hasCity) {
+    return "(CASE WHEN t.is_remote IS TRUE THEN 2 WHEN t.city IS NULL OR t.city = '' THEN 1 ELSE 0 END)";
+  }
+
+  return "(CASE WHEN t.is_remote IS TRUE THEN 1 ELSE 0 END)";
 }
 
 function computeJaccardOverlap(baseSet, candidateIds) {
@@ -253,11 +309,16 @@ async function fetchOpenRoleSearchResults({
   limit = 20,
   userId = null,
   includeDemoData = true,
+  userLocation = null,
+  maxDistance = null,
 }) {
   const searchValue = typeof query === "string" ? query.trim() : query;
   const offset = (page - 1) * limit;
   const isMatchSort = sort === "match" && !!userId;
+  const hasValidMaxDistance =
+    maxDistance !== null && Number.isFinite(maxDistance) && maxDistance > 0;
 
+  const roleCountParams = [searchValue];
   let roleCountQuery = `
     SELECT COUNT(DISTINCT vr.id) AS total
     FROM team_vacant_roles vr
@@ -281,6 +342,44 @@ async function fetchOpenRoleSearchResults({
     `;
   }
 
+  if (hasValidMaxDistance && userLocation && direction !== "REMOTE") {
+    const distFilter = searchController.buildDistanceFilterSQL(
+      userLocation,
+      "vr",
+      `$${roleCountParams.length + 1}`,
+    );
+    if (distFilter) {
+      roleCountQuery += distFilter;
+      roleCountParams.push(maxDistance);
+    }
+  }
+
+  let roleDistanceSelect = "";
+  if (userLocation && (sort === "proximity" || hasValidMaxDistance)) {
+    if (userLocation.hasCoordinates) {
+      roleDistanceSelect = `,
+      CASE
+        WHEN vr.latitude IS NULL OR vr.longitude IS NULL THEN 999999
+        ELSE (
+          6371 * acos(
+            LEAST(1.0, GREATEST(-1.0,
+              cos(radians(${userLocation.latitude})) * cos(radians(vr.latitude)) *
+              cos(radians(vr.longitude) - radians(${userLocation.longitude})) +
+              sin(radians(${userLocation.latitude})) * sin(radians(vr.latitude))
+            ))
+          )
+        )
+      END as distance_km`;
+    } else if (userLocation.hasPostalCode) {
+      roleDistanceSelect = `,
+      ${searchController.buildPostalCodeDistanceSQL(userLocation.postal_code, "vr")} as distance_km`;
+    } else if (userLocation.hasCity) {
+      roleDistanceSelect = `,
+      ${searchController.buildCityDistanceSQL(userLocation.city, "vr")} as distance_km`;
+    }
+  }
+
+  const roleDataParams = [searchValue];
   let roleDataQuery = `
     SELECT
       vr.id,
@@ -304,6 +403,7 @@ async function fetchOpenRoleSearchResults({
       t.country AS team_country,
       t.is_synthetic AS team_is_synthetic,
       t.is_remote AS team_is_remote
+      ${roleDistanceSelect}
     FROM team_vacant_roles vr
     JOIN teams t ON vr.team_id = t.id
     WHERE vr.status = 'open'
@@ -327,20 +427,31 @@ async function fetchOpenRoleSearchResults({
     `;
   }
 
+  if (hasValidMaxDistance && userLocation && direction !== "REMOTE") {
+    const distFilter = searchController.buildDistanceFilterSQL(
+      userLocation,
+      "vr",
+      `$${roleDataParams.length + 1}`,
+    );
+    if (distFilter) {
+      roleDataQuery += distFilter;
+      roleDataParams.push(maxDistance);
+    }
+  }
+
   roleDataQuery += `
-    ORDER BY ${buildRoleOrderBy(sort, direction)}
+    ORDER BY ${buildRoleOrderBy(sort, direction, userLocation)}
   `;
 
-  const roleDataParams = [searchValue];
   if (!isMatchSort) {
     roleDataQuery += `
-      LIMIT $2 OFFSET $3
+      LIMIT $${roleDataParams.length + 1} OFFSET $${roleDataParams.length + 2}
     `;
     roleDataParams.push(limit, offset);
   }
 
   const [roleCountResult, roleDataResult] = await Promise.all([
-    db.pool.query(roleCountQuery, [searchValue]),
+    db.pool.query(roleCountQuery, roleCountParams),
     db.pool.query(roleDataQuery, roleDataParams),
   ]);
 
@@ -564,6 +675,11 @@ const searchController = {
         });
       }
 
+      let userLocation = null;
+      if (userId) {
+        userLocation = await searchController.getUserLocation(userId);
+      }
+
       if (includeRoles) {
         const { roles, totalRoles } = await fetchOpenRoleSearchResults({
           query,
@@ -573,6 +689,8 @@ const searchController = {
           limit,
           userId,
           includeDemoData,
+          userLocation,
+          maxDistance,
         });
 
         return res.status(200).json({
@@ -625,11 +743,6 @@ const searchController = {
       ];
 
       const searchTerm = `%${query.trim()}%`;
-
-      let userLocation = null;
-      if (userId) {
-        userLocation = await searchController.getUserLocation(userId);
-      }
 
       // ========== TEAM COUNT QUERY ==========
       let teamCountQuery = `
@@ -716,12 +829,6 @@ const searchController = {
         teamCountParams.push(userId);
       }
 
-      if (sort === "proximity" && direction === "REMOTE") {
-        teamCountQuery += ` AND t.is_remote = TRUE`;
-      } else if (sort === "proximity") {
-        teamCountQuery += ` AND t.is_remote IS NOT TRUE`;
-      }
-
       if (hasValidMaxDistance && userLocation && direction !== "REMOTE") {
         const distFilter = searchController.buildDistanceFilterSQL(
           userLocation,
@@ -759,8 +866,7 @@ const searchController = {
       let teamDistanceSelect = "";
       if (
         userLocation &&
-        ((sort === "proximity" && direction !== "REMOTE") ||
-          hasValidMaxDistance)
+        (sort === "proximity" || hasValidMaxDistance)
       ) {
         if (userLocation.hasCoordinates) {
           teamDistanceSelect = `,
@@ -907,12 +1013,6 @@ ${teamDistanceSelect}
         teamParamIndex++;
       }
 
-      if (sort === "proximity" && direction === "REMOTE") {
-        teamQuery += ` AND t.is_remote = TRUE`;
-      } else if (sort === "proximity") {
-        teamQuery += ` AND t.is_remote IS NOT TRUE`;
-      }
-
       if (hasValidMaxDistance && userLocation && direction !== "REMOTE") {
         const distFilter = searchController.buildDistanceFilterSQL(
           userLocation,
@@ -978,13 +1078,20 @@ ${teamDistanceSelect}
           teamOrderBy = "t.name ASC";
           break;
         case "proximity":
-          if (direction === "REMOTE") {
-            teamOrderBy = "t.name ASC";
+          if (direction === "REMOTE" && userLocation) {
+            teamOrderBy =
+              "(CASE WHEN t.is_remote IS TRUE THEN 0 ELSE 1 END) ASC, distance_km DESC, t.name ASC";
+          } else if (direction === "REMOTE") {
+            teamOrderBy =
+              "(CASE WHEN t.is_remote IS TRUE THEN 0 ELSE 1 END) ASC, t.name ASC";
           } else if (userLocation) {
             teamOrderBy =
-              direction === "DESC" ? "distance_km DESC" : "distance_km ASC";
+              direction === "DESC"
+                ? "(CASE WHEN t.is_remote IS TRUE THEN 0 ELSE 1 END) ASC, distance_km DESC, t.name ASC"
+                : `${buildTeamNearestPrioritySQL(userLocation)} ASC, distance_km ASC, t.name ASC`;
           } else {
-            teamOrderBy = "t.name ASC";
+            teamOrderBy =
+              "(CASE WHEN t.is_remote IS TRUE THEN 1 ELSE 0 END) ASC, t.name ASC";
           }
           break;
         case "name":
@@ -993,9 +1100,13 @@ ${teamDistanceSelect}
           break;
       }
 
-      teamQuery += `
+      const teamGroupByClause = `
         GROUP BY
           t.id, t.name, t.description, t.is_public, t.is_synthetic, t.max_members, t.owner_id, t.teamavatar_url, t.created_at, t.updated_at, t.is_remote, t.postal_code, t.city, t.state, t.country, t.latitude, t.longitude
+      `;
+
+      teamQuery += `
+        ${teamGroupByClause}
         ORDER BY ${teamOrderBy}
       `;
 
@@ -1603,6 +1714,8 @@ ${teamDistanceSelect}
             limit,
             userId,
             includeDemoData,
+            userLocation,
+            maxDistance,
           }));
       }
 
@@ -1611,13 +1724,13 @@ ${teamDistanceSelect}
           ? totalTeams
           : searchType === "users"
             ? totalUsers
-            : Math.max(totalTeams, totalUsers);
+            : Math.max(totalTeams, totalUsers, totalRolesForAll);
       const totalItems =
         searchType === "teams"
           ? totalTeams
           : searchType === "users"
             ? totalUsers
-            : totalTeams + totalUsers;
+            : totalTeams + totalUsers + totalRolesForAll;
 
       res.status(200).json({
         success: true,
@@ -1742,6 +1855,11 @@ ${teamDistanceSelect}
         console.log(`Exclude team members: teamId=${excludeTeamId || "none"}`);
       }
 
+      let userLocation = null;
+      if (userId) {
+        userLocation = await searchController.getUserLocation(userId);
+      }
+
       if (includeRoles) {
         const { roles, totalRoles } = await fetchOpenRoleSearchResults({
           sort: roleSort,
@@ -1750,6 +1868,8 @@ ${teamDistanceSelect}
           limit,
           userId,
           includeDemoData,
+          userLocation,
+          maxDistance,
         });
 
         return res.status(200).json({
@@ -1775,12 +1895,6 @@ ${teamDistanceSelect}
             sortDir: getRolesSortDir(roleSort, direction),
           },
         });
-      }
-
-      let userLocation = null;
-
-      if (userId) {
-        userLocation = await searchController.getUserLocation(userId);
       }
 
       // ========== TEAM COUNT QUERY ==========
@@ -1834,12 +1948,6 @@ ${teamDistanceSelect}
           )
         `;
         teamCountParams.push(userId);
-      }
-
-      if (sort === "proximity" && direction === "REMOTE") {
-        teamCountQuery += ` AND t.is_remote = TRUE`;
-      } else if (sort === "proximity") {
-        teamCountQuery += ` AND t.is_remote IS NOT TRUE`;
       }
 
       if (hasValidMaxDistance && userLocation && direction !== "REMOTE") {
@@ -1898,8 +2006,7 @@ ${teamDistanceSelect}
       let teamDistanceSelect = "";
       if (
         userLocation &&
-        ((sort === "proximity" && direction !== "REMOTE") ||
-          hasValidMaxDistance)
+        (sort === "proximity" || hasValidMaxDistance)
       ) {
         if (userLocation.hasCoordinates) {
           teamDistanceSelect = `,
@@ -2014,12 +2121,6 @@ ${teamDistanceSelect}
         teamParamIndex++;
       }
 
-      if (sort === "proximity" && direction === "REMOTE") {
-        teamQuery += ` AND t.is_remote = TRUE`;
-      } else if (sort === "proximity") {
-        teamQuery += ` AND t.is_remote IS NOT TRUE`;
-      }
-
       if (hasValidMaxDistance && userLocation && direction !== "REMOTE") {
         const distFilter = searchController.buildDistanceFilterSQL(
           userLocation,
@@ -2105,13 +2206,20 @@ ${teamDistanceSelect}
           teamOrderBy = "t.name ASC";
           break;
         case "proximity":
-          if (direction === "REMOTE") {
-            teamOrderBy = "t.name ASC";
+          if (direction === "REMOTE" && userLocation) {
+            teamOrderBy =
+              "(CASE WHEN t.is_remote IS TRUE THEN 0 ELSE 1 END) ASC, distance_km DESC, t.name ASC";
+          } else if (direction === "REMOTE") {
+            teamOrderBy =
+              "(CASE WHEN t.is_remote IS TRUE THEN 0 ELSE 1 END) ASC, t.name ASC";
           } else if (userLocation) {
             teamOrderBy =
-              direction === "DESC" ? "distance_km DESC" : "distance_km ASC";
+              direction === "DESC"
+                ? "(CASE WHEN t.is_remote IS TRUE THEN 0 ELSE 1 END) ASC, distance_km DESC, t.name ASC"
+                : `${buildTeamNearestPrioritySQL(userLocation)} ASC, distance_km ASC, t.name ASC`;
           } else {
-            teamOrderBy = "t.name ASC";
+            teamOrderBy =
+              "(CASE WHEN t.is_remote IS TRUE THEN 1 ELSE 0 END) ASC, t.name ASC";
           }
           break;
         case "name":
@@ -2120,9 +2228,13 @@ ${teamDistanceSelect}
           break;
       }
 
-      teamQuery += `
+      const teamGroupByClause = `
         GROUP BY
           t.id, t.name, t.description, t.is_public, t.is_synthetic, t.max_members, t.owner_id, t.teamavatar_url, t.created_at, t.updated_at, t.is_remote, t.postal_code, t.city, t.state, t.country, t.latitude, t.longitude
+      `;
+
+      teamQuery += `
+        ${teamGroupByClause}
         ORDER BY ${teamOrderBy}
       `;
 
@@ -2684,6 +2796,8 @@ ${teamDistanceSelect}
             limit,
             userId,
             includeDemoData,
+            userLocation,
+            maxDistance,
           }));
       }
 
@@ -2692,13 +2806,13 @@ ${teamDistanceSelect}
           ? totalTeams
           : searchType === "users"
             ? totalUsers
-            : Math.max(totalTeams, totalUsers);
+            : Math.max(totalTeams, totalUsers, totalRolesForAll);
       const totalItems =
         searchType === "teams"
           ? totalTeams
           : searchType === "users"
             ? totalUsers
-            : totalTeams + totalUsers;
+            : totalTeams + totalUsers + totalRolesForAll;
 
       res.status(200).json({
         success: true,

--- a/test/searchController.test.js
+++ b/test/searchController.test.js
@@ -93,10 +93,18 @@ function createRole(id, roleName, overrides = {}) {
   };
 }
 
-function buildQueryStub() {
+function buildQueryStub({
+  userLocation = {
+    latitude: null,
+    longitude: null,
+    postal_code: null,
+    city: null,
+  },
+  teams = null,
+} = {}) {
   const calls = [];
-  const baselineTeams = [createTeam(1, "Alpha"), createTeam(2, "Beta")];
-  const filteredTeams = [createTeam(2, "Beta")];
+  const baselineTeams = teams ?? [createTeam(1, "Alpha"), createTeam(2, "Beta")];
+  const filteredTeams = baselineTeams.filter((team) => team.id !== 1);
   const users = [createUser(11, "ada"), createUser(12, "bea")];
 
   const query = async (sql, params = []) => {
@@ -104,21 +112,16 @@ function buildQueryStub() {
 
     if (sql.includes("SELECT latitude, longitude, postal_code, city FROM users")) {
       return {
-        rows: [
-          {
-            latitude: null,
-            longitude: null,
-            postal_code: null,
-            city: null,
-          },
-        ],
+        rows: [userLocation],
       };
     }
 
     const hasExclusion = sql.includes("tm_excluded");
 
     if (sql.includes("FROM teams t") && sql.includes("as total")) {
-      return { rows: [{ total: hasExclusion ? "1" : "2" }] };
+      return {
+        rows: [{ total: String(hasExclusion ? filteredTeams.length : baselineTeams.length) }],
+      };
     }
 
     if (sql.includes("FROM users u") && sql.includes("as total")) {
@@ -416,6 +419,31 @@ function hasRoleSyntheticFilter(calls) {
   );
 }
 
+function getTeamDataQuery(calls) {
+  return calls.find(
+    ({ sql }) =>
+      sql.includes("FROM teams t") &&
+      sql.includes('t.teamavatar_url as "teamavatarUrl"'),
+  )?.sql;
+}
+
+function getRoleDataQuery(calls) {
+  return calls.find(
+    ({ sql }) =>
+      sql.includes("FROM team_vacant_roles vr") &&
+      sql.includes("t.teamavatar_url AS team_avatar_url"),
+  )?.sql;
+}
+
+function hasTeamRemoteOnlyProximityFilter(calls) {
+  return calls.some(
+    ({ sql }) =>
+      sql.includes("FROM teams t") &&
+      (sql.includes("t.is_remote = TRUE") ||
+        sql.includes("t.is_remote IS NOT TRUE")),
+  );
+}
+
 test.afterEach(() => {
   db.pool.query = originalQuery;
 });
@@ -514,6 +542,143 @@ test("getAllUsersAndTeams keeps searchType=users unchanged even if excludeOwnTea
     [11],
   );
   assert.equal(countTeamQueries(calls), 0);
+});
+
+test("getAllUsersAndTeams nearest proximity sort paginates remote teams after local teams", async () => {
+  const remoteTeam = {
+    ...createTeam(3, "Remote"),
+    is_remote: true,
+    postal_code: null,
+    city: null,
+    state: null,
+    latitude: null,
+    longitude: null,
+  };
+  const { query, calls } = buildQueryStub({
+    userLocation: {
+      latitude: "52.52",
+      longitude: "13.405",
+      postal_code: "10115",
+      city: "Berlin",
+    },
+    teams: [createTeam(1, "Alpha"), createTeam(2, "Beta"), remoteTeam],
+  });
+  db.pool.query = query;
+
+  const pageOneReq = {
+    query: {
+      page: "1",
+      limit: "2",
+      sortBy: "proximity",
+      sortDir: "asc",
+      searchType: "teams",
+    },
+    user: { id: 99 },
+  };
+  const pageOneRes = createResponse();
+
+  await searchController.getAllUsersAndTeams(pageOneReq, pageOneRes);
+
+  const teamSql = getTeamDataQuery(calls);
+  assert.equal(pageOneRes.statusCode, 200);
+  assert.deepEqual(
+    pageOneRes.body.data.teams.map((team) => team.id),
+    [1, 2],
+  );
+  assert.equal(pageOneRes.body.data.teams.some((team) => team.is_remote), false);
+  assert.equal(hasTeamRemoteOnlyProximityFilter(calls), false);
+  assert.match(
+    teamSql,
+    /CASE WHEN t\.is_remote IS TRUE THEN 2 WHEN t\.latitude IS NULL OR t\.longitude IS NULL THEN 1 ELSE 0 END\) ASC, distance_km ASC/,
+  );
+  assert.doesNotMatch(teamSql, /WHEN distance_km >= 999999/);
+
+  const pageTwoReq = {
+    ...pageOneReq,
+    query: {
+      ...pageOneReq.query,
+      page: "2",
+    },
+  };
+  const pageTwoRes = createResponse();
+
+  await searchController.getAllUsersAndTeams(pageTwoReq, pageTwoRes);
+
+  assert.equal(pageTwoRes.statusCode, 200);
+  assert.deepEqual(
+    pageTwoRes.body.data.teams.map((team) => team.id),
+    [3],
+  );
+  assert.equal(pageTwoRes.body.data.teams[0].is_remote, true);
+});
+
+test("globalSearch remote proximity sort keeps non-remote teams in the result set", async () => {
+  const { query, calls } = buildQueryStub({
+    userLocation: {
+      latitude: "52.52",
+      longitude: "13.405",
+      postal_code: "10115",
+      city: "Berlin",
+    },
+  });
+  db.pool.query = query;
+
+  const req = {
+    query: {
+      query: "de",
+      page: "1",
+      limit: "10",
+      sortBy: "proximity",
+      sortDir: "remote",
+      searchType: "teams",
+    },
+    user: { id: 99 },
+  };
+  const res = createResponse();
+
+  await searchController.globalSearch(req, res);
+
+  const teamSql = getTeamDataQuery(calls);
+  assert.equal(res.statusCode, 200);
+  assert.equal(hasTeamRemoteOnlyProximityFilter(calls), false);
+  assert.match(
+    teamSql,
+    /CASE WHEN t\.is_remote IS TRUE THEN 0 ELSE 1 END\) ASC, distance_km DESC/,
+  );
+});
+
+test("globalSearch proximity sort applies distance ordering to open roles in all results", async () => {
+  const { query, calls } = buildQueryStub({
+    userLocation: {
+      latitude: "52.52",
+      longitude: "13.405",
+      postal_code: "10115",
+      city: "Berlin",
+    },
+  });
+  db.pool.query = query;
+
+  const req = {
+    query: {
+      query: "de",
+      page: "1",
+      limit: "15",
+      sortBy: "proximity",
+      sortDir: "asc",
+      searchType: "all",
+    },
+    user: { id: 99 },
+  };
+  const res = createResponse();
+
+  await searchController.globalSearch(req, res);
+
+  const roleSql = getRoleDataQuery(calls);
+  assert.equal(res.statusCode, 200);
+  assert.match(roleSql, /distance_km/);
+  assert.match(roleSql, /vr\.is_remote IS TRUE/);
+  assert.match(roleSql, /vr\.latitude IS NULL OR vr\.longitude IS NULL/);
+  assert.match(roleSql, /ORDER BY .*distance_km ASC/s);
 });
 
 test("globalSearch excludes own teams for authenticated users and keeps user results unchanged", async () => {
@@ -645,7 +810,7 @@ test("getAllUsersAndTeams with includeDemoData=false excludes synthetic rows", a
   assert.equal(res.body.pagination.totalTeams, 1);
   assert.equal(res.body.pagination.totalUsers, 1);
   assert.equal(res.body.pagination.totalRoles, 1);
-  assert.equal(res.body.pagination.totalItems, 2);
+  assert.equal(res.body.pagination.totalItems, 3);
   assert.deepEqual(
     res.body.data.teams.map((team) => team.id),
     [2],
@@ -685,7 +850,7 @@ test("globalSearch with includeDemoData=false excludes synthetic rows", async ()
   assert.equal(res.body.pagination.totalTeams, 1);
   assert.equal(res.body.pagination.totalUsers, 1);
   assert.equal(res.body.pagination.totalRoles, 1);
-  assert.equal(res.body.pagination.totalItems, 2);
+  assert.equal(res.body.pagination.totalItems, 3);
   assert.deepEqual(
     res.body.data.teams.map((team) => team.id),
     [2],
@@ -719,7 +884,7 @@ test("default search behavior includes synthetic rows when includeDemoData is om
   assert.equal(res.body.pagination.totalTeams, 2);
   assert.equal(res.body.pagination.totalUsers, 2);
   assert.equal(res.body.pagination.totalRoles, 2);
-  assert.equal(res.body.pagination.totalItems, 4);
+  assert.equal(res.body.pagination.totalItems, 6);
   assert.deepEqual(
     res.body.data.teams.map((team) => team.id),
     [1, 2],


### PR DESCRIPTION
## Summary

Improve proximity-based search sorting for teams and open roles.

## What Changed

- Added proximity sorting support for open role search results.
- Included `distance_km` in role results when proximity sorting or max-distance filtering is active.
- Updated team proximity sorting so remote and non-remote teams stay in the result set, instead of being filtered out.
- Prioritized local results before remote or incomplete-location results when sorting by nearest distance.
- Added remote-first ordering for `sortDir=remote` while preserving non-remote results.
- Applied max-distance filtering to role searches when user location is available.
- Fixed aggregate pagination totals so `all` search includes role counts alongside teams and users.

## Tests

- `npm test -- test/searchController.test.js`
