### PR TITLE
Add mention notifications for @mentions in chat

### DIFF
--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -69,6 +69,11 @@ const getNavigationUrl = (notification) => {
       return `/profile?scrollTo=badges&highlightBadge=${encodeURIComponent(badgeName)}`;
     }
 
+    case "message_mention":
+      // Navigate to team chat if mentioned there, otherwise to DM with sender
+      if (team_id) return `/chat/${team_id}?type=team`;
+      return `/chat/${actor_id}?type=direct`;
+
     default:
       return "/teams/my-teams";
   }

--- a/src/server.js
+++ b/src/server.js
@@ -260,6 +260,66 @@ io.on("connection", (socket) => {
         io.to(`user:${userId}`).emit("message:received", message);
         io.to(`user:${conversationId}`).emit("message:received", message);
       }
+
+      // Notify mentioned users
+      if (content) {
+        const { createNotification } = require("./controllers/notificationController");
+        const MENTION_RE = /@\[([^\]]+)\]\(([^)]+)\)/g;
+        const senderName =
+          `${sender.first_name || ""} ${sender.last_name || ""}`.trim() ||
+          sender.username ||
+          "Someone";
+        let mentionMatch;
+        const notified = new Set();
+
+        // Expand @all into every participant except the sender
+        if (content.includes("@[all](all)")) {
+          let allUserIds = [];
+          if (type === "team") {
+            const allMembersResult = await db.query(
+              `SELECT user_id FROM team_members WHERE team_id = $1 AND user_id != $2`,
+              [conversationId, userId],
+            );
+            allUserIds = allMembersResult.rows.map((r) => String(r.user_id));
+          } else {
+            allUserIds = [String(conversationId)];
+          }
+          for (const uid of allUserIds) notified.add(uid);
+        }
+
+        // Collect individual mentions
+        while ((mentionMatch = MENTION_RE.exec(content)) !== null) {
+          const mentionedUserId = mentionMatch[2];
+          if (mentionedUserId === "all" || mentionedUserId === String(userId)) continue;
+          notified.add(mentionedUserId);
+        }
+
+        for (const mentionedUserId of notified) {
+          try {
+            await createNotification({
+              userId: mentionedUserId,
+              type: "message_mention",
+              title: `${senderName} mentioned you`,
+              message:
+                content.length > 100 ? `${content.slice(0, 97)}…` : content,
+              referenceType: type === "team" ? "team" : "direct",
+              referenceId: messageResult.rows[0].id,
+              teamId: type === "team" ? parseInt(conversationId) : null,
+              actorId: userId,
+            });
+            io.to(`user:${mentionedUserId}`).emit("notification:new", {
+              type: "message_mention",
+              teamId: type === "team" ? parseInt(conversationId) : null,
+              actorId: userId,
+            });
+          } catch (mentionErr) {
+            console.error(
+              `Error creating mention notification for ${mentionedUserId}:`,
+              mentionErr,
+            );
+          }
+        }
+      }
     } catch (error) {
       console.error("Error handling new message:", error);
       socket.emit("error", { message: "Error sending message" });


### PR DESCRIPTION
# Summary

This PR adds backend support for chat mention notifications.

## What changed

- Detects `@mentions` in new chat messages using the existing mention format: `@[name](userId)`.
- Creates `message_mention` notifications for mentioned users.
- Supports `@[all](all)` mentions:
  - In team chats, notifies all team members except the sender.
  - In direct chats, notifies the other participant.
- Prevents duplicate notifications when the same user is mentioned multiple times.
- Skips notifying the sender when they mention themselves.
- Emits real-time `notification:new` socket events to mentioned users.
- Adds navigation handling for `message_mention` notifications:
  - Team mentions open the team chat.
  - Direct message mentions open the DM with the sender.
