### PR TITLE
Feature/hide awards

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -63,6 +63,42 @@ const refreshBadgeViews = async (clientOrPool) => {
 // ============================================================================
 const VALID_CONTEXT_TYPES = ["personal", "team", "project"];
 
+const recalculateUserTagBadgeCredits = async (client, userId, tagId) => {
+  if (!tagId) return;
+
+  const totalsResult = await client.query(
+    `SELECT
+       COALESCE(SUM(credits), 0)::int AS badge_credits,
+       (
+         SELECT b.category
+         FROM badge_awards ba
+         JOIN badges b ON b.id = ba.badge_id
+         WHERE ba.awarded_to_user_id = $1
+           AND ba.tag_id = $2
+         GROUP BY b.category
+         ORDER BY SUM(ba.credits) DESC, b.category ASC
+         LIMIT 1
+       ) AS dominant_badge_category
+     FROM badge_awards
+     WHERE awarded_to_user_id = $1
+       AND tag_id = $2`,
+    [userId, tagId],
+  );
+
+  const nextCredits = Number(totalsResult.rows[0]?.badge_credits ?? 0);
+  const nextDominantCategory =
+    totalsResult.rows[0]?.dominant_badge_category ?? null;
+
+  await client.query(
+    `UPDATE user_tags
+     SET badge_credits = $1,
+         dominant_badge_category = $2
+     WHERE user_id = $3
+       AND tag_id = $4`,
+    [nextCredits, nextDominantCategory, userId, tagId],
+  );
+};
+
 /**
  * @description Award a badge to a user
  * @route POST /api/badges/award
@@ -415,6 +451,75 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW())
 };
 
 /**
+ * @description Delete one badge award received by the authenticated user
+ * @route DELETE /api/badges/awards/:awardId
+ * @access Private (recipient only)
+ */
+const deleteBadgeAward = async (req, res) => {
+  const client = await pool.connect();
+
+  try {
+    const userId = req.user.id;
+    const awardId = req.params.awardId;
+
+    if (!awardId) {
+      return res.status(400).json({
+        success: false,
+        message: "awardId is required",
+      });
+    }
+
+    await client.query("BEGIN");
+
+    const awardResult = await client.query(
+      `DELETE FROM badge_awards
+       WHERE id = $1
+         AND awarded_to_user_id = $2
+       RETURNING id, awarded_to_user_id, badge_id, credits, tag_id`,
+      [awardId, userId],
+    );
+
+    if (awardResult.rows.length === 0) {
+      await client.query("ROLLBACK");
+      return res.status(404).json({
+        success: false,
+        message: "Badge award not found",
+      });
+    }
+
+    const deletedAward = awardResult.rows[0];
+
+    await recalculateUserTagBadgeCredits(
+      client,
+      deletedAward.awarded_to_user_id,
+      deletedAward.tag_id,
+    );
+
+    await client.query("COMMIT");
+
+    refreshBadgeViews(pool).catch((err) =>
+      console.warn("⚠️ View refresh failed:", err.message),
+    );
+
+    res.status(200).json({
+      success: true,
+      message: "Badge award deleted successfully",
+      data: deletedAward,
+    });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    console.error("Error deleting badge award:", error);
+    res.status(500).json({
+      success: false,
+      message: "Error deleting badge award",
+      ...(process.env.NODE_ENV === "development" && { error: error.message }),
+    });
+  } finally {
+    client.release();
+  }
+};
+
+/**
  * @description Get teams shared between the authenticated user and another user
  * @route GET /api/badges/shared-teams/:userId
  * @access Private (requires authentication)
@@ -533,6 +638,7 @@ const getUserBadges = async (req, res) => {
 module.exports = {
   getAllBadges,
   awardBadge,
+  deleteBadgeAward,
   getUserBadges,
   getSharedTeams,
 };

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -62,6 +62,15 @@ const insertNotificationRecord = async (
   );
 };
 
+const ensureBadgeVisibilityColumns = async () => {
+  await pool.query(
+    `ALTER TABLE users
+     ADD COLUMN IF NOT EXISTS hide_badges BOOLEAN DEFAULT FALSE,
+     ADD COLUMN IF NOT EXISTS hidden_badge_ids INTEGER[] DEFAULT '{}'::INTEGER[],
+     ADD COLUMN IF NOT EXISTS hidden_award_ids INTEGER[] DEFAULT '{}'::INTEGER[]`,
+  );
+};
+
 const getSuccessorCandidatesByTeam = async (queryable, teamIds, excludedUserId) => {
   if (teamIds.length === 0) {
     return new Map();
@@ -148,6 +157,8 @@ const getUserById = async (req, res) => {
       console.log(`Fetching user with ID: ${userId}`);
     }
 
+    await ensureBadgeVisibilityColumns();
+
     // Fetch user with tags as a comma-separated string
     const result = await pool.query(
       `
@@ -167,6 +178,9 @@ const getUserById = async (req, res) => {
     u.avatar_url,
     u.is_public,
     u.is_synthetic,
+    COALESCE(u.hide_badges, FALSE) AS hide_badges,
+    COALESCE(u.hidden_badge_ids, '{}'::INTEGER[]) AS hidden_badge_ids,
+    COALESCE(u.hidden_award_ids, '{}'::INTEGER[]) AS hidden_award_ids,
     u.created_at,
     u.updated_at,
     COALESCE((
@@ -185,35 +199,84 @@ const getUserById = async (req, res) => {
       SELECT COALESCE(
         json_agg(
           json_build_object(
-            'id', v.badge_id,
-            'name', v.badge_name,
-            'category', v.category,
-            'color', v.badge_color,
-            'cat_image_url', v.cat_image_url,
-            'total_credits', v.total_credits,
-            'award_count', v.award_count,
-            'awarder_count', v.awarder_count,
-            'category_total_credits', v.category_total_credits,
-            'category_award_count', v.category_award_count,
-            'category_awarder_count', v.category_awarder_count,
-            'last_awarded_at', v.last_awarded_at
+            'id', badge_rows.badge_id,
+            'name', badge_rows.badge_name,
+            'category', badge_rows.category,
+            'color', badge_rows.badge_color,
+            'cat_image_url', badge_rows.cat_image_url,
+            'total_credits', badge_rows.total_credits,
+            'award_count', badge_rows.award_count,
+            'awarder_count', badge_rows.awarder_count,
+            'category_total_credits', badge_rows.category_total_credits,
+            'category_award_count', badge_rows.category_award_count,
+            'category_awarder_count', badge_rows.category_awarder_count,
+            'last_awarded_at', badge_rows.last_awarded_at
           )
           ORDER BY
-            v.category_total_credits DESC,
-            v.category ASC,
-            v.total_credits DESC,
-            v.badge_name ASC
+            badge_rows.category_total_credits DESC,
+            badge_rows.category ASC,
+            badge_rows.total_credits DESC,
+            badge_rows.badge_name ASC
         ),
         '[]'::json
       )
-      FROM v_user_badges_with_category_totals v
-      WHERE v.user_id = u.id
+      FROM (
+        WITH visible_awards AS (
+          SELECT
+            ba.id,
+            ba.badge_id,
+            ba.credits,
+            ba.awarded_by_user_id,
+            ba.created_at,
+            b.name AS badge_name,
+            b.category,
+            b.color AS badge_color,
+            b.cat_image_url
+          FROM badge_awards ba
+          JOIN badges b ON b.id = ba.badge_id
+          WHERE ba.awarded_to_user_id = u.id
+            AND (
+              $2::BOOLEAN = TRUE
+              OR NOT (ba.id = ANY(COALESCE(u.hidden_award_ids, '{}'::INTEGER[])))
+            )
+        ),
+        badge_totals AS (
+          SELECT
+            badge_id,
+            badge_name,
+            category,
+            badge_color,
+            cat_image_url,
+            COALESCE(SUM(credits), 0)::INT AS total_credits,
+            COUNT(*)::INT AS award_count,
+            COUNT(DISTINCT awarded_by_user_id)::INT AS awarder_count,
+            MAX(created_at) AS last_awarded_at
+          FROM visible_awards
+          GROUP BY badge_id, badge_name, category, badge_color, cat_image_url
+        ),
+        category_totals AS (
+          SELECT
+            category,
+            COALESCE(SUM(credits), 0)::INT AS category_total_credits,
+            COUNT(*)::INT AS category_award_count,
+            COUNT(DISTINCT awarded_by_user_id)::INT AS category_awarder_count
+          FROM visible_awards
+          GROUP BY category
+        )
+        SELECT
+          bt.*,
+          ct.category_total_credits,
+          ct.category_award_count,
+          ct.category_awarder_count
+        FROM badge_totals bt
+        JOIN category_totals ct ON ct.category = bt.category
+      ) badge_rows
     ) as badges
 
   FROM users u
   WHERE u.id = $1
 `,
-      [userId],
+      [userId, Number(req.user?.id) === Number(userId)],
     );
 
     if (result.rows.length === 0) {
@@ -1574,6 +1637,87 @@ WHERE ut.user_id = $1
   }
 };
 
+const updateUserBadgeVisibility = async (req, res) => {
+  try {
+    const userId = Number(req.params.id);
+    const awardId = Number(req.params.awardId);
+    const hidden = req.body?.hidden !== false;
+
+    if (!Number.isFinite(userId) || !Number.isFinite(awardId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Valid user ID and award ID are required",
+      });
+    }
+
+    if (Number(req.user.id) !== userId) {
+      return res.status(403).json({
+        success: false,
+        message: "You can only update badge visibility on your own profile",
+      });
+    }
+
+    await ensureBadgeVisibilityColumns();
+
+    const awardResult = await pool.query(
+      `SELECT id, badge_id
+       FROM badge_awards
+       WHERE id = $1
+         AND awarded_to_user_id = $2
+       LIMIT 1`,
+      [awardId, userId],
+    );
+
+    if (awardResult.rows.length === 0) {
+      return res.status(404).json({
+        success: false,
+        message: "Badge award not found",
+      });
+    }
+
+    const result = await pool.query(
+      hidden
+        ? `UPDATE users
+           SET hidden_award_ids = (
+                 SELECT ARRAY(
+                   SELECT DISTINCT value
+                   FROM unnest(COALESCE(hidden_award_ids, '{}'::INTEGER[]) || $2::INTEGER) AS hidden_ids(value)
+                   ORDER BY value
+                 )
+               ),
+               updated_at = NOW()
+           WHERE id = $1
+           RETURNING hidden_award_ids`
+        : `UPDATE users
+           SET hidden_award_ids = array_remove(COALESCE(hidden_award_ids, '{}'::INTEGER[]), $2::INTEGER),
+               updated_at = NOW()
+           WHERE id = $1
+           RETURNING hidden_award_ids`,
+      [userId, awardId],
+    );
+
+    res.status(200).json({
+      success: true,
+      message: hidden
+        ? "Badge hidden successfully"
+        : "Badge made visible successfully",
+      data: {
+        awardId,
+        badgeId: awardResult.rows[0].badge_id,
+        hidden,
+        hiddenAwardIds: result.rows[0]?.hidden_award_ids ?? [],
+      },
+    });
+  } catch (error) {
+    console.error("Error updating badge visibility:", error);
+    res.status(500).json({
+      success: false,
+      message: "Error updating badge visibility",
+      ...(process.env.NODE_ENV === "development" && { error: error.message }),
+    });
+  }
+};
+
 /**
  * @description Get badges for a specific user
  * @route GET /api/users/:id/badges
@@ -1582,6 +1726,9 @@ WHERE ut.user_id = $1
 const getUserBadges = async (req, res) => {
   try {
     const userId = req.params.id;
+    const canViewHiddenAwards = Number(req.user?.id) === Number(userId);
+
+    await ensureBadgeVisibilityColumns();
 
     const result = await pool.query(
       `
@@ -1622,10 +1769,15 @@ const getUserBadges = async (req, res) => {
       LEFT JOIN users awarder ON ba.awarded_by_user_id = awarder.id
       LEFT JOIN teams t ON ba.team_id = t.id
       LEFT JOIN tags tag ON ba.tag_id = tag.id
+      LEFT JOIN users awardee ON awardee.id = ba.awarded_to_user_id
       WHERE ba.awarded_to_user_id = $1
+        AND (
+          $2::BOOLEAN = TRUE
+          OR NOT (ba.id = ANY(COALESCE(awardee.hidden_award_ids, '{}'::INTEGER[])))
+        )
       ORDER BY ba.created_at DESC, ba.id DESC
       `,
-      [userId],
+      [userId, canViewHiddenAwards],
     );
 
     res.status(200).json({ success: true, data: result.rows });
@@ -1648,5 +1800,6 @@ module.exports = {
   deleteAvatar,
   getUserTags,
   updateUserTags,
+  updateUserBadgeVisibility,
   getUserBadges,
 };

--- a/src/routes/badgeRoutes.js
+++ b/src/routes/badgeRoutes.js
@@ -10,6 +10,13 @@ router.get("/", badgeController.getAllBadges);
 // Award a badge to a user (requires auth)
 router.post("/award", authenticateToken, badgeController.awardBadge);
 
+// Delete one received badge award (requires auth; recipient only)
+router.delete(
+  "/awards/:awardId",
+  authenticateToken,
+  badgeController.deleteBadgeAward,
+);
+
 // Get shared teams between authenticated user and target user (requires auth)
 // Used by BadgeAwardModal to populate the team context dropdown
 router.get(

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -12,8 +12,8 @@ const router = express.Router();
 router.get("/", userController.getUsers);
 
 // GET /api/users/:id - Get a specific user by their ID
-// Access: Public (or add auth.authenticateToken if needed)
-router.get("/:id", userController.getUserById);
+// Access: Public, with optional auth for own-profile hidden award visibility
+router.get("/:id", auth.optionalAuthenticateToken, userController.getUserById);
 
 // PUT /api/users/:id - Update a specific user by their ID
 // Access: Private (Requires valid token)
@@ -52,9 +52,21 @@ router.get("/:id/tags", userController.getUserTags);
 // Access: Private (Requires valid token)
 router.put("/:id/tags", auth.authenticateToken, userController.updateUserTags);
 
+// PATCH /api/users/:id/badges/awards/:awardId/visibility - Hide/show one award on own profile
+// Access: Private (Requires valid token)
+router.patch(
+  "/:id/badges/awards/:awardId/visibility",
+  auth.authenticateToken,
+  userController.updateUserBadgeVisibility,
+);
+
 // GET /api/users/:id/badges - Get badges for a specific user
-// Access: Public
-router.get("/:id/badges", userController.getUserBadges);
+// Access: Public, with optional auth for own-profile hidden award visibility
+router.get(
+  "/:id/badges",
+  auth.optionalAuthenticateToken,
+  userController.getUserBadges,
+);
 
 // Export the router for use in app.js
 module.exports = router;


### PR DESCRIPTION
## Summary

This PR adds backend support for hiding and deleting individual badge awards from a user profile.

## Changes

- Added `DELETE /api/badges/awards/:awardId` so authenticated users can delete badge awards they received.
- Recalculates `user_tags.badge_credits` and `dominant_badge_category` after a badge award is deleted.
- Added `PATCH /api/users/:id/badges/awards/:awardId/visibility` to hide or show a specific badge award on the authenticated user’s own profile.
- Added optional auth to user profile and user badge routes so profile owners can still see their hidden awards, while public viewers only see visible awards.
- Added lazy user visibility columns:
  - `hide_badges`
  - `hidden_badge_ids`
  - `hidden_award_ids`
- Updated badge aggregation queries so hidden awards are excluded from public badge totals and badge lists.

## Testing

- Ran `git diff dev..HEAD --check`: passed.
- Ran `npm test`: 46 passed, 2 failed in existing `userController.deleteUser.test.js` stubs expecting older delete-user SQL behavior.
