### PR TITLE
Improvement of  real-time notification accuracy and chat message metadata

### DIFF
--- a/src/controllers/invitationController.js
+++ b/src/controllers/invitationController.js
@@ -1117,10 +1117,19 @@ const cancelInvitation = async (req, res) => {
 
     // Cancel the invitation
     await db.pool.query(
-      `UPDATE team_invitations 
+      `UPDATE team_invitations
        SET status = 'canceled', responded_at = NOW()
        WHERE id = $1`,
       [invitationId],
+    );
+
+    // Remove stale invitation_received notification for the invitee
+    await db.pool.query(
+      `DELETE FROM notifications
+       WHERE type = 'invitation_received'
+         AND reference_id = $1
+         AND read_at IS NULL`,
+      [parseInt(invitationId)],
     );
 
     // System message format (parseable + clickable team/user)

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -16,7 +16,7 @@ const getUnreadCount = async (req, res) => {
            COUNT(*) AS cnt,
            MAX(sent_at) AS latest
          FROM messages
-         WHERE receiver_id = $1 AND read_at IS NULL AND team_id IS NULL
+         WHERE receiver_id = $1 AND read_at IS NULL AND team_id IS NULL AND deleted_at IS NULL
          GROUP BY sender_id
        ),
        team_unread AS (
@@ -29,6 +29,7 @@ const getUnreadCount = async (req, res) => {
          JOIN team_members tm ON m.team_id = tm.team_id AND tm.user_id = $1
          WHERE m.sender_id != $1
            AND m.team_id IS NOT NULL
+           AND m.deleted_at IS NULL
            AND NOT EXISTS (
              SELECT 1
              FROM message_reads mr
@@ -45,7 +46,15 @@ const getUnreadCount = async (req, res) => {
        SELECT
          COALESCE(SUM(cnt), 0)::int AS total_count,
          (SELECT conversation_id FROM combined ORDER BY latest DESC LIMIT 1) AS first_conversation_id,
-         (SELECT type FROM combined ORDER BY latest DESC LIMIT 1) AS first_type
+         (SELECT type FROM combined ORDER BY latest DESC LIMIT 1) AS first_type,
+         (SELECT COUNT(*)::int FROM team_unread) AS team_count,
+         (SELECT COUNT(DISTINCT m.sender_id)::int
+          FROM messages m
+          WHERE (m.receiver_id = $1 AND m.read_at IS NULL AND m.team_id IS NULL AND m.deleted_at IS NULL)
+             OR (m.team_id IS NOT NULL AND m.sender_id != $1 AND m.deleted_at IS NULL
+                 AND EXISTS (SELECT 1 FROM team_members tm WHERE tm.team_id = m.team_id AND tm.user_id = $1)
+                 AND NOT EXISTS (SELECT 1 FROM message_reads mr WHERE mr.message_id = m.id AND mr.user_id = $1))
+         ) AS sender_count
        FROM combined`,
       [userId],
     );
@@ -64,7 +73,9 @@ const getUnreadCount = async (req, res) => {
       success: true,
       data: {
         count: totalUnreadCount,
-        firstUnread: firstUnread,
+        firstUnread,
+        teamCount: parseInt(unreadRow.team_count, 10) || 0,
+        senderCount: parseInt(unreadRow.sender_count, 10) || 0,
       },
     });
   } catch (error) {

--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -215,7 +215,7 @@ const getUnreadCount = async (req, res) => {
            )
            FROM notifications n2
            WHERE n2.user_id = $1 AND n2.read_at IS NULL
-           ORDER BY n2.created_at DESC
+           ORDER BY n2.created_at ASC
            LIMIT 1
          ) AS first_unread_json
        FROM notifications
@@ -243,11 +243,25 @@ const getUnreadCount = async (req, res) => {
       };
     }
 
+    const typeCountResult = await db.query(
+      `SELECT type, COUNT(*)::int AS count
+       FROM notifications
+       WHERE user_id = $1 AND read_at IS NULL
+       GROUP BY type`,
+      [userId],
+    );
+
+    const typeCounts = {};
+    for (const row of typeCountResult.rows) {
+      typeCounts[row.type] = row.count;
+    }
+
     res.status(200).json({
       success: true,
       data: {
         count: unreadCount,
         firstUnread,
+        typeCounts,
       },
     });
   } catch (error) {

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -917,6 +917,16 @@ const cancelApplication = async (req, res) => {
       applicationId,
     ]);
 
+    // Remove stale application_received notifications for this team + applicant
+    await db.pool.query(
+      `DELETE FROM notifications
+       WHERE type = 'application_received'
+         AND team_id = $1
+         AND actor_id = $2
+         AND read_at IS NULL`,
+      [application.team_id, userId],
+    );
+
     // Get team admins and owners to notify
     const adminsResult = await db.pool.query(
       `SELECT tm.user_id, u.first_name, u.last_name, u.username
@@ -1805,6 +1815,18 @@ const handleTeamApplication = async (req, res) => {
     try {
       await client.query("BEGIN");
 
+      // Remove unread application_received notifications for all admins now that the application is being handled
+      const deletedAdminNotifs = await client.query(
+        `DELETE FROM notifications
+         WHERE type = 'application_received'
+           AND team_id = $1
+           AND actor_id = $2
+           AND read_at IS NULL
+         RETURNING user_id`,
+        [application.team_id, application.applicant_id],
+      );
+      const affectedAdminIds = [...new Set(deletedAdminNotifs.rows.map((r) => r.user_id))];
+
       if (action === "approve") {
         // Check if applicant is already a member (internal role application)
         const existingMember = await client.query(
@@ -1948,6 +1970,9 @@ const handleTeamApplication = async (req, res) => {
               type: "member_joined",
               teamId: application.team_id,
             });
+            for (const adminId of affectedAdminIds) {
+              io.to(`user:${adminId}`).emit("notification:updated");
+            }
           }
         } catch (notificationError) {
           console.error(
@@ -2044,13 +2069,16 @@ const handleTeamApplication = async (req, res) => {
             actorId: userId,
           });
 
-          // Emit socket event
+          // Emit socket events
           const io = req.app.get("io");
           if (io) {
             io.to(`user:${application.applicant_id}`).emit("notification:new", {
               type: "application_rejected",
               teamId: application.team_id,
             });
+            for (const adminId of affectedAdminIds) {
+              io.to(`user:${adminId}`).emit("notification:updated");
+            }
           }
         } catch (notificationError) {
           console.error(

--- a/src/server.js
+++ b/src/server.js
@@ -169,6 +169,11 @@ io.on("connection", (socket) => {
       }
 
       const db = require("./config/database");
+      const senderResult = await db.query(
+        `SELECT username, first_name, last_name FROM users WHERE id = $1`,
+        [userId],
+      );
+      const sender = senderResult.rows[0] || {};
       let messageResult;
 
       if (type === "team") {
@@ -201,7 +206,9 @@ io.on("connection", (socket) => {
           conversationId: String(conversationId),
           teamId: parseInt(conversationId),
           senderId: userId,
-          senderUsername: socket.username,
+          senderUsername: sender.username || socket.username,
+          senderFirstName: sender.first_name,
+          senderLastName: sender.last_name,
           content: messageResult.rows[0].content,
           imageUrl: messageResult.rows[0].image_url,
           fileUrl: messageResult.rows[0].file_url,
@@ -237,7 +244,9 @@ io.on("connection", (socket) => {
           id: messageResult.rows[0].id,
           conversationId: String(conversationId),
           senderId: userId,
-          senderUsername: socket.username,
+          senderUsername: sender.username || socket.username,
+          senderFirstName: sender.first_name,
+          senderLastName: sender.last_name,
           content: messageResult.rows[0].content,
           imageUrl: messageResult.rows[0].image_url,
           fileUrl: messageResult.rows[0].file_url,


### PR DESCRIPTION
## Summary

This PR improves real-time notification accuracy and chat message metadata.

It ensures stale unread notifications are removed when invitations/applications are canceled or handled, enriches unread-count responses with more detail for frontend badges/tooltips, and adds sender first/last names to live chat socket payloads so the frontend can display proper user names in message toasts.

## Changes

- Remove stale unread `invitation_received` notifications when an invitation is canceled.
- Remove stale unread `application_received` notifications when:
  - an applicant cancels their application
  - an admin approves or rejects an application
- Emit `notification:updated` socket events to affected admins after application notifications are cleared.
- Update notification unread count behavior:
  - return the oldest unread notification as `firstUnread`
  - include unread `typeCounts` grouped by notification type
- Update message unread count behavior:
  - exclude deleted messages from unread totals
  - include `teamCount` and `senderCount` metadata
- Enrich `message:received` socket payloads with:
  - `senderFirstName`
  - `senderLastName`
  - database-backed `senderUsername` fallback

## Testing

Not run; PR description generated from `main..dev` diff analysis.
