### PR TITLE
Notify role applicants/invitees on role changes and fix CORS for loca…

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -39,6 +39,10 @@ const isAllowedOrigin = (origin) => {
   try {
     const url = new URL(normalized);
 
+    if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+      return true;
+    }
+
     if (
       url.protocol === "https:" &&
       (url.hostname === "lomir-frontend.vercel.app" ||

--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -411,12 +411,16 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW())
     }
 
     // ── Non-critical: Create notification (SAVEPOINT) ──
+    const badgeName = badgeCheck.rows[0].name;
+    const awarderRow = (await client.query(
+      "SELECT first_name, last_name, username FROM users WHERE id = $1",
+      [req.user.id],
+    )).rows[0];
+    const awarderName = [awarderRow?.first_name, awarderRow?.last_name].filter(Boolean).join(" ") || awarderRow?.username || "Someone";
+
     let notificationCreated = false;
     try {
       await client.query("SAVEPOINT notification_sp");
-
-      const badgeName = badgeCheck.rows[0].name;
-      const awarderName = req.user.first_name || req.user.username || "Someone";
 
       await client.query(
         `INSERT INTO notifications (user_id, type, title, message, reference_type, reference_id, team_id, actor_id)
@@ -458,17 +462,23 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW())
     );
 
     // Notify recipient instantly via socket
-    if (notificationCreated) {
-      try {
-        const io = req.app.get("io");
-        if (io) {
+    try {
+      const io = req.app.get("io");
+      if (io) {
+        if (notificationCreated) {
           io.to(`user:${awarded_to_user_id}`).emit("notification:new", {
             type: "badge_awarded",
           });
         }
-      } catch (socketError) {
-        console.warn("⚠️ Socket emit failed (non-critical):", socketError.message);
+        io.to(`user:${awarded_to_user_id}`).emit("badge:awarded", {
+          badgeName,
+          badgeCategory: badgeCheck.rows[0].category || null,
+          awarderName,
+          badgeId: badge_id,
+        });
       }
+    } catch (socketError) {
+      console.warn("⚠️ Socket emit failed (non-critical):", socketError.message);
     }
 
     if (process.env.NODE_ENV !== "production") {

--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -110,6 +110,14 @@ const getNavigationUrl = (notification) => {
         ? `/chat/${team_id}?type=team${messageHighlight}`
         : `/chat/${team_id}?type=team&highlightUser=${actor_id}`;
 
+    case "role_status_changed_applicant":
+      // Applicant sees their application modal with role highlighted
+      return `/teams/my-teams?openApplication=${reference_id}`;
+
+    case "role_status_changed_invitee":
+      // Invitee sees their invitation modal with role highlighted
+      return `/teams/my-teams?openInvitation=${reference_id}`;
+
     case "badge_awarded": {
       // Navigate to own profile, scroll to badges, highlight the awarded badge
       // title format: "New Badge: Quick Learner"

--- a/src/controllers/vacantRoleController.js
+++ b/src/controllers/vacantRoleController.js
@@ -191,6 +191,145 @@ const notifyTeamMembersOfRoleEvent = async ({
 };
 
 // ============================================================
+// Helper: Notify role applicants and invitees of a role status change
+// ============================================================
+const ACTION_LABELS = {
+  role_updated: "updated",
+  role_deleted: "deleted",
+  role_closed: "closed",
+  role_filled: "filled",
+  role_reopened: "reopened",
+  role_reopened_admin: "reopened",
+};
+
+const notifyRoleApplicantsAndInvitees = async ({
+  req,
+  roleId,
+  type,
+  roleName,
+  teamId,
+  teamName,
+  actorId,
+  actorName,
+}) => {
+  if (typeof req?.app?.get !== "function") return;
+  const io = req.app.get("io");
+  if (!io) return;
+
+  const action = ACTION_LABELS[type] || "changed";
+  const applicantTitle = `The role "${roleName}" you applied for has been ${action}`;
+  const inviteeTitle = `The role "${roleName}" you were invited to has been ${action}`;
+
+  try {
+    // Pending role applications for this role
+    const applicationsResult = await db.pool.query(
+      `SELECT id, applicant_id FROM team_applications
+       WHERE role_id = $1 AND status = 'pending'`,
+      [roleId],
+    );
+
+    for (const row of applicationsResult.rows) {
+      // Remove any existing role-status notification for this application so
+      // repeated role changes don't stack up in the bell, then insert fresh.
+      let notification = null;
+      try {
+        await db.pool.query(
+          `DELETE FROM notifications
+           WHERE user_id = $1 AND type = 'role_status_changed_applicant' AND reference_id = $2`,
+          [row.applicant_id, row.id],
+        );
+        notification = await createNotification({
+          userId: row.applicant_id,
+          type: "role_status_changed_applicant",
+          title: applicantTitle,
+          message: applicantTitle,
+          referenceType: "application",
+          referenceId: row.id,
+          teamId,
+          actorId,
+        });
+      } catch (dbErr) {
+        console.error("Error replacing applicant role-status notification:", dbErr);
+      }
+
+      io.to(`user:${row.applicant_id}`).emit("notification:new", {
+        type: "role_status_changed_applicant",
+        teamId: Number(teamId),
+        referenceId: Number(row.id),
+        actorId: actorId != null ? Number(actorId) : null,
+      });
+
+      io.to(`user:${row.applicant_id}`).emit("role:statusChanged", {
+        userType: "applicant",
+        roleChangeType: type,
+        roleName,
+        teamName,
+        teamId: Number(teamId),
+        roleId: Number(roleId),
+        applicationId: Number(row.id),
+        invitationId: null,
+        actorName,
+        notificationId: notification?.id ?? null,
+      });
+    }
+
+    // Pending role invitations for this role
+    const invitationsResult = await db.pool.query(
+      `SELECT id, invitee_id FROM team_invitations
+       WHERE role_id = $1 AND status = 'pending'`,
+      [roleId],
+    );
+
+    for (const row of invitationsResult.rows) {
+      // Remove any existing role-status notification for this invitation so
+      // repeated role changes don't stack up in the bell, then insert fresh.
+      let notification = null;
+      try {
+        await db.pool.query(
+          `DELETE FROM notifications
+           WHERE user_id = $1 AND type = 'role_status_changed_invitee' AND reference_id = $2`,
+          [row.invitee_id, row.id],
+        );
+        notification = await createNotification({
+          userId: row.invitee_id,
+          type: "role_status_changed_invitee",
+          title: inviteeTitle,
+          message: inviteeTitle,
+          referenceType: "invitation",
+          referenceId: row.id,
+          teamId,
+          actorId,
+        });
+      } catch (dbErr) {
+        console.error("Error replacing invitee role-status notification:", dbErr);
+      }
+
+      io.to(`user:${row.invitee_id}`).emit("notification:new", {
+        type: "role_status_changed_invitee",
+        teamId: Number(teamId),
+        referenceId: Number(row.id),
+        actorId: actorId != null ? Number(actorId) : null,
+      });
+
+      io.to(`user:${row.invitee_id}`).emit("role:statusChanged", {
+        userType: "invitee",
+        roleChangeType: type,
+        roleName,
+        teamName,
+        teamId: Number(teamId),
+        roleId: Number(roleId),
+        applicationId: null,
+        invitationId: Number(row.id),
+        actorName,
+        notificationId: notification?.id ?? null,
+      });
+    }
+  } catch (error) {
+    console.error(`Error notifying applicants/invitees for role ${type}:`, error);
+  }
+};
+
+// ============================================================
 // Helper: Check if user is owner or admin of a team
 // ============================================================
 const checkTeamAuth = async (teamId, userId) => {
@@ -863,6 +1002,16 @@ const updateVacantRole = async (req, res) => {
           roleName,
           actorName,
         });
+        await notifyRoleApplicantsAndInvitees({
+          req,
+          roleId: updatedRole.id,
+          type: "role_updated",
+          roleName,
+          teamId,
+          teamName,
+          actorId: userId,
+          actorName,
+        });
       } catch (notificationError) {
         console.error("Error creating role_updated notification:", notificationError);
       }
@@ -955,6 +1104,16 @@ const deleteVacantRole = async (req, res) => {
       const io = req.app.get("io");
       io?.to(`team:${teamId}`).emit("notification:updated");
 
+      await notifyRoleApplicantsAndInvitees({
+        req,
+        roleId: result.rows[0].id,
+        type: "role_deleted",
+        roleName,
+        teamId,
+        teamName,
+        actorId: userId,
+        actorName,
+      });
       await notifyTeamMembersOfRoleEvent({
         req,
         teamId,
@@ -1078,6 +1237,16 @@ const updateVacantRoleStatus = async (req, res) => {
       const notificationConfig = notificationByStatus[status];
 
       if (notificationConfig) {
+        await notifyRoleApplicantsAndInvitees({
+          req,
+          roleId: updatedRole.id,
+          type: notificationConfig.type,
+          roleName,
+          teamId,
+          teamName,
+          actorId: userId,
+          actorName,
+        });
         await notifyTeamMembersOfRoleEvent({
           req,
           teamId,

--- a/src/server.js
+++ b/src/server.js
@@ -15,13 +15,23 @@ const server = http.createServer(app);
 // Set up Socket.IO with CORS
 const io = socketIo(server, {
   cors: {
-    origin: [
-      "http://localhost:5173",
-      "https://lomir-frontend.vercel.app",
-      process.env.CLIENT_URL,
-      process.env.FRONTEND_URL,
-      process.env.FRONTEND_ORIGIN,
-    ].filter(Boolean),
+    origin: (origin, callback) => {
+      if (!origin) return callback(null, true);
+      try {
+        const url = new URL(origin);
+        if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+          return callback(null, true);
+        }
+      } catch (_) {}
+      const allowed = [
+        "https://lomir-frontend.vercel.app",
+        process.env.CLIENT_URL,
+        process.env.FRONTEND_URL,
+        process.env.FRONTEND_ORIGIN,
+      ].filter(Boolean);
+      if (allowed.includes(origin)) return callback(null, true);
+      callback(new Error("Not allowed by CORS"));
+    },
     methods: ["GET", "POST"],
     credentials: true,
   },


### PR DESCRIPTION
## Summary

This PR adds backend support for role-change notifications targeted at users who have pending applications or invitations for a vacant role.

## Changes

- Notify pending role applicants when a role they applied for is updated, deleted, closed, filled, or reopened.
- Notify pending role invitees when a role they were invited to changes status.
- Emit realtime `role:statusChanged` socket events to affected applicants/invitees with role, team, application, invitation, actor, and notification metadata.
- Replace stale applicant/invitee role-status notifications for the same application/invitation so repeated role changes do not stack duplicate bell notifications.
- Add notification navigation targets:
  - applicants: `/teams/my-teams?openApplication=...`
  - invitees: `/teams/my-teams?openInvitation=...`
- Improve badge award realtime events by emitting `badge:awarded` with badge and awarder details.
- Allow localhost and `127.0.0.1` origins in Express and Socket.IO CORS handling for local frontend/backend development.

## Testing

- Ran `npm test`
- Result: 46 passing, 2 failing
- The failing tests are in `test/userController.deleteUser.test.js` and appear related to existing/stubbed user deletion SQL expectations, not the role notification changes in this branch.