### PR TITLE
Add reply-to support for chat messages

### DIFF
--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -440,6 +440,7 @@ const getMessages = async (req, res) => {
       m.sender_id,
       m.team_id,
       m.content,
+      m.reply_to_id,
       m.image_url,
       m.file_url,
       m.file_name,
@@ -460,9 +461,16 @@ const getMessages = async (req, res) => {
       u.username as sender_username,
       u.first_name as sender_first_name,
       u.last_name as sender_last_name,
-      u.avatar_url as sender_avatar_url
+      u.avatar_url as sender_avatar_url,
+      rm.id as reply_to_message_id,
+      rm.content as reply_to_content,
+      rm.sender_id as reply_to_sender_id,
+      ru.username as reply_to_sender_username,
+      ru.first_name as reply_to_sender_first_name
     FROM messages m
     LEFT JOIN users u ON m.sender_id = u.id
+    LEFT JOIN messages rm ON m.reply_to_id = rm.id
+    LEFT JOIN users ru ON rm.sender_id = ru.id
     LEFT JOIN LATERAL (
       SELECT mr.read_at
       FROM message_reads mr
@@ -512,6 +520,7 @@ const getMessages = async (req, res) => {
       m.sender_id,
       m.receiver_id,
       m.content,
+      m.reply_to_id,
       m.image_url,
       m.file_url,
       m.file_name,
@@ -527,9 +536,16 @@ const getMessages = async (req, res) => {
       u.username as sender_username,
       u.first_name as sender_first_name,
       u.last_name as sender_last_name,
-      u.avatar_url as sender_avatar_url
+      u.avatar_url as sender_avatar_url,
+      rm.id as reply_to_message_id,
+      rm.content as reply_to_content,
+      rm.sender_id as reply_to_sender_id,
+      ru.username as reply_to_sender_username,
+      ru.first_name as reply_to_sender_first_name
     FROM messages m
     LEFT JOIN users u ON m.sender_id = u.id
+    LEFT JOIN messages rm ON m.reply_to_id = rm.id
+    LEFT JOIN users ru ON rm.sender_id = ru.id
     WHERE ((m.sender_id = $1 AND m.receiver_id = $2) 
        OR (m.sender_id = $2 AND m.receiver_id = $1))
       AND m.team_id IS NULL
@@ -552,6 +568,18 @@ const getMessages = async (req, res) => {
       receiverId: row.receiver_id,
       teamId: row.team_id,
       content: row.content,
+      replyToId: row.reply_to_id,
+      replyTo: row.reply_to_message_id
+        ? {
+            id: row.reply_to_message_id,
+            content: row.reply_to_content
+              ? row.reply_to_content.slice(0, 150)
+              : null,
+            senderId: row.reply_to_sender_id,
+            senderUsername: row.reply_to_sender_username,
+            senderFirstName: row.reply_to_sender_first_name,
+          }
+        : null,
       imageUrl: row.image_url,
       fileUrl: row.file_url,
       fileName: row.file_name,
@@ -597,7 +625,16 @@ const sendMessage = async (req, res) => {
   try {
     const userId = req.user.id;
     const conversationId = req.params.id;
-    const { content, type, imageUrl, fileUrl, fileName } = req.body;
+    const {
+      content,
+      type,
+      imageUrl,
+      fileUrl,
+      fileName,
+      replyToId: bodyReplyToId,
+      reply_to_id: bodyReplyToIdSnake,
+    } = req.body;
+    const replyToId = bodyReplyToId || bodyReplyToIdSnake || null;
 
     // Allow content OR imageUrl OR fileUrl (or combinations)
     if ((!content || content.trim() === "") && !imageUrl && !fileUrl) {
@@ -637,13 +674,14 @@ const sendMessage = async (req, res) => {
 
     if (type === "team") {
       messageResult = await db.query(
-        `INSERT INTO messages (sender_id, team_id, content, image_url, file_url, file_name, sent_at)
-     VALUES ($1, $2, $3, $4, $5, $6, NOW())
-     RETURNING id, sender_id, team_id, content, image_url, file_url, file_name, sent_at`,
+        `INSERT INTO messages (sender_id, team_id, content, reply_to_id, image_url, file_url, file_name, sent_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+     RETURNING id, sender_id, team_id, content, reply_to_id, image_url, file_url, file_name, sent_at`,
         [
           userId,
           conversationId,
           content?.trim() || null,
+          replyToId || null,
           imageUrl || null,
           fileUrl || null,
           fileName || null,
@@ -651,13 +689,14 @@ const sendMessage = async (req, res) => {
       );
     } else {
       messageResult = await db.query(
-        `INSERT INTO messages (sender_id, receiver_id, content, image_url, file_url, file_name, sent_at)
-     VALUES ($1, $2, $3, $4, $5, $6, NOW())
-     RETURNING id, sender_id, receiver_id, content, image_url, file_url, file_name, sent_at`,
+        `INSERT INTO messages (sender_id, receiver_id, content, reply_to_id, image_url, file_url, file_name, sent_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+     RETURNING id, sender_id, receiver_id, content, reply_to_id, image_url, file_url, file_name, sent_at`,
         [
           userId,
           conversationId,
           content?.trim() || null,
+          replyToId || null,
           imageUrl || null,
           fileUrl || null,
           fileName || null,
@@ -690,11 +729,19 @@ const getMessageById = async (req, res) => {
         m.receiver_id,
         m.team_id,
         m.content,
+        m.reply_to_id,
         m.sent_at,
         m.read_at,
-        u.username as sender_username
+        u.username as sender_username,
+        rm.id as reply_to_message_id,
+        rm.content as reply_to_content,
+        rm.sender_id as reply_to_sender_id,
+        ru.username as reply_to_sender_username,
+        ru.first_name as reply_to_sender_first_name
       FROM messages m
       LEFT JOIN users u ON m.sender_id = u.id
+      LEFT JOIN messages rm ON m.reply_to_id = rm.id
+      LEFT JOIN users ru ON rm.sender_id = ru.id
       WHERE m.id = $1
     `;
 
@@ -707,9 +754,24 @@ const getMessageById = async (req, res) => {
       });
     }
 
+    const row = result.rows[0];
+
     res.status(200).json({
       success: true,
-      data: result.rows[0],
+      data: {
+        ...row,
+        replyTo: row.reply_to_message_id
+          ? {
+              id: row.reply_to_message_id,
+              content: row.reply_to_content
+                ? row.reply_to_content.slice(0, 150)
+                : null,
+              senderId: row.reply_to_sender_id,
+              senderUsername: row.reply_to_sender_username,
+              senderFirstName: row.reply_to_sender_first_name,
+            }
+          : null,
+      },
     });
   } catch (error) {
     res.status(500).json({

--- a/src/database/migrations/add_reply_to_id.js
+++ b/src/database/migrations/add_reply_to_id.js
@@ -1,0 +1,19 @@
+const db = require("../../config/database");
+
+const addReplyToId = async () => {
+  try {
+    await db.query(`
+      ALTER TABLE messages
+        ADD COLUMN IF NOT EXISTS reply_to_id INTEGER REFERENCES messages(id) ON DELETE SET NULL;
+    `);
+    await db.query(`
+      CREATE INDEX IF NOT EXISTS idx_messages_reply_to_id ON messages(reply_to_id);
+    `);
+    console.log("reply_to_id column and index added (or already exist)");
+  } catch (error) {
+    console.error("Error adding reply_to_id:", error);
+    throw error;
+  }
+};
+
+module.exports = addReplyToId;

--- a/src/database/migrations/index.js
+++ b/src/database/migrations/index.js
@@ -14,6 +14,7 @@ const createTeamApplicationsTable = require("./create_team_applications");
 const fixMessagesTimestamps = require("./fix_messages_timestamps");
 const createMessageReads = require("./create_message_reads");
 const addMessageEditColumns = require("./add_message_edit_columns");
+const addReplyToId = require("./add_reply_to_id");
 
 const runMigrations = async () => {
   try {
@@ -34,6 +35,7 @@ const runMigrations = async () => {
     await fixMessagesTimestamps();
     await createMessageReads();
     await addMessageEditColumns();
+    await addReplyToId();
 
     console.log("All migrations completed successfully!");
   } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -126,6 +126,7 @@ io.on("connection", (socket) => {
         imageUrl,
         fileUrl,
         fileName,
+        replyToId,
       } = data;
 
       // Allow content OR imageUrl OR fileUrl
@@ -175,16 +176,18 @@ io.on("connection", (socket) => {
       );
       const sender = senderResult.rows[0] || {};
       let messageResult;
+      let replyTo = null;
 
       if (type === "team") {
         messageResult = await db.query(
-          `INSERT INTO messages (sender_id, team_id, content, image_url, file_url, file_name, file_size, file_expires_at, sent_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
-         RETURNING id, sender_id, team_id, content, image_url, file_url, file_name, file_size, file_expires_at, sent_at`,
+          `INSERT INTO messages (sender_id, team_id, content, reply_to_id, image_url, file_url, file_name, file_size, file_expires_at, sent_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+         RETURNING id, sender_id, team_id, content, reply_to_id, image_url, file_url, file_name, file_size, file_expires_at, sent_at`,
           [
             userId,
             conversationId,
             content?.trim() || null,
+            replyToId || null,
             imageUrl || null,
             fileUrl || null,
             fileName || null,
@@ -192,6 +195,28 @@ io.on("connection", (socket) => {
             fileExpiresAt,
           ],
         );
+
+        if (replyToId) {
+          const replyResult = await db.query(
+            `SELECT m.id, m.content, m.sender_id,
+                    u.username, u.first_name
+             FROM messages m
+             LEFT JOIN users u ON m.sender_id = u.id
+             WHERE m.id = $1`,
+            [replyToId],
+          );
+
+          if (replyResult.rows.length > 0) {
+            const r = replyResult.rows[0];
+            replyTo = {
+              id: r.id,
+              content: r.content ? r.content.slice(0, 150) : null,
+              senderId: r.sender_id,
+              senderUsername: r.username,
+              senderFirstName: r.first_name,
+            };
+          }
+        }
 
         const recipientCountResult = await db.query(
           `SELECT COUNT(*)::int as recipient_count
@@ -210,6 +235,8 @@ io.on("connection", (socket) => {
           senderFirstName: sender.first_name,
           senderLastName: sender.last_name,
           content: messageResult.rows[0].content,
+          replyToId: messageResult.rows[0].reply_to_id,
+          replyTo,
           imageUrl: messageResult.rows[0].image_url,
           fileUrl: messageResult.rows[0].file_url,
           fileName: messageResult.rows[0].file_name,
@@ -225,13 +252,14 @@ io.on("connection", (socket) => {
         io.to(`team:${conversationId}`).emit("message:received", message);
       } else {
         messageResult = await db.query(
-          `INSERT INTO messages (sender_id, receiver_id, content, image_url, file_url, file_name, file_size, file_expires_at, sent_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
-         RETURNING id, sender_id, receiver_id, content, image_url, file_url, file_name, file_size, file_expires_at, sent_at`,
+          `INSERT INTO messages (sender_id, receiver_id, content, reply_to_id, image_url, file_url, file_name, file_size, file_expires_at, sent_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+         RETURNING id, sender_id, receiver_id, content, reply_to_id, image_url, file_url, file_name, file_size, file_expires_at, sent_at`,
           [
             userId,
             conversationId,
             content?.trim() || null,
+            replyToId || null,
             imageUrl || null,
             fileUrl || null,
             fileName || null,
@@ -239,6 +267,28 @@ io.on("connection", (socket) => {
             fileExpiresAt,
           ],
         );
+
+        if (replyToId) {
+          const replyResult = await db.query(
+            `SELECT m.id, m.content, m.sender_id,
+                    u.username, u.first_name
+             FROM messages m
+             LEFT JOIN users u ON m.sender_id = u.id
+             WHERE m.id = $1`,
+            [replyToId],
+          );
+
+          if (replyResult.rows.length > 0) {
+            const r = replyResult.rows[0];
+            replyTo = {
+              id: r.id,
+              content: r.content ? r.content.slice(0, 150) : null,
+              senderId: r.sender_id,
+              senderUsername: r.username,
+              senderFirstName: r.first_name,
+            };
+          }
+        }
 
         const message = {
           id: messageResult.rows[0].id,
@@ -248,6 +298,8 @@ io.on("connection", (socket) => {
           senderFirstName: sender.first_name,
           senderLastName: sender.last_name,
           content: messageResult.rows[0].content,
+          replyToId: messageResult.rows[0].reply_to_id,
+          replyTo,
           imageUrl: messageResult.rows[0].image_url,
           fileUrl: messageResult.rows[0].file_url,
           fileName: messageResult.rows[0].file_name,


### PR DESCRIPTION
<h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em;"><strong>Reply-to messages</strong>: Users can now reply to a specific message in both team chats and DMs. Adds a <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">reply_to_id</code> FK column to the <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">messages</code> table (with <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ON DELETE SET NULL</code> and an index). All message-fetching queries (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getMessages</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getMessageById</code>) join the replied-to message and its sender, returning a <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">replyTo</code> preview object (content truncated to 150 chars, sender username and first name). The <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sendMessage</code> REST endpoint and the <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">message:send</code> socket handler both accept <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">replyToId</code> and store/emit it accordingly.</p></li><li><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em;"><strong>@mention notifications</strong>: When a message is sent via socket, the content is parsed for <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@[name](userId)</code> mentions. Each mentioned user receives a <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">message_mention</code> notification (created in the DB and pushed via <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">notification:new</code> socket event). <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@[all](all)</code> is expanded to all team members (excluding the sender) for team messages, or to the DM partner for direct messages. Navigation URLs for <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">message_mention</code> notifications route to the relevant team chat or DM.</p></li></ul><h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Files changed</h2>
File | What changed
-- | --
src/database/migrations/add_reply_to_id.js | New migration — adds reply_to_id column + index
src/database/migrations/index.js | Registers the new migration
src/controllers/messageController.js | Reply-to support in getMessages, sendMessage, getMessageById
src/controllers/notificationController.js | Navigation URL for message_mention notification type
src/server.js | Reply-to + mention notifications in the message:send socket handler

<h2 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test plan</h2><ul class="contains-task-list" style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Send a message replying to an existing message (team and DM) — verify<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">replyTo</code><span> </span>is returned in the REST response and the socket event</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Fetch message list — verify<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">replyTo</code><span> </span>is populated for messages that have a<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">reply_to_id</code></li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Delete a replied-to message — verify<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">reply_to_id</code><span> </span>becomes<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">null</code><span> </span>(ON DELETE SET NULL) and no error occurs</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Send a message with a<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@mention</code><span> </span>— verify the mentioned user receives a<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">message_mention</code><span> </span>notification instantly</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Send a message with<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@all</code><span> </span>in a team chat — verify all team members (except sender) are notified</li><li class="task-list-item"><input type="checkbox" disabled="" style="appearance: none; border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; position: relative; pointer-events: none; vertical-align: middle; border-radius: 2px; width: 1em; height: 1em; margin: 2px 4px 2px 2px;"><span> </span>Click a<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">message_mention</code><span> </span>notification — verify it navigates to the correct team chat or DM</li></ul>Summary
Reply-to messages: Users can now reply to a specific message in both team chats and DMs. Adds a reply_to_id FK column to the messages table (with ON DELETE SET NULL and an index). All message-fetching queries (getMessages, getMessageById) join the replied-to message and its sender, returning a replyTo preview object (content truncated to 150 chars, sender username and first name). The sendMessage REST endpoint and the message:send socket handler both accept replyToId and store/emit it accordingly.

@mention notifications: When a message is sent via socket, the content is parsed for @[name](userId) mentions. Each mentioned user receives a message_mention notification (created in the DB and pushed via notification:new socket event). @[all](all) is expanded to all team members (excluding the sender) for team messages, or to the DM partner for direct messages. Navigation URLs for message_mention notifications route to the relevant team chat or DM.

Files changed
File	What changed
[src/database/migrations/add_reply_to_id.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/database/migrations/add_reply_to_id.js)	New migration — adds reply_to_id column + index
[src/database/migrations/index.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/database/migrations/index.js)	Registers the new migration
[src/controllers/messageController.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/controllers/messageController.js)	Reply-to support in getMessages, sendMessage, getMessageById
[src/controllers/notificationController.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/controllers/notificationController.js)	Navigation URL for message_mention notification type
[src/server.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/server.js)	Reply-to + mention notifications in the message:send socket handler
Test plan
 Send a message replying to an existing message (team and DM) — verify replyTo is returned in the REST response and the socket event
 Fetch message list — verify replyTo is populated for messages that have a reply_to_id
 Delete a replied-to message — verify reply_to_id becomes null (ON DELETE SET NULL) and no error occurs
 Send a message with a @mention — verify the mentioned user receives a message_mention notification instantly
 Send a message with @all in a team chat — verify all team members (except sender) are notified
 Click a message_mention notification — verify it navigates to the correct team chat or DM