### PR TITLE
Fix/reopen roles former members and different fixes and light design fine tuning

### DIFF
--- a/src/controllers/invitationController.js
+++ b/src/controllers/invitationController.js
@@ -1370,7 +1370,8 @@ const getTeamsWhereUserCanInvite = async (req, res) => {
     const { inviteeId } = req.query;
 
     let query = `
-      SELECT t.id, t.name, t.teamavatar_url, t.max_members,
+      SELECT t.id, t.name, t.teamavatar_url, t.max_members, t.city, t.country, t.is_remote,
+             tm.role as user_role,
              (SELECT COUNT(*) FROM team_members WHERE team_id = t.id) as current_members_count
     `;
 
@@ -1420,6 +1421,10 @@ const getTeamsWhereUserCanInvite = async (req, res) => {
             team.max_members === null
               ? null
               : team.max_members - parseInt(team.current_members_count),
+          city: team.city ?? null,
+          country: team.country ?? null,
+          is_remote: team.is_remote ?? false,
+          user_role: team.user_role,
         };
 
         if (inviteeId) {

--- a/src/controllers/vacantRoleController.js
+++ b/src/controllers/vacantRoleController.js
@@ -124,6 +124,7 @@ const notifyTeamMembersOfRoleEvent = async ({
   actorName = null,
   filledUserId = null,
   filledUserName = null,
+  skipChatMessage = false,
 }) => {
   if (typeof req?.app?.get !== "function") return;
 
@@ -141,7 +142,7 @@ const notifyTeamMembersOfRoleEvent = async ({
     });
     let messageRow = null;
 
-    if (eventContent) {
+    if (eventContent && !skipChatMessage) {
       const messageResult = await db.pool.query(
         `INSERT INTO messages (sender_id, team_id, content, sent_at)
          VALUES ($1, $2, $3, NOW())
@@ -1152,7 +1153,7 @@ const updateVacantRoleStatus = async (req, res) => {
   try {
     const { teamId, roleId } = req.params;
     const userId = req.user.id;
-    const { status, filled_by } = req.body;
+    const { status, filled_by, skip_chat_message: skipChatMessage } = req.body;
 
     // Authorization check
     const userRole = await checkTeamAuth(teamId, userId);
@@ -1260,6 +1261,7 @@ const updateVacantRoleStatus = async (req, res) => {
           actorName,
           filledUserId: status === "filled" ? filledUser?.id ?? null : null,
           filledUserName: status === "filled" ? filledUserName : null,
+          skipChatMessage: !!skipChatMessage,
         });
       }
     } catch (notificationError) {


### PR DESCRIPTION
Summary
This branch introduces real-time system message delivery, deep-linked notifications, a full search refactor, enriched notification payloads, and several role/invitation workflow improvements — including the fix for reopening roles for former members.

Real-Time System Message Delivery
All team events (role changes, invitations accepted/declined/cancelled, applications approved/rejected, member joins/leaves/removal, ownership transfers, team deletion) are now broadcast instantly via Socket.IO instead of being visible only on next page load
New socketMessageEmitter.js utility handles broadcasting inserted messages to the correct room (team chat or DM)
Deep-Linked Notifications
Notifications now reference the exact message that triggered them (reference_type: "message") rather than the team/invitation entity
getNavigationUrl() rewritten to construct URLs with messageHighlight and eventHighlight params so the frontend can scroll to and highlight the relevant message
Notification Payload Enrichment
All notification:new socket payloads now include title and actorName across invitation, application, member removal, and role lifecycle events
notification:updated event added so clients can refetch counts after state changes (e.g. when a member is removed or an invitation is cancelled)
Stale unread notifications are automatically cleaned up on member removal and team deletion
Role & Invitation Workflow
New DELETE /api/teams/:teamId/invitations/:invitationId/role endpoint to cancel only the role portion of a pending invitation (preserving the team invitation for external users)
getTeamsWhereUserCanInvite now returns city, country, is_remote, and user_role so the frontend can display location info and role-based UI without a second request
updateVacantRoleStatus supports a skip_chat_message body field to suppress team chat messages when reopening roles for former members
getTeamApplications now includes isInternalRoleApplication flag distinguishing existing team members applying for a role from external applicants
Search Refactor
Extracted all distance/proximity SQL into searchQueryBuilder.js (buildHaversineDistanceSQL, buildPostalCodeDistanceSQL, buildCityDistanceSQL, etc.)
Consolidated parameter parsing into parseSearchParams() and query execution into executeSearchQueries() — shared by both /api/search/global and /api/search/all
Removed three legacy search routes (/search, /search/by-tag/:tagId, /search/by-location)
Boolean query support and "Best Match" in-memory scoring with tag/badge/distance overlap
CORS & Dev Experience
Socket.IO and app.js CORS now dynamically allow any localhost/127.0.0.1 origin for local development while keeping the production allowlist unchanged
Docs
README updated to reflect new search endpoints, socket events, and notification payload shapes
New docs/team-service-boundaries.md proposing extraction order for teamController.js into dedicated services
Test plan
 Invite a user to a team for a specific role → accept/decline → verify system message appears in chat in real-time and notification navigates to that message
 Apply to join a team → approve/reject → verify chat message appears instantly and notification deep-links correctly
 Remove a team member → verify team:member_kicked socket event fires, stale notifications are cleaned up, and removed member loses access
 Cancel the role portion of an invitation → verify team invitation remains, role notification is cleaned up
 Update a vacant role status with skip_chat_message: true → verify no chat message is generated
 Call GET /api/invitations/teams → verify response includes city, country, is_remote, user_role
 Run search with proximity filter → verify distance calculations work and legacy routes return 404
 Test on localhost → verify CORS does not block Socket.IO or API calls