### PR TITLE
Require receivers to confirm badge awards

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -58,6 +58,15 @@ const refreshBadgeViews = async (clientOrPool) => {
   }
 };
 
+const ensureBadgeVisibilityColumns = async (clientOrPool = pool) => {
+  await clientOrPool.query(
+    `ALTER TABLE users
+     ADD COLUMN IF NOT EXISTS hide_badges BOOLEAN DEFAULT FALSE,
+     ADD COLUMN IF NOT EXISTS hidden_badge_ids INTEGER[] DEFAULT '{}'::INTEGER[],
+     ADD COLUMN IF NOT EXISTS hidden_award_ids INTEGER[] DEFAULT '{}'::INTEGER[]`,
+  );
+};
+
 // ============================================================================
 // Allowed context types for badge awards
 // ============================================================================
@@ -287,6 +296,7 @@ const awardBadge = async (req, res) => {
 
     // ── Insert award (main transaction) ──
     await client.query("BEGIN");
+    await ensureBadgeVisibilityColumns(client);
 
     const insertResult = await client.query(
       `INSERT INTO badge_awards
@@ -311,6 +321,23 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW())
     if (process.env.NODE_ENV !== "production") {
       console.log("🏅 badge_awards INSERT success! ID:", insertResult.rows[0].id);
     }
+
+    // New awards start private so the receiver can confirm them before they
+    // become visible on their public profile.
+    const hiddenAwardsResult = await client.query(
+      `UPDATE users
+       SET hidden_award_ids = (
+             SELECT ARRAY(
+               SELECT DISTINCT value
+               FROM unnest(COALESCE(hidden_award_ids, '{}'::INTEGER[]) || $2::INTEGER) AS hidden_ids(value)
+               ORDER BY value
+             )
+           ),
+           updated_at = NOW()
+       WHERE id = $1
+       RETURNING hidden_award_ids`,
+      [awarded_to_user_id, insertResult.rows[0].id],
+    );
 
     // ── Non-critical: Update user_badges summary table (SAVEPOINT) ──
     try {
@@ -435,7 +462,11 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW())
     res.status(201).json({
       success: true,
       message: "Badge awarded successfully",
-      data: insertResult.rows[0],
+      data: {
+        ...insertResult.rows[0],
+        hidden: true,
+        hidden_award_ids: hiddenAwardsResult.rows[0]?.hidden_award_ids ?? [],
+      },
     });
   } catch (error) {
     await client.query("ROLLBACK");

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -184,9 +184,13 @@ const getUserById = async (req, res) => {
     u.created_at,
     u.updated_at,
     COALESCE((
-      SELECT total_badge_credits
-      FROM v_user_total_badge_credits
-      WHERE user_id = u.id
+      SELECT SUM(ba.credits)
+      FROM badge_awards ba
+      WHERE ba.awarded_to_user_id = u.id
+        AND (
+          $2::BOOLEAN = TRUE
+          OR NOT (ba.id = ANY(COALESCE(u.hidden_award_ids, '{}'::INTEGER[])))
+        )
     ), 0) AS total_badge_credits,
 
     (
@@ -1480,30 +1484,61 @@ const deletionPreview = async (req, res) => {
 /**
  * @description Get tags for a specific user
  * @route GET /api/users/:id/tags
- * @access Public
+ * @access Public, with optional auth for own-profile hidden award visibility
  */
 const getUserTags = async (req, res) => {
   try {
     const userId = req.params.id;
+    const canViewHiddenAwards = Number(req.user?.id) === Number(userId);
+
+    await ensureBadgeVisibilityColumns();
 
     const result = await pool.query(
       `
-      SELECT 
-  t.id,
-  t.name,
-  t.category,
-  t.supercategory,
-  ut.experience_level,
-  ut.interest_level,
-  ut.badge_credits,
-  ut.dominant_badge_category,
-  (SELECT COUNT(*) FROM badge_awards ba WHERE ba.tag_id = t.id AND ba.awarded_to_user_id = ut.user_id) AS linked_badge_count,
-  (SELECT COUNT(DISTINCT ba.awarded_by_user_id) FROM badge_awards ba WHERE ba.tag_id = t.id AND ba.awarded_to_user_id = ut.user_id) AS awarder_count
-FROM user_tags ut
-JOIN tags t ON ut.tag_id = t.id
-WHERE ut.user_id = $1
+      SELECT
+        t.id,
+        t.name,
+        t.category,
+        t.supercategory,
+        ut.experience_level,
+        ut.interest_level,
+        COALESCE(tag_award_stats.badge_credits, 0)::INT AS badge_credits,
+        tag_award_stats.dominant_badge_category,
+        COALESCE(tag_award_stats.linked_badge_count, 0)::INT AS linked_badge_count,
+        COALESCE(tag_award_stats.awarder_count, 0)::INT AS awarder_count
+      FROM user_tags ut
+      JOIN users u ON u.id = ut.user_id
+      JOIN tags t ON ut.tag_id = t.id
+      LEFT JOIN LATERAL (
+        SELECT
+          COALESCE(SUM(ba.credits), 0)::INT AS badge_credits,
+          COUNT(*)::INT AS linked_badge_count,
+          COUNT(DISTINCT ba.awarded_by_user_id)::INT AS awarder_count,
+          (
+            SELECT b2.category
+            FROM badge_awards ba2
+            JOIN badges b2 ON b2.id = ba2.badge_id
+            WHERE ba2.tag_id = t.id
+              AND ba2.awarded_to_user_id = ut.user_id
+              AND (
+                $2::BOOLEAN = TRUE
+                OR NOT (ba2.id = ANY(COALESCE(u.hidden_award_ids, '{}'::INTEGER[])))
+              )
+            GROUP BY b2.category
+            ORDER BY SUM(ba2.credits) DESC, b2.category ASC
+            LIMIT 1
+          ) AS dominant_badge_category
+        FROM badge_awards ba
+        WHERE ba.tag_id = t.id
+          AND ba.awarded_to_user_id = ut.user_id
+          AND (
+            $2::BOOLEAN = TRUE
+            OR NOT (ba.id = ANY(COALESCE(u.hidden_award_ids, '{}'::INTEGER[])))
+          )
+      ) tag_award_stats ON TRUE
+      WHERE ut.user_id = $1
     `,
-      [userId],
+      [userId, canViewHiddenAwards],
     );
 
     res.status(200).json({

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -45,8 +45,12 @@ router.delete(
 // router.get("/:id/teams", auth.authenticateToken, userController.getUserTeams);
 
 // GET /api/users/:id/tags - Get tags associated with a specific user
-// Access: Public (as written - add auth.authenticateToken if it should be private)
-router.get("/:id/tags", userController.getUserTags);
+// Access: Public, with optional auth for own-profile hidden award visibility
+router.get(
+  "/:id/tags",
+  auth.optionalAuthenticateToken,
+  userController.getUserTags,
+);
 
 // PUT /api/users/:id/tags - Update tags associated with a specific user
 // Access: Private (Requires valid token)


### PR DESCRIPTION
## Summary

This PR updates backend badge award visibility so newly received badge awards start hidden until the receiver confirms them.

## Changes

- Adds newly created badge award IDs to the receiver’s `hidden_award_ids` during badge awarding.
- Returns `hidden: true` and the updated `hidden_award_ids` in the badge award response.
- Updates user profile badge totals to exclude hidden awards for public viewers.
- Updates user tag badge credits, linked badge counts, awarder counts, and dominant badge category to respect hidden award visibility.
- Allows authenticated users to see their own hidden award data by adding optional auth to `GET /api/users/:id/tags`.
- Ensures badge visibility columns exist before related award/profile/tag operations run.

## Behavior

New awards are private by default. Public profile and tag data only include confirmed/visible awards, while the award receiver can still see their own hidden awards and make them visible through the existing award visibility endpoint.

## Testing

Not run; PR description only.
