### PR TITLE
Security Hardening & Account Deletion — Backend

### DIFF
--- a/src/config/database.js
+++ b/src/config/database.js
@@ -1,7 +1,11 @@
-const { Pool } = require('pg');
+const { Pool, types } = require('pg');
 const dotenv = require('dotenv');
 
 dotenv.config();
+
+// Treat TIMESTAMP WITHOUT TIME ZONE as UTC so the pg driver never applies
+// local-timezone shifts when constructing JavaScript Date objects.
+types.setTypeParser(1114, (str) => new Date(str + 'Z'));
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -437,6 +437,8 @@ const getMessages = async (req, res) => {
       m.file_deleted_at,
       m.deleted_at,
       m.deleted_by,
+      m.edited_at,
+      m.edited_by,
       m.sent_at as created_at,
       m.read_at,
       current_user_read.read_at as current_user_read_at,
@@ -507,6 +509,8 @@ const getMessages = async (req, res) => {
       m.file_deleted_at,
       m.deleted_at,
       m.deleted_by,
+      m.edited_at,
+      m.edited_by,
       m.sent_at as created_at,
       m.read_at,
       u.username as sender_username,
@@ -545,6 +549,9 @@ const getMessages = async (req, res) => {
       fileDeletedAt: row.file_deleted_at,
       deletedAt: row.deleted_at,
       deletedBy: row.deleted_by,
+      editedAt: row.edited_at,
+      editedBy: row.edited_by,
+      isEdited: Boolean(row.edited_at),
       createdAt: row.created_at,
       readAt:
         row.team_id && Number(row.sender_id) !== Number(userId)
@@ -702,6 +709,130 @@ const getMessageById = async (req, res) => {
   }
 };
 
+const updateMessage = async (req, res) => {
+  try {
+    const messageId = req.params.id;
+    const currentUserId = req.user?.id ?? req.userId;
+    const content = typeof req.body?.content === "string" ? req.body.content.trim() : "";
+
+    if (!content) {
+      return res.status(400).json({ message: "Message content is required" });
+    }
+
+    if (content.length > 500) {
+      return res.status(400).json({ message: "Message content is too long" });
+    }
+
+    const msgResult = await db.query(
+      `SELECT id, sender_id, receiver_id, team_id, deleted_at
+       FROM messages
+       WHERE id = $1`,
+      [messageId],
+    );
+
+    if (msgResult.rows.length === 0) {
+      return res.status(404).json({ message: "Message not found" });
+    }
+
+    const msg = msgResult.rows[0];
+
+    if (Number(msg.sender_id) !== Number(currentUserId)) {
+      return res
+        .status(403)
+        .json({ message: "Not authorized to edit this message" });
+    }
+
+    if (msg.deleted_at) {
+      return res.status(400).json({ message: "Cannot edit a deleted message" });
+    }
+
+    const updateResult = await db.query(
+      `UPDATE messages
+       SET content = $2,
+           edited_at = NOW(),
+           edited_by = $3
+       WHERE id = $1
+       RETURNING id, sender_id, receiver_id, team_id, content, edited_at, edited_by`,
+      [messageId, content, currentUserId],
+    );
+
+    const updatedMessage = updateResult.rows[0];
+    const latestMessageResult = updatedMessage.team_id
+      ? await db.query(
+          `SELECT id
+           FROM messages
+           WHERE team_id = $1
+           ORDER BY sent_at DESC, id DESC
+           LIMIT 1`,
+          [updatedMessage.team_id],
+        )
+      : await db.query(
+          `SELECT id
+           FROM messages
+           WHERE team_id IS NULL
+             AND (
+               (sender_id = $1 AND receiver_id = $2)
+               OR (sender_id = $2 AND receiver_id = $1)
+             )
+           ORDER BY sent_at DESC, id DESC
+           LIMIT 1`,
+          [updatedMessage.sender_id, updatedMessage.receiver_id],
+        );
+    const isLatestMessage =
+      String(latestMessageResult.rows[0]?.id) === String(updatedMessage.id);
+    const payload = {
+      messageId: Number(updatedMessage.id),
+      conversationId: updatedMessage.team_id
+        ? String(updatedMessage.team_id)
+        : String(
+            Number(updatedMessage.sender_id) === Number(currentUserId)
+              ? updatedMessage.receiver_id
+              : updatedMessage.sender_id,
+          ),
+      content: updatedMessage.content,
+      editedAt: updatedMessage.edited_at,
+      editedBy: Number(updatedMessage.edited_by),
+      isEdited: true,
+      type: updatedMessage.team_id ? "team" : "direct",
+      teamId: updatedMessage.team_id ? Number(updatedMessage.team_id) : null,
+      senderId: updatedMessage.sender_id ? Number(updatedMessage.sender_id) : null,
+      receiverId: updatedMessage.receiver_id
+        ? Number(updatedMessage.receiver_id)
+        : null,
+      isLatestMessage,
+    };
+
+    const io = req.app.get("io");
+
+    if (io) {
+      if (updatedMessage.team_id) {
+        io.to(`team:${updatedMessage.team_id}`).emit("message:edited", payload);
+      } else {
+        io.to(`user:${updatedMessage.sender_id}`).emit("message:edited", payload);
+        io.to(`user:${updatedMessage.receiver_id}`).emit("message:edited", payload);
+      }
+    }
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        id: updatedMessage.id,
+        senderId: updatedMessage.sender_id,
+        receiverId: updatedMessage.receiver_id,
+        teamId: updatedMessage.team_id,
+        content: updatedMessage.content,
+        editedAt: updatedMessage.edited_at,
+        editedBy: updatedMessage.edited_by,
+        isEdited: true,
+        isLatestMessage,
+      },
+    });
+  } catch (error) {
+    console.error("updateMessage error:", error);
+    return res.status(500).json({ message: "Failed to edit message" });
+  }
+};
+
 const deleteMessage = async (req, res) => {
   try {
     const messageId = req.params.id;
@@ -789,6 +920,7 @@ module.exports = {
   sendMessage,
   getMessages,
   getMessageById,
+  updateMessage,
   deleteMessage,
   getUnreadCount,
 };

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -27,7 +27,14 @@ const getUnreadCount = async (req, res) => {
            MAX(m.sent_at) AS latest
          FROM messages m
          JOIN team_members tm ON m.team_id = tm.team_id AND tm.user_id = $1
-         WHERE m.sender_id != $1 AND m.read_at IS NULL AND m.team_id IS NOT NULL
+         WHERE m.sender_id != $1
+           AND m.team_id IS NOT NULL
+           AND NOT EXISTS (
+             SELECT 1
+             FROM message_reads mr
+             WHERE mr.message_id = m.id
+               AND mr.user_id = $1
+           )
          GROUP BY m.team_id
        ),
        combined AS (
@@ -212,8 +219,13 @@ const getConversations = async (req, res) => {
         JOIN team_members tm ON m.team_id = tm.team_id
         WHERE tm.user_id = $1 
           AND m.sender_id != $1
-          AND m.read_at IS NULL
           AND m.team_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1
+            FROM message_reads mr
+            WHERE mr.message_id = m.id
+              AND mr.user_id = $1
+          )
         GROUP BY m.team_id
       )
       SELECT 
@@ -427,20 +439,59 @@ const getMessages = async (req, res) => {
       m.deleted_by,
       m.sent_at as created_at,
       m.read_at,
+      current_user_read.read_at as current_user_read_at,
+      COALESCE(read_stats.read_count, 0)::int as read_count,
+      read_stats.first_read_at,
+      COALESCE(read_stats.read_by_users, '[]'::jsonb) as read_by_users,
+      COALESCE(recipient_stats.recipient_count, 0)::int as recipient_count,
       u.username as sender_username,
       u.first_name as sender_first_name,
       u.last_name as sender_last_name,
       u.avatar_url as sender_avatar_url
     FROM messages m
     LEFT JOIN users u ON m.sender_id = u.id
+    LEFT JOIN LATERAL (
+      SELECT mr.read_at
+      FROM message_reads mr
+      WHERE mr.message_id = m.id
+        AND mr.user_id = $2
+      LIMIT 1
+    ) current_user_read ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT
+        COUNT(*)::int as read_count,
+        MIN(mr.read_at) as first_read_at,
+        COALESCE(
+          jsonb_agg(
+            jsonb_build_object(
+              'id', u.id,
+              'username', u.username,
+              'firstName', u.first_name,
+              'lastName', u.last_name
+            )
+            ORDER BY mr.read_at
+          ) FILTER (WHERE u.id IS NOT NULL),
+          '[]'::jsonb
+        ) as read_by_users
+      FROM message_reads mr
+      LEFT JOIN users u ON u.id = mr.user_id
+      WHERE mr.message_id = m.id
+        AND mr.user_id != m.sender_id
+    ) read_stats ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*)::int as recipient_count
+      FROM team_members tm
+      WHERE tm.team_id = m.team_id
+        AND tm.user_id != m.sender_id
+    ) recipient_stats ON TRUE
     WHERE m.team_id = $1
-    ${before ? "AND m.id < $2" : ""}
+    ${before ? "AND m.id < $3" : ""}
     ORDER BY m.sent_at DESC, m.id DESC
-    LIMIT $${before ? "3" : "2"}
+    LIMIT $${before ? "4" : "3"}
   `;
       queryParams = before
-        ? [conversationId, before, limit]
-        : [conversationId, limit];
+        ? [conversationId, userId, before, limit]
+        : [conversationId, userId, limit];
     } else {
       messagesQuery = `
     SELECT 
@@ -495,7 +546,13 @@ const getMessages = async (req, res) => {
       deletedAt: row.deleted_at,
       deletedBy: row.deleted_by,
       createdAt: row.created_at,
-      readAt: row.read_at,
+      readAt:
+        row.team_id && Number(row.sender_id) !== Number(userId)
+          ? row.current_user_read_at
+          : row.first_read_at || row.read_at,
+      readCount: parseInt(row.read_count, 10) || 0,
+      recipientCount: parseInt(row.recipient_count, 10) || 0,
+      readByUsers: row.read_by_users || [],
       senderUsername: row.sender_username,
       senderFirstName: row.sender_first_name,
       senderLastName: row.sender_last_name,

--- a/src/database/migrations/add_message_edit_columns.js
+++ b/src/database/migrations/add_message_edit_columns.js
@@ -1,0 +1,17 @@
+const db = require("../../config/database");
+
+const addMessageEditColumns = async () => {
+  try {
+    await db.query(`
+      ALTER TABLE messages
+        ADD COLUMN IF NOT EXISTS edited_at TIMESTAMPTZ,
+        ADD COLUMN IF NOT EXISTS edited_by INT REFERENCES users(id) ON DELETE SET NULL
+    `);
+    console.log("Message edit columns added (or already exist)");
+  } catch (error) {
+    console.error("Error adding message edit columns:", error);
+    throw error;
+  }
+};
+
+module.exports = addMessageEditColumns;

--- a/src/database/migrations/create_message_reads.js
+++ b/src/database/migrations/create_message_reads.js
@@ -1,0 +1,39 @@
+const db = require("../../config/database");
+
+const createMessageReads = async () => {
+  try {
+    await db.query(`
+      CREATE TABLE IF NOT EXISTS message_reads (
+        message_id BIGINT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+        user_id    INT    NOT NULL REFERENCES users(id)    ON DELETE CASCADE,
+        read_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (message_id, user_id)
+      )
+    `);
+    await db.query(`
+      CREATE INDEX IF NOT EXISTS idx_message_reads_message_id
+        ON message_reads (message_id)
+    `);
+    await db.query(`
+      CREATE INDEX IF NOT EXISTS idx_message_reads_user_id
+        ON message_reads (user_id)
+    `);
+    await db.query(`
+      INSERT INTO message_reads (message_id, user_id, read_at)
+      SELECT m.id, tm.user_id, m.read_at
+      FROM messages m
+      JOIN team_members tm
+        ON tm.team_id = m.team_id
+       AND tm.user_id != m.sender_id
+      WHERE m.team_id IS NOT NULL
+        AND m.read_at IS NOT NULL
+      ON CONFLICT (message_id, user_id) DO NOTHING
+    `);
+    console.log("message_reads table created (or already exists)");
+  } catch (error) {
+    console.error("Error creating message_reads table:", error);
+    throw error;
+  }
+};
+
+module.exports = createMessageReads;

--- a/src/database/migrations/fix_messages_timestamps.js
+++ b/src/database/migrations/fix_messages_timestamps.js
@@ -1,0 +1,25 @@
+const db = require("../../config/database");
+
+const fixMessagesTimestamps = async () => {
+  try {
+    await db.query(`
+      ALTER TABLE messages
+        ALTER COLUMN sent_at       TYPE TIMESTAMPTZ USING sent_at       AT TIME ZONE 'UTC',
+        ALTER COLUMN read_at       TYPE TIMESTAMPTZ USING read_at       AT TIME ZONE 'UTC',
+        ALTER COLUMN file_expires_at TYPE TIMESTAMPTZ USING file_expires_at AT TIME ZONE 'UTC',
+        ALTER COLUMN file_deleted_at TYPE TIMESTAMPTZ USING file_deleted_at AT TIME ZONE 'UTC',
+        ALTER COLUMN deleted_at    TYPE TIMESTAMPTZ USING deleted_at    AT TIME ZONE 'UTC';
+    `);
+    console.log("Messages timestamp columns converted to TIMESTAMPTZ");
+  } catch (error) {
+    if (error.message && error.message.includes("does not exist")) {
+      console.log(
+        "Some columns not found — skipping (table may not have all columns yet)",
+      );
+    } else {
+      throw error;
+    }
+  }
+};
+
+module.exports = fixMessagesTimestamps;

--- a/src/database/migrations/index.js
+++ b/src/database/migrations/index.js
@@ -12,6 +12,7 @@ const enhanceTagsTable = require("./10_enhance_tags_table");
 const addUserVisibilityColumn = require("./add_visibility_to_users");
 const createTeamApplicationsTable = require("./create_team_applications");
 const fixMessagesTimestamps = require("./fix_messages_timestamps");
+const createMessageReads = require("./create_message_reads");
 
 const runMigrations = async () => {
   try {
@@ -30,6 +31,7 @@ const runMigrations = async () => {
     await addUserVisibilityColumn();
     await createTeamApplicationsTable();
     await fixMessagesTimestamps();
+    await createMessageReads();
 
     console.log("All migrations completed successfully!");
   } catch (error) {

--- a/src/database/migrations/index.js
+++ b/src/database/migrations/index.js
@@ -11,6 +11,7 @@ const createUserBadgesTable = require("./09_create_user_badges");
 const enhanceTagsTable = require("./10_enhance_tags_table");
 const addUserVisibilityColumn = require("./add_visibility_to_users");
 const createTeamApplicationsTable = require("./create_team_applications");
+const fixMessagesTimestamps = require("./fix_messages_timestamps");
 
 const runMigrations = async () => {
   try {
@@ -28,6 +29,7 @@ const runMigrations = async () => {
     await enhanceTagsTable();
     await addUserVisibilityColumn();
     await createTeamApplicationsTable();
+    await fixMessagesTimestamps();
 
     console.log("All migrations completed successfully!");
   } catch (error) {

--- a/src/database/migrations/index.js
+++ b/src/database/migrations/index.js
@@ -13,6 +13,7 @@ const addUserVisibilityColumn = require("./add_visibility_to_users");
 const createTeamApplicationsTable = require("./create_team_applications");
 const fixMessagesTimestamps = require("./fix_messages_timestamps");
 const createMessageReads = require("./create_message_reads");
+const addMessageEditColumns = require("./add_message_edit_columns");
 
 const runMigrations = async () => {
   try {
@@ -32,6 +33,7 @@ const runMigrations = async () => {
     await createTeamApplicationsTable();
     await fixMessagesTimestamps();
     await createMessageReads();
+    await addMessageEditColumns();
 
     console.log("All migrations completed successfully!");
   } catch (error) {

--- a/src/routes/messageRoutes.js
+++ b/src/routes/messageRoutes.js
@@ -48,6 +48,9 @@ router.post(
 // Get specific message
 router.get("/:id", authenticateToken, messageController.getMessageById);
 
+// Edit a message
+router.patch("/:id", authenticateToken, messageController.updateMessage);
+
 // Delete a message
 router.delete("/:id", authenticateToken, messageController.deleteMessage);
 

--- a/src/server.js
+++ b/src/server.js
@@ -188,6 +188,14 @@ io.on("connection", (socket) => {
           ],
         );
 
+        const recipientCountResult = await db.query(
+          `SELECT COUNT(*)::int as recipient_count
+           FROM team_members
+           WHERE team_id = $1
+             AND user_id != $2`,
+          [conversationId, userId],
+        );
+
         const message = {
           id: messageResult.rows[0].id,
           conversationId: String(conversationId),
@@ -201,6 +209,9 @@ io.on("connection", (socket) => {
           fileSize: messageResult.rows[0].file_size,
           fileExpiresAt: messageResult.rows[0].file_expires_at,
           createdAt: messageResult.rows[0].sent_at,
+          readCount: 0,
+          recipientCount:
+            Number(recipientCountResult.rows[0]?.recipient_count) || 0,
           type: "team",
         };
 
@@ -319,23 +330,76 @@ io.on("connection", (socket) => {
       }
 
       if (type === "team") {
-        // Mark team messages as read (messages not sent by this user)
-        await db.query(
-          `UPDATE messages
-           SET read_at = NOW()
-           WHERE team_id = $1 
-             AND sender_id != $2 
-             AND read_at IS NULL`,
+        const readStatusResult = await db.query(
+          `WITH inserted_reads AS (
+             INSERT INTO message_reads (message_id, user_id, read_at)
+             SELECT m.id, $2, NOW()
+             FROM messages m
+             WHERE m.team_id = $1
+               AND m.sender_id != $2
+               AND NOT EXISTS (
+                 SELECT 1
+                 FROM message_reads mr
+                 WHERE mr.message_id = m.id
+                   AND mr.user_id = $2
+               )
+             ON CONFLICT (message_id, user_id) DO NOTHING
+             RETURNING message_id, read_at
+           )
+           SELECT
+             m.id as message_id,
+             COALESCE(read_stats.read_count, 0)::int as read_count,
+             COALESCE(recipient_stats.recipient_count, 0)::int as recipient_count,
+             read_stats.first_read_at,
+             COALESCE(read_stats.read_by_users, '[]'::jsonb) as read_by_users
+           FROM inserted_reads ir
+           JOIN messages m ON m.id = ir.message_id
+           LEFT JOIN LATERAL (
+             SELECT
+               COUNT(*)::int as read_count,
+               MIN(mr.read_at) as first_read_at,
+               COALESCE(
+                 jsonb_agg(
+                   jsonb_build_object(
+                     'id', u.id,
+                     'username', u.username,
+                     'firstName', u.first_name,
+                     'lastName', u.last_name
+                   )
+                   ORDER BY mr.read_at
+                 ) FILTER (WHERE u.id IS NOT NULL),
+                 '[]'::jsonb
+               ) as read_by_users
+             FROM message_reads mr
+             LEFT JOIN users u ON u.id = mr.user_id
+             WHERE mr.message_id = m.id
+               AND mr.user_id != m.sender_id
+           ) read_stats ON TRUE
+           LEFT JOIN LATERAL (
+             SELECT COUNT(*)::int as recipient_count
+             FROM team_members tm
+             WHERE tm.team_id = m.team_id
+               AND tm.user_id != m.sender_id
+           ) recipient_stats ON TRUE`,
           [conversationId, userId],
         );
 
         // Emit read status update to the team room
-        socket.to(`team:${conversationId}`).emit("message:status", {
-          conversationId: String(conversationId),
-          type: "team",
-          readBy: userId,
-          readAt: new Date().toISOString(),
-        });
+        if (readStatusResult.rows.length > 0) {
+          socket.to(`team:${conversationId}`).emit("message:status", {
+            conversationId: String(conversationId),
+            type: "team",
+            readBy: userId,
+            readAt: new Date().toISOString(),
+            messageReadCounts: readStatusResult.rows.map((row) => ({
+              messageId: row.message_id,
+              readCount: Number(row.read_count) || 0,
+              recipientCount: Number(row.recipient_count) || 0,
+              firstReadAt: row.first_read_at,
+              readByUsers: row.read_by_users || [],
+            })),
+          });
+        }
       } else {
         // Mark direct messages as read
         await db.query(
@@ -347,7 +411,7 @@ io.on("connection", (socket) => {
 
         // Emit read status update to the sender
         socket.to(`user:${conversationId}`).emit("message:status", {
-          conversationId: String(conversationId),
+          conversationId: String(userId),
           type: "direct",
           readBy: userId,
           readAt: new Date().toISOString(),


### PR DESCRIPTION
# Merge dev → main: Security Hardening & Account Deletion — Backend

## Summary

This PR brings the backend `dev` branch to production on `main`, delivering two major areas of work: a full security hardening pass across auth, logging, CORS, and password policy — and a complete account deletion system with a multi-phase transactional controller, impact preview endpoint, and 41 tests. All items on the Pre-Merge Deployment Checklist have been completed.

---

## 🔒 Security Hardening

### 1. Rate Limiting on Auth Endpoints (new dependency: `express-rate-limit`)

- **New file:** `src/middlewares/rateLimiter.js` with named limiters
- `authLimiter` — 8 requests per IP per 15 min, applied to `POST /login`, `/forgot-password`, `/reset-password`, `/resend-verification`
- `registerLimiter` — 10 requests per IP per hour, applied to `POST /register`
- Applied in `src/routes/authRoutes.js`
- A general API limiter was tested but removed — SPA parallel requests caused false positives; auth-specific limiters are sufficient
- Tested via curl script and browser — confirmed 429 responses after threshold

### 2. Cloudflare Turnstile CAPTCHA on Registration

- **New file:** `src/utils/turnstileVerify.js` — server-side token verification using Node 18 built-in `fetch`
- Verification gate added at the top of `register` method in `authController.js`
- `turnstile_token` field added to Joi registration schema
- **Feature-flagged:** if `TURNSTILE_SECRET_KEY` is not set, registration works without CAPTCHA — local dev unaffected
- `TURNSTILE_SECRET_KEY` added to Render environment variables

### 3. Production Console.log Cleanup

- **`src/utils/jwtUtils.js`** — JWT_SECRET prefix logging removed entirely; remaining logs wrapped in `NODE_ENV` guard
- **`src/middlewares/auth.js`** — all `console.log` calls wrapped in `if (process.env.NODE_ENV !== 'production')`
- **Controllers** — audited and cleaned `authController.js`, `userController.js`, `teamController.js`, `searchController.js`, `badgeController.js`, and others; debug dumps deleted, informational logs gated behind `NODE_ENV`
- **Utilities & routes** — cleaned `geocodingUtil.js`, `geocodingRoutes.js`, `emailService.js`, `fileValidation.js`, `fileCleanupScheduler.js`, `tags.js`, `app.js`, `server.js`
- All `console.error` and `console.warn` calls left untouched (real error logging)

### 4. Tightened CORS Origin Allowlist

- Replaced blanket `*.vercel.app` check in `src/app.js` → `isAllowedOrigin()` with specific patterns:
  - Exact match for `lomir-frontend.vercel.app`
  - Regex for preview deployments (`lomir-frontend-*-juliabaurs-projects.vercel.app`)
- Production trust proxy setting added to `src/app.js` for correct IP detection behind Render's proxy

### 5. Stronger Password Policy

- Registration Joi schema updated to `min(8)` + regex pattern requiring at least one letter and one number, with custom error messages
- `resetPassword` and `changePassword` methods updated with the same rules
- `loginSchema` intentionally left at `min(6)` so existing test/seed users with 6-character passwords can still log in

---

## 🗑️ Account Deletion (Full Implementation)

### Overview

`deleteUser` was previously a **placeholder** that returned a success message without touching the database. It is now a full transactional controller that handles every FK constraint, preserves data for other users, and emits real-time events.

### New Endpoint: `POST /api/users/:id/deletion-preview`

- **Auth:** Requires valid JWT + password verification
- **Route:** Added to `src/routes/userRoutes.js`
- **Controller:** `deletionPreview` function in `src/controllers/userController.js`
- Returns an impact summary JSON:
  - Teams where ownership will be transferred (with auto-selected successors and successor options for override)
  - Teams that will be permanently deleted (sole-owner, no other members)
  - Roles that will be reopened
  - Counts: badge awards given, DMs, team memberships

### Rewritten: `DELETE /api/users/:id`

- **Auth:** Requires valid JWT + password in request body
- **Body:** `{ password: string, ownershipOverrides?: { teamId: number, successorId: number }[] }`
- Executes all operations in a **single database transaction** across 6 phases:

**Phase A — Gather context:**
1. Verify password against stored hash
2. Fetch user data, team memberships, owned teams, filled roles

**Phase B — Messages & chat cleanup (while sender_id still resolves):**
3. Delete all DMs involving the user
4. Post departure messages to team chats: `"🚪 [Name] has left Lomir."`
5. Replace user's name in existing system messages with `"Former Lomir User"`

**Phase C — Team ownership (while team_members still exist):**
6. Handle sole-owner teams:
   - Copy team name into `badge_awards.custom_team_name` (preserves badge context)
   - Create notifications for pending applicants/invitees about dissolution
   - Hard delete in correct order: invitations → applications → messages → role tags → role badges → roles → team tags → team members → team
7. Transfer ownership of multi-member teams (update `teams.owner_id` + `team_members.role`)

**Phase D — Resolve all 6 NO ACTION FK blockers:**
8. Reopen filled roles (`SET status='open', filled_by=NULL`)
9. Create notifications for team owners/admins about reopened roles
10. SET NULL: `team_vacant_roles.created_by`, `team_applications.reviewed_by`, `user_badges.awarded_by`, `tags.created_by`
11. SET NULL: `messages.deleted_by` (no FK, but cleanup)
12. SET NULL: `notifications.reference_id` for deleted resources

**Phase E — Delete user row** (CASCADE handles remaining FKs)

**Phase F — Post-transaction cleanup:**
14. Delete Cloudinary avatar (non-blocking, best-effort)
15. Emit Socket.IO events: `team:member_left`, `notification:new`, `conversation:deleted`

### Schema Change

- `team_vacant_roles.created_by` changed from `NOT NULL` to **nullable** — required for SET NULL cleanup during deletion

### Message Controller Fix

- `getMessages` query changed `JOIN users u ON m.sender_id = u.id` → `LEFT JOIN users u ON m.sender_id = u.id`
- Prevents messages from vanishing when the sender has been deleted

### Test Coverage

- **New file:** `test/userController.deleteUser.test.js` — **41 tests** covering:
  - Password verification failures
  - Sole-owner team dissolution with badge preservation
  - Multi-member ownership transfer with successor cascade
  - Role reopening and notification creation
  - FK blocker resolution in correct order
  - DM deletion and team chat rewriting
  - Socket.IO event emission
  - Cloudinary cleanup (non-blocking)

---

## 📁 Files Changed

### New Files
- `src/middlewares/rateLimiter.js` — auth + registration rate limiters
- `src/utils/turnstileVerify.js` — Cloudflare Turnstile server-side verification
- `test/userController.deleteUser.test.js` — 41 deletion tests
- `docs/USER_DELETION_SPEC.md` — complete deletion specification

### Modified Files
- `src/controllers/userController.js` — `deleteUser` rewritten from placeholder; new `deletionPreview` function added; console.log cleanup
- `src/controllers/authController.js` — Turnstile verification gate on `register`; stronger password validation in Joi schemas for registration, reset, and change password; console.log cleanup
- `src/controllers/messageController.js` — `LEFT JOIN` fix for deleted user messages
- `src/controllers/teamController.js` — console.log cleanup
- `src/controllers/searchController.js` — console.log cleanup
- `src/controllers/badgeController.js` — console.log cleanup
- `src/routes/userRoutes.js` — new `POST /:id/deletion-preview` route
- `src/routes/authRoutes.js` — rate limiter middleware applied to auth endpoints
- `src/middlewares/auth.js` — console.log gated behind `NODE_ENV`
- `src/utils/jwtUtils.js` — JWT_SECRET logging removed; remaining logs gated
- `src/app.js` — CORS `isAllowedOrigin()` rewrite; production trust proxy setting
- `src/server.js` — console.log cleanup
- Various utilities — `geocodingUtil.js`, `geocodingRoutes.js`, `emailService.js`, `fileValidation.js`, `fileCleanupScheduler.js`, `tags.js` — console.log cleanup
- `package.json` / `package-lock.json` — `express-rate-limit` added

### Database Migration
- `team_vacant_roles.created_by`: `NOT NULL` → nullable

---

## ✅ Pre-Merge Checklist

- [x] `TURNSTILE_SECRET_KEY` added to Render environment variables
- [x] `NODE_ENV=production` confirmed on Render
- [x] `CLIENT_URL`, `FRONTEND_URL`, `FRONTEND_ORIGIN` all point to `https://lomir-frontend.vercel.app`
- [x] Feature-flag confirmed: local dev works without CAPTCHA keys
- [x] Rate limiting tested (429 responses after threshold)
- [x] All 41 deletion tests passing
- [x] LEFT JOIN fix verified — messages display correctly after user deletion
- [ ] **Post-merge:** Redeploy on Render
- [ ] **Post-merge:** Test registration on production (Turnstile verification works)
- [ ] **Post-merge:** Test account deletion flow end-to-end on production