### PR TITLE
Fix/timestamp chat

### DIFF
--- a/src/config/database.js
+++ b/src/config/database.js
@@ -1,7 +1,11 @@
-const { Pool } = require('pg');
+const { Pool, types } = require('pg');
 const dotenv = require('dotenv');
 
 dotenv.config();
+
+// Treat TIMESTAMP WITHOUT TIME ZONE as UTC so the pg driver never applies
+// local-timezone shifts when constructing JavaScript Date objects.
+types.setTypeParser(1114, (str) => new Date(str + 'Z'));
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -27,7 +27,14 @@ const getUnreadCount = async (req, res) => {
            MAX(m.sent_at) AS latest
          FROM messages m
          JOIN team_members tm ON m.team_id = tm.team_id AND tm.user_id = $1
-         WHERE m.sender_id != $1 AND m.read_at IS NULL AND m.team_id IS NOT NULL
+         WHERE m.sender_id != $1
+           AND m.team_id IS NOT NULL
+           AND NOT EXISTS (
+             SELECT 1
+             FROM message_reads mr
+             WHERE mr.message_id = m.id
+               AND mr.user_id = $1
+           )
          GROUP BY m.team_id
        ),
        combined AS (
@@ -212,8 +219,13 @@ const getConversations = async (req, res) => {
         JOIN team_members tm ON m.team_id = tm.team_id
         WHERE tm.user_id = $1 
           AND m.sender_id != $1
-          AND m.read_at IS NULL
           AND m.team_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1
+            FROM message_reads mr
+            WHERE mr.message_id = m.id
+              AND mr.user_id = $1
+          )
         GROUP BY m.team_id
       )
       SELECT 
@@ -427,20 +439,59 @@ const getMessages = async (req, res) => {
       m.deleted_by,
       m.sent_at as created_at,
       m.read_at,
+      current_user_read.read_at as current_user_read_at,
+      COALESCE(read_stats.read_count, 0)::int as read_count,
+      read_stats.first_read_at,
+      COALESCE(read_stats.read_by_users, '[]'::jsonb) as read_by_users,
+      COALESCE(recipient_stats.recipient_count, 0)::int as recipient_count,
       u.username as sender_username,
       u.first_name as sender_first_name,
       u.last_name as sender_last_name,
       u.avatar_url as sender_avatar_url
     FROM messages m
     LEFT JOIN users u ON m.sender_id = u.id
+    LEFT JOIN LATERAL (
+      SELECT mr.read_at
+      FROM message_reads mr
+      WHERE mr.message_id = m.id
+        AND mr.user_id = $2
+      LIMIT 1
+    ) current_user_read ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT
+        COUNT(*)::int as read_count,
+        MIN(mr.read_at) as first_read_at,
+        COALESCE(
+          jsonb_agg(
+            jsonb_build_object(
+              'id', u.id,
+              'username', u.username,
+              'firstName', u.first_name,
+              'lastName', u.last_name
+            )
+            ORDER BY mr.read_at
+          ) FILTER (WHERE u.id IS NOT NULL),
+          '[]'::jsonb
+        ) as read_by_users
+      FROM message_reads mr
+      LEFT JOIN users u ON u.id = mr.user_id
+      WHERE mr.message_id = m.id
+        AND mr.user_id != m.sender_id
+    ) read_stats ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*)::int as recipient_count
+      FROM team_members tm
+      WHERE tm.team_id = m.team_id
+        AND tm.user_id != m.sender_id
+    ) recipient_stats ON TRUE
     WHERE m.team_id = $1
-    ${before ? "AND m.id < $2" : ""}
+    ${before ? "AND m.id < $3" : ""}
     ORDER BY m.sent_at DESC, m.id DESC
-    LIMIT $${before ? "3" : "2"}
+    LIMIT $${before ? "4" : "3"}
   `;
       queryParams = before
-        ? [conversationId, before, limit]
-        : [conversationId, limit];
+        ? [conversationId, userId, before, limit]
+        : [conversationId, userId, limit];
     } else {
       messagesQuery = `
     SELECT 
@@ -495,7 +546,13 @@ const getMessages = async (req, res) => {
       deletedAt: row.deleted_at,
       deletedBy: row.deleted_by,
       createdAt: row.created_at,
-      readAt: row.read_at,
+      readAt:
+        row.team_id && Number(row.sender_id) !== Number(userId)
+          ? row.current_user_read_at
+          : row.first_read_at || row.read_at,
+      readCount: parseInt(row.read_count, 10) || 0,
+      recipientCount: parseInt(row.recipient_count, 10) || 0,
+      readByUsers: row.read_by_users || [],
       senderUsername: row.sender_username,
       senderFirstName: row.sender_first_name,
       senderLastName: row.sender_last_name,

--- a/src/database/migrations/create_message_reads.js
+++ b/src/database/migrations/create_message_reads.js
@@ -1,0 +1,39 @@
+const db = require("../../config/database");
+
+const createMessageReads = async () => {
+  try {
+    await db.query(`
+      CREATE TABLE IF NOT EXISTS message_reads (
+        message_id BIGINT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+        user_id    INT    NOT NULL REFERENCES users(id)    ON DELETE CASCADE,
+        read_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (message_id, user_id)
+      )
+    `);
+    await db.query(`
+      CREATE INDEX IF NOT EXISTS idx_message_reads_message_id
+        ON message_reads (message_id)
+    `);
+    await db.query(`
+      CREATE INDEX IF NOT EXISTS idx_message_reads_user_id
+        ON message_reads (user_id)
+    `);
+    await db.query(`
+      INSERT INTO message_reads (message_id, user_id, read_at)
+      SELECT m.id, tm.user_id, m.read_at
+      FROM messages m
+      JOIN team_members tm
+        ON tm.team_id = m.team_id
+       AND tm.user_id != m.sender_id
+      WHERE m.team_id IS NOT NULL
+        AND m.read_at IS NOT NULL
+      ON CONFLICT (message_id, user_id) DO NOTHING
+    `);
+    console.log("message_reads table created (or already exists)");
+  } catch (error) {
+    console.error("Error creating message_reads table:", error);
+    throw error;
+  }
+};
+
+module.exports = createMessageReads;

--- a/src/database/migrations/fix_messages_timestamps.js
+++ b/src/database/migrations/fix_messages_timestamps.js
@@ -1,0 +1,25 @@
+const db = require("../../config/database");
+
+const fixMessagesTimestamps = async () => {
+  try {
+    await db.query(`
+      ALTER TABLE messages
+        ALTER COLUMN sent_at       TYPE TIMESTAMPTZ USING sent_at       AT TIME ZONE 'UTC',
+        ALTER COLUMN read_at       TYPE TIMESTAMPTZ USING read_at       AT TIME ZONE 'UTC',
+        ALTER COLUMN file_expires_at TYPE TIMESTAMPTZ USING file_expires_at AT TIME ZONE 'UTC',
+        ALTER COLUMN file_deleted_at TYPE TIMESTAMPTZ USING file_deleted_at AT TIME ZONE 'UTC',
+        ALTER COLUMN deleted_at    TYPE TIMESTAMPTZ USING deleted_at    AT TIME ZONE 'UTC';
+    `);
+    console.log("Messages timestamp columns converted to TIMESTAMPTZ");
+  } catch (error) {
+    if (error.message && error.message.includes("does not exist")) {
+      console.log(
+        "Some columns not found — skipping (table may not have all columns yet)",
+      );
+    } else {
+      throw error;
+    }
+  }
+};
+
+module.exports = fixMessagesTimestamps;

--- a/src/database/migrations/index.js
+++ b/src/database/migrations/index.js
@@ -12,6 +12,7 @@ const enhanceTagsTable = require("./10_enhance_tags_table");
 const addUserVisibilityColumn = require("./add_visibility_to_users");
 const createTeamApplicationsTable = require("./create_team_applications");
 const fixMessagesTimestamps = require("./fix_messages_timestamps");
+const createMessageReads = require("./create_message_reads");
 
 const runMigrations = async () => {
   try {
@@ -30,6 +31,7 @@ const runMigrations = async () => {
     await addUserVisibilityColumn();
     await createTeamApplicationsTable();
     await fixMessagesTimestamps();
+    await createMessageReads();
 
     console.log("All migrations completed successfully!");
   } catch (error) {

--- a/src/database/migrations/index.js
+++ b/src/database/migrations/index.js
@@ -11,6 +11,7 @@ const createUserBadgesTable = require("./09_create_user_badges");
 const enhanceTagsTable = require("./10_enhance_tags_table");
 const addUserVisibilityColumn = require("./add_visibility_to_users");
 const createTeamApplicationsTable = require("./create_team_applications");
+const fixMessagesTimestamps = require("./fix_messages_timestamps");
 
 const runMigrations = async () => {
   try {
@@ -28,6 +29,7 @@ const runMigrations = async () => {
     await enhanceTagsTable();
     await addUserVisibilityColumn();
     await createTeamApplicationsTable();
+    await fixMessagesTimestamps();
 
     console.log("All migrations completed successfully!");
   } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -188,6 +188,14 @@ io.on("connection", (socket) => {
           ],
         );
 
+        const recipientCountResult = await db.query(
+          `SELECT COUNT(*)::int as recipient_count
+           FROM team_members
+           WHERE team_id = $1
+             AND user_id != $2`,
+          [conversationId, userId],
+        );
+
         const message = {
           id: messageResult.rows[0].id,
           conversationId: String(conversationId),
@@ -201,6 +209,9 @@ io.on("connection", (socket) => {
           fileSize: messageResult.rows[0].file_size,
           fileExpiresAt: messageResult.rows[0].file_expires_at,
           createdAt: messageResult.rows[0].sent_at,
+          readCount: 0,
+          recipientCount:
+            Number(recipientCountResult.rows[0]?.recipient_count) || 0,
           type: "team",
         };
 
@@ -319,23 +330,76 @@ io.on("connection", (socket) => {
       }
 
       if (type === "team") {
-        // Mark team messages as read (messages not sent by this user)
-        await db.query(
-          `UPDATE messages
-           SET read_at = NOW()
-           WHERE team_id = $1 
-             AND sender_id != $2 
-             AND read_at IS NULL`,
+        const readStatusResult = await db.query(
+          `WITH inserted_reads AS (
+             INSERT INTO message_reads (message_id, user_id, read_at)
+             SELECT m.id, $2, NOW()
+             FROM messages m
+             WHERE m.team_id = $1
+               AND m.sender_id != $2
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM message_reads mr
+                 WHERE mr.message_id = m.id
+                   AND mr.user_id = $2
+               )
+             ON CONFLICT (message_id, user_id) DO NOTHING
+             RETURNING message_id, read_at
+           )
+           SELECT
+             m.id as message_id,
+             COALESCE(read_stats.read_count, 0)::int as read_count,
+             COALESCE(recipient_stats.recipient_count, 0)::int as recipient_count,
+             read_stats.first_read_at,
+             COALESCE(read_stats.read_by_users, '[]'::jsonb) as read_by_users
+           FROM inserted_reads ir
+           JOIN messages m ON m.id = ir.message_id
+           LEFT JOIN LATERAL (
+             SELECT
+               COUNT(*)::int as read_count,
+               MIN(mr.read_at) as first_read_at,
+               COALESCE(
+                 jsonb_agg(
+                   jsonb_build_object(
+                     'id', u.id,
+                     'username', u.username,
+                     'firstName', u.first_name,
+                     'lastName', u.last_name
+                   )
+                   ORDER BY mr.read_at
+                 ) FILTER (WHERE u.id IS NOT NULL),
+                 '[]'::jsonb
+               ) as read_by_users
+             FROM message_reads mr
+             LEFT JOIN users u ON u.id = mr.user_id
+             WHERE mr.message_id = m.id
+               AND mr.user_id != m.sender_id
+           ) read_stats ON TRUE
+           LEFT JOIN LATERAL (
+             SELECT COUNT(*)::int as recipient_count
+             FROM team_members tm
+             WHERE tm.team_id = m.team_id
+               AND tm.user_id != m.sender_id
+           ) recipient_stats ON TRUE`,
           [conversationId, userId],
         );
 
         // Emit read status update to the team room
-        socket.to(`team:${conversationId}`).emit("message:status", {
-          conversationId: String(conversationId),
-          type: "team",
-          readBy: userId,
-          readAt: new Date().toISOString(),
-        });
+        if (readStatusResult.rows.length > 0) {
+          socket.to(`team:${conversationId}`).emit("message:status", {
+            conversationId: String(conversationId),
+            type: "team",
+            readBy: userId,
+            readAt: new Date().toISOString(),
+            messageReadCounts: readStatusResult.rows.map((row) => ({
+              messageId: row.message_id,
+              readCount: Number(row.read_count) || 0,
+              recipientCount: Number(row.recipient_count) || 0,
+              firstReadAt: row.first_read_at,
+              readByUsers: row.read_by_users || [],
+            })),
+          });
+        }
       } else {
         // Mark direct messages as read
         await db.query(
@@ -347,7 +411,7 @@ io.on("connection", (socket) => {
 
         // Emit read status update to the sender
         socket.to(`user:${conversationId}`).emit("message:status", {
-          conversationId: String(conversationId),
+          conversationId: String(userId),
           type: "direct",
           readBy: userId,
           readAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary

This PR fixes chat timestamp handling and adds per-user read tracking for team messages.

## What Changed

- Converts message timestamp columns to `TIMESTAMPTZ` so chat times are stored/read consistently in UTC.
- Configures the Postgres driver to treat timestamp-without-timezone values as UTC to avoid local timezone shifts.
- Adds a new `message_reads` table for per-user team message read receipts.
- Backfills team message read receipts from existing `messages.read_at` values.
- Updates unread counts and conversation queries to use `message_reads` instead of the shared `messages.read_at` field for team chats.
- Returns team message read metadata, including `readCount`, `recipientCount`, `readByUsers`, and current-user read status.
- Emits richer socket read-status updates for team chats.
- Fixes direct-message socket status payloads to use the reader’s user id as the conversation id.

## Testing

- `npm test` was run.
- Result: 46 passing, 2 failing.
- The failing tests are in `test/userController.deleteUser.test.js` and appear related to existing SQL stub expectations in the delete-user flow, not the chat/timestamp changes in this PR.
