### PR TITLE
Fix/leave teamand role

### DIFF
--- a/scripts/fix_team_invitations_unique_constraint.sql
+++ b/scripts/fix_team_invitations_unique_constraint.sql
@@ -1,0 +1,32 @@
+-- The original unique constraint on (team_id, invitee_id) was created before
+-- role_id was added to team_invitations. It blocks the deferred-invite flow:
+-- when a user already has a general invitation in a team, inserting a
+-- role-specific invite for the same user+team fails.
+--
+-- This migration replaces it with two partial unique indexes that are
+-- role-aware and only enforce uniqueness on pending invitations (so a user
+-- can receive a new invite after a previous one was declined/accepted).
+
+BEGIN;
+
+-- Drop the old broad constraint
+ALTER TABLE team_invitations
+  DROP CONSTRAINT IF EXISTS team_invitations_team_id_invitee_id_key;
+
+-- One pending general invitation (no role) per user per team
+CREATE UNIQUE INDEX IF NOT EXISTS team_invitations_unique_general_pending
+  ON team_invitations (team_id, invitee_id)
+  WHERE role_id IS NULL AND status = 'pending';
+
+-- One pending role invitation per user per team per role
+CREATE UNIQUE INDEX IF NOT EXISTS team_invitations_unique_role_pending
+  ON team_invitations (team_id, invitee_id, role_id)
+  WHERE role_id IS NOT NULL AND status = 'pending';
+
+COMMIT;
+
+-- Verification
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'team_invitations'
+ORDER BY indexname;

--- a/src/controllers/invitationController.js
+++ b/src/controllers/invitationController.js
@@ -7,6 +7,26 @@ const { computeDistanceScore, WEIGHTS } = require("./matchingController");
 const { serializeEmbeddedVacantRole } = require("../utils/vacantRoleSerializer");
 const { emitInsertedMessage } = require("../utils/socketMessageEmitter");
 
+const buildRoleReopenedMessage = ({
+  teamId,
+  teamName,
+  roleId,
+  roleName,
+  userId,
+  userName,
+}) =>
+  `🔓 ROLE_REOPENED: ${teamId}:${teamName || "your team"} | ${roleId}:${roleName || "Vacant Role"} | ${userId}:${userName || "Someone"}`;
+
+const buildRoleInvitationFilledMessage = ({
+  teamId,
+  teamName,
+  roleId,
+  roleName,
+  userId,
+  userName,
+}) =>
+  `✅ ROLE_INVITATION_FILLED: ${teamId}:${teamName || "your team"} | ${roleId}:${roleName || "Vacant Role"} | ${userId}:${userName || "Someone"}`;
+
 /**
  * Send a team invitation to a user
  */
@@ -314,6 +334,8 @@ const getUserReceivedInvitations = async (req, res) => {
         vr.latitude as role_latitude, vr.longitude as role_longitude,
         vr.max_distance_km as role_max_distance_km,
         vr.status as role_status, vr.is_synthetic as role_is_synthetic,
+        filled_role.id as current_filled_role_id,
+        filled_role.role_name as current_filled_role_name,
         u.id as inviter_id, u.username as inviter_username,
         u.first_name as inviter_first_name, u.last_name as inviter_last_name,
         u.avatar_url as inviter_avatar_url,
@@ -324,6 +346,16 @@ const getUserReceivedInvitations = async (req, res) => {
        FROM team_invitations ti
        JOIN teams t ON ti.team_id = t.id
        LEFT JOIN team_vacant_roles vr ON ti.role_id = vr.id
+       LEFT JOIN LATERAL (
+         SELECT id, role_name
+         FROM team_vacant_roles
+         WHERE team_id = ti.team_id
+           AND filled_by = $1
+           AND status = 'filled'
+           AND (ti.role_id IS NULL OR id <> ti.role_id)
+         ORDER BY updated_at DESC
+         LIMIT 1
+       ) filled_role ON true
        JOIN users u ON ti.inviter_id = u.id
        WHERE ti.invitee_id = $1
        AND ti.status = 'pending'
@@ -469,6 +501,19 @@ const getUserReceivedInvitations = async (req, res) => {
       created_at: row.created_at,
       role_id: row.role_id === null ? null : parseInt(row.role_id),
       role_name: row.role_name,
+      current_filled_role_id:
+        row.current_filled_role_id === null || row.current_filled_role_id === undefined
+          ? null
+          : parseInt(row.current_filled_role_id),
+      current_filled_role_name: row.current_filled_role_name ?? null,
+      currentFilledRole:
+        row.current_filled_role_id == null
+          ? null
+          : {
+              id: parseInt(row.current_filled_role_id),
+              roleName: row.current_filled_role_name,
+              role_name: row.current_filled_role_name,
+            },
       role: row.role_id
         ? (() => {
             const roleTags = roleTagsByRole[row.role_id] || [];
@@ -592,6 +637,8 @@ const getTeamSentInvitations = async (req, res) => {
     vr.latitude as role_latitude, vr.longitude as role_longitude,
     vr.max_distance_km as role_max_distance_km,
     vr.status as role_status, vr.is_synthetic as role_is_synthetic,
+    filled_role.id as current_filled_role_id,
+    filled_role.role_name as current_filled_role_name,
     u.id as invitee_id, u.username, u.first_name, u.last_name,
     u.avatar_url, u.bio, u.postal_code, u.is_synthetic as invitee_is_synthetic,
     u.latitude as invitee_latitude, u.longitude as invitee_longitude,
@@ -606,6 +653,16 @@ const getTeamSentInvitations = async (req, res) => {
     ) as is_internal
    FROM team_invitations ti
    LEFT JOIN team_vacant_roles vr ON ti.role_id = vr.id
+   LEFT JOIN LATERAL (
+     SELECT id, role_name
+     FROM team_vacant_roles
+     WHERE team_id = ti.team_id
+       AND filled_by = ti.invitee_id
+       AND status = 'filled'
+       AND (ti.role_id IS NULL OR id <> ti.role_id)
+     ORDER BY updated_at DESC
+     LIMIT 1
+   ) filled_role ON true
    JOIN users u ON ti.invitee_id = u.id
    JOIN users inv ON ti.inviter_id = inv.id
    WHERE ti.team_id = $1 AND ti.status = 'pending'
@@ -763,6 +820,8 @@ const getTeamSentInvitations = async (req, res) => {
       role_is_synthetic: row.role_is_synthetic === true,
       inviter_username: row.inviter_username,
       is_internal: row.is_internal === true || row.is_internal === "true",
+      current_filled_role_id: row.current_filled_role_id ? parseInt(row.current_filled_role_id) : null,
+      current_filled_role_name: row.current_filled_role_name ?? null,
     }));
 
     res.status(200).json({
@@ -788,6 +847,8 @@ const respondToInvitation = async (req, res) => {
     const userId = req.user.id;
     const { action, response_message } = req.body;
     const fillRole = req.body.fill_role ?? req.body.fillRole ?? false;
+    const switchRoles =
+      req.body.switch_roles ?? req.body.switchRoles ?? false;
 
     if (!["accept", "decline"].includes(action)) {
       return res.status(400).json({
@@ -800,7 +861,8 @@ const respondToInvitation = async (req, res) => {
     const invitationResult = await db.pool.query(
       `SELECT ti.*, t.max_members, t.name as team_name,
           u.first_name as invitee_first_name, u.last_name as invitee_last_name, u.username as invitee_username,
-          tvr.role_name
+          tvr.role_name,
+          tvr.status as role_status
    FROM team_invitations ti
    JOIN teams t ON ti.team_id = t.id
    JOIN users u ON ti.invitee_id = u.id
@@ -825,6 +887,10 @@ const respondToInvitation = async (req, res) => {
 
       let roleFilled = false;
       let filledRoleName = null;
+      let roleSwitched = false;
+      let reopenedRole = null;
+      let reopenedRoleMessageRow = null;
+      let filledRoleMessageRow = null;
 
       if (action === "accept") {
         // Check if user is already a team member (internal role invite)
@@ -869,18 +935,84 @@ const respondToInvitation = async (req, res) => {
         );
 
         // Internal role accepts always fill the linked role; external accepts remain opt-in.
+        // A member can only fill one role at a time inside the same team.
         if (invitation.role_id && (fillRole || isInternalAccept)) {
-          const roleUpdateResult = await client.query(
-            `UPDATE team_vacant_roles
-             SET status = 'filled', filled_by = $1, updated_at = NOW()
-             WHERE id = $2 AND team_id = $3 AND status = 'open'
-             RETURNING id, role_name`,
-            [userId, invitation.role_id, invitation.team_id],
+          const existingFilledRoleResult = await client.query(
+            `SELECT id, role_name
+             FROM team_vacant_roles
+             WHERE team_id = $1
+               AND filled_by = $2
+               AND status = 'filled'
+               AND id <> $3
+             ORDER BY updated_at DESC
+             LIMIT 1`,
+            [invitation.team_id, userId, invitation.role_id],
           );
-          roleFilled = roleUpdateResult.rows.length > 0;
-          filledRoleName = roleFilled
-            ? roleUpdateResult.rows[0].role_name
-            : null;
+
+          if (existingFilledRoleResult.rows.length > 0) {
+            if (!switchRoles) {
+              await client.query("ROLLBACK");
+              return res.status(409).json({
+                success: false,
+                message: `You are already filling ${existingFilledRoleResult.rows[0].role_name} in this team. Leave that role before accepting this role offer.`,
+                data: {
+                  currentRoleId: existingFilledRoleResult.rows[0].id,
+                  currentRoleName: existingFilledRoleResult.rows[0].role_name,
+                },
+              });
+            }
+
+            if (invitation.role_status !== "open") {
+              await client.query("ROLLBACK");
+              return res.status(400).json({
+                success: false,
+                message: "This role offer is no longer available.",
+              });
+            }
+
+            reopenedRole = existingFilledRoleResult.rows[0];
+
+            await client.query(
+              `UPDATE team_vacant_roles
+               SET status = 'open',
+                   filled_by = NULL,
+                   updated_at = NOW()
+               WHERE id = $1 AND team_id = $2 AND filled_by = $3 AND status = 'filled'`,
+              [reopenedRole.id, invitation.team_id, userId],
+            );
+
+            const roleUpdateResult = await client.query(
+              `UPDATE team_vacant_roles
+               SET status = 'filled', filled_by = $1, updated_at = NOW()
+               WHERE id = $2 AND team_id = $3 AND status = 'open'
+               RETURNING id, role_name`,
+              [userId, invitation.role_id, invitation.team_id],
+            );
+
+            if (roleUpdateResult.rows.length === 0) {
+              await client.query("ROLLBACK");
+              return res.status(400).json({
+                success: false,
+                message: "This role offer is no longer available.",
+              });
+            }
+
+            roleFilled = true;
+            roleSwitched = true;
+            filledRoleName = roleUpdateResult.rows[0].role_name;
+          } else {
+            const roleUpdateResult = await client.query(
+              `UPDATE team_vacant_roles
+               SET status = 'filled', filled_by = $1, updated_at = NOW()
+               WHERE id = $2 AND team_id = $3 AND status = 'open'
+               RETURNING id, role_name`,
+              [userId, invitation.role_id, invitation.team_id],
+            );
+            roleFilled = roleUpdateResult.rows.length > 0;
+            filledRoleName = roleFilled
+              ? roleUpdateResult.rows[0].role_name
+              : null;
+          }
         }
 
         const inviteeName =
@@ -888,53 +1020,157 @@ const respondToInvitation = async (req, res) => {
             ? `${invitation.invitee_first_name} ${invitation.invitee_last_name}`
             : invitation.invitee_username;
 
-        let joinLine;
-        if (isInternalAccept && roleFilled) {
-          joinLine = `🎯 ${inviteeName} was assigned the role ${filledRoleName}!`;
-        } else if (isInternalAccept) {
-          joinLine = `🎯 ${inviteeName} accepted a role invitation!`;
-        } else if (roleFilled) {
-          joinLine = `👋 ${inviteeName} joined the team as ${filledRoleName}!`;
-        } else {
-          joinLine = `👋 ${inviteeName} joined the team!`;
-        }
-        const formattedMessage =
-          response_message && response_message.trim()
-            ? `${joinLine}\n\n"${response_message.trim()}"`
-            : joinLine;
+        let teamMessageResult = null;
 
-        const teamMessageResult = await client.query(
-          `INSERT INTO messages (sender_id, team_id, content, sent_at)
-           VALUES ($1, $2, $3, NOW())
-           RETURNING id, sender_id, team_id, content, sent_at`,
-          [userId, invitation.team_id, formattedMessage],
-        );
-        await emitInsertedMessage(req, teamMessageResult.rows[0]);
+        if (roleSwitched && reopenedRole) {
+          const reopenedMessageResult = await client.query(
+            `INSERT INTO messages (sender_id, team_id, content, sent_at)
+             VALUES ($1, $2, $3, NOW())
+             RETURNING id, sender_id, team_id, content, sent_at`,
+            [
+              userId,
+              invitation.team_id,
+              buildRoleReopenedMessage({
+                teamId: invitation.team_id,
+                teamName: invitation.team_name,
+                roleId: reopenedRole.id,
+                roleName: reopenedRole.role_name,
+                userId,
+                userName: inviteeName,
+              }),
+            ],
+          );
+          reopenedRoleMessageRow = reopenedMessageResult.rows[0];
+          await emitInsertedMessage(req, reopenedRoleMessageRow);
+
+          const filledMessageResult = await client.query(
+            `INSERT INTO messages (sender_id, team_id, content, sent_at)
+             VALUES ($1, $2, $3, NOW())
+             RETURNING id, sender_id, team_id, content, sent_at`,
+            [
+              userId,
+              invitation.team_id,
+              buildRoleInvitationFilledMessage({
+                teamId: invitation.team_id,
+                teamName: invitation.team_name,
+                roleId: invitation.role_id,
+                roleName: filledRoleName,
+                userId,
+                userName: inviteeName,
+              }),
+            ],
+          );
+          filledRoleMessageRow = filledMessageResult.rows[0];
+          await emitInsertedMessage(req, filledRoleMessageRow);
+          teamMessageResult = filledMessageResult;
+
+          if (response_message && response_message.trim()) {
+            const responseMessageResult = await client.query(
+              `INSERT INTO messages (sender_id, team_id, content, sent_at)
+               VALUES ($1, $2, $3, NOW())
+               RETURNING id, sender_id, team_id, content, sent_at`,
+              [userId, invitation.team_id, response_message.trim()],
+            );
+            await emitInsertedMessage(req, responseMessageResult.rows[0]);
+          }
+        } else {
+          let joinLine;
+          if (isInternalAccept && roleFilled) {
+            joinLine = `🎯 ${inviteeName} was assigned the role ${filledRoleName}!`;
+          } else if (isInternalAccept) {
+            joinLine = `🎯 ${inviteeName} accepted a role invitation!`;
+          } else if (roleFilled) {
+            joinLine = `👋 ${inviteeName} joined the team as ${filledRoleName}!`;
+          } else {
+            joinLine = `👋 ${inviteeName} joined the team!`;
+          }
+          const formattedMessage =
+            response_message && response_message.trim()
+              ? `${joinLine}\n\n"${response_message.trim()}"`
+              : joinLine;
+
+          teamMessageResult = await client.query(
+            `INSERT INTO messages (sender_id, team_id, content, sent_at)
+             VALUES ($1, $2, $3, NOW())
+             RETURNING id, sender_id, team_id, content, sent_at`,
+            [userId, invitation.team_id, formattedMessage],
+          );
+          await emitInsertedMessage(req, teamMessageResult.rows[0]);
+        }
 
         // === CREATE NOTIFICATIONS FOR TEAM MEMBERS ===
         try {
-          const notificationType = isInternalAccept ? "role_assigned" : "member_joined";
-          const notificationTitle = isInternalAccept
-            ? `${inviteeName} was assigned a role in ${invitation.team_name}`
-            : `${inviteeName} joined ${invitation.team_name}`;
-
-          await notifyTeamMembers({
-            teamId: invitation.team_id,
-            excludeUserId: userId,
-            type: notificationType,
-            title: notificationTitle,
-            referenceType: "message",
-            referenceId: teamMessageResult.rows[0]?.id || userId,
-            actorId: userId,
-          });
-
-          // Emit socket event to team members
           const io = req.app.get("io");
-          if (io) {
-            io.to(`team:${invitation.team_id}`).emit("notification:new", {
-              type: notificationType,
+
+          if (roleSwitched && reopenedRole) {
+            await notifyTeamMembers({
               teamId: invitation.team_id,
+              excludeUserId: userId,
+              type: "role_reopened",
+              title: `${inviteeName} left the role ${reopenedRole.role_name} in ${invitation.team_name}`,
+              message: `${reopenedRole.role_name} is open again to be filled.`,
+              referenceType: "message",
+              referenceId: reopenedRoleMessageRow?.id || reopenedRole.id,
+              actorId: userId,
             });
+
+            await notifyTeamMembers({
+              teamId: invitation.team_id,
+              excludeUserId: userId,
+              type: "role_filled",
+              title: `${inviteeName} is now filling ${filledRoleName} in ${invitation.team_name}`,
+              message: `${filledRoleName} has been filled by ${inviteeName}.`,
+              referenceType: "message",
+              referenceId:
+                filledRoleMessageRow?.id ||
+                teamMessageResult?.rows?.[0]?.id ||
+                invitation.role_id,
+              actorId: userId,
+            });
+
+            if (io) {
+              io.to(`team:${invitation.team_id}`).emit("notification:new", {
+                type: "role_reopened",
+                teamId: invitation.team_id,
+                roleId: reopenedRole.id,
+                roleName: reopenedRole.role_name,
+                actorId: userId,
+                title: `${inviteeName} left the role ${reopenedRole.role_name} in ${invitation.team_name}`,
+              });
+              io.to(`team:${invitation.team_id}`).emit("notification:new", {
+                type: "role_filled",
+                teamId: invitation.team_id,
+                roleId: invitation.role_id,
+                roleName: filledRoleName,
+                filledUserId: userId,
+                filledUserName: inviteeName,
+                actorId: userId,
+                title: `${inviteeName} is now filling ${filledRoleName} in ${invitation.team_name}`,
+              });
+            }
+          } else {
+            const notificationType = isInternalAccept ? "role_assigned" : "member_joined";
+            const notificationTitle = isInternalAccept
+              ? `${inviteeName} was assigned a role in ${invitation.team_name}`
+              : `${inviteeName} joined ${invitation.team_name}`;
+
+            await notifyTeamMembers({
+              teamId: invitation.team_id,
+              excludeUserId: userId,
+              type: notificationType,
+              title: notificationTitle,
+              referenceType: "message",
+              referenceId: teamMessageResult.rows[0]?.id || userId,
+              actorId: userId,
+            });
+
+            // Emit socket event to team members
+            if (io) {
+              io.to(`team:${invitation.team_id}`).emit("notification:new", {
+                type: notificationType,
+                teamId: invitation.team_id,
+              });
+            }
           }
 
           // Notify the inviter if the role was filled
@@ -1068,6 +1304,9 @@ const respondToInvitation = async (req, res) => {
         data: {
           roleFilled,
           filledRoleName,
+          roleSwitched,
+          reopenedRoleId: reopenedRole?.id ?? null,
+          reopenedRoleName: reopenedRole?.role_name ?? null,
         },
       });
     } catch (dbError) {

--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -22,6 +22,9 @@ const getNavigationUrl = (notification) => {
       // Invitee sees their invitation card highlighted
       return `/teams/my-teams?tab=invitations&highlight=${reference_id}`;
 
+    case "role_application_deferred_invite":
+      return `/teams/my-teams?openInvitation=${reference_id}`;
+
     case "application_received":
       // Team admin sees applications modal with applicant highlighted
       return `/teams/my-teams?team=${team_id}&openApplications=true&highlight=${actor_id}&highlightApplication=${reference_id}`;

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -82,6 +82,96 @@ const checkAndCleanupArchivedTeam = async (teamId) => {
   return false;
 };
 
+const reopenRolesFilledByMember = async (queryRunner, teamId, memberId) => {
+  const result = await queryRunner.query(
+    `UPDATE team_vacant_roles
+     SET status = 'open',
+         filled_by = NULL,
+         updated_at = NOW()
+     WHERE team_id = $1
+       AND filled_by = $2
+       AND status = 'filled'
+     RETURNING id, role_name`,
+    [teamId, memberId],
+  );
+
+  return result.rows;
+};
+
+const buildRoleReopenedLeaveMessage = ({
+  teamId,
+  teamName,
+  roleId,
+  roleName,
+  memberId,
+  memberName,
+}) =>
+  `🔓 ROLE_REOPENED: ${teamId}:${teamName || "your team"} | ${roleId}:${roleName || "Vacant Role"} | ${memberId}:${memberName || "Someone"}`;
+
+const buildRoleApplicationDeferredInviteMessage = ({
+  teamId,
+  teamName,
+  roleId,
+  roleName,
+  applicantId,
+  applicantName,
+  approverId,
+  approverName,
+  currentRoleId,
+  currentRoleName,
+}) =>
+  `📬 ROLE_APPLICATION_DEFERRED_INVITE: ${teamId}:${teamName || "your team"} | ${roleId}:${roleName || "Vacant Role"} | ${applicantId}:${applicantName || "Someone"} | ${approverId}:${approverName || "Someone"} | ${currentRoleId}:${currentRoleName || "their current role"}`;
+
+const notifyRemainingMembersOfReopenedRoles = async ({
+  req,
+  teamId,
+  teamName,
+  memberId,
+  memberName,
+  roleEvents,
+}) => {
+  if (!Array.isArray(roleEvents) || roleEvents.length === 0) return;
+
+  const io = req.app?.get?.("io");
+
+  for (const event of roleEvents) {
+    if (event.messageRow) {
+      await emitInsertedMessage(req, event.messageRow);
+    }
+
+    const membersResult = await db.pool.query(
+      `SELECT user_id
+       FROM team_members
+       WHERE team_id = $1
+         AND user_id != $2`,
+      [teamId, memberId],
+    );
+
+    for (const member of membersResult.rows) {
+      await createNotification({
+        userId: member.user_id,
+        type: "role_reopened",
+        title: `${memberName} left the role ${event.roleName || "Vacant Role"} in ${teamName}`,
+        message: `${event.roleName || "Vacant Role"} is open again to be filled.`,
+        referenceType: "message",
+        referenceId: event.messageRow?.id || event.roleId,
+        teamId: parseInt(teamId, 10),
+        actorId: parseInt(memberId, 10),
+      });
+    }
+
+    io?.to(`team:${teamId}`).emit("notification:new", {
+      type: "role_reopened",
+      teamId: parseInt(teamId, 10),
+      referenceId: event.messageRow?.id
+        ? Number(event.messageRow.id)
+        : Number(event.roleId),
+      messageId: event.messageRow?.id ? Number(event.messageRow.id) : null,
+      actorId: parseInt(memberId, 10),
+    });
+  }
+};
+
 /**
  * @description Delete team's avatar image
  * @route DELETE /api/teams/:id/avatar
@@ -1789,11 +1879,14 @@ const handleTeamApplication = async (req, res) => {
     // Get application details
     const applicationResult = await db.pool.query(
       `SELECT ta.*, t.owner_id, t.max_members, t.name as team_name, tm.role,
+          vr.role_name,
+          vr.status AS role_status,
           applicant.first_name as applicant_first_name, 
           applicant.last_name as applicant_last_name,
           applicant.username as applicant_username
    FROM team_applications ta
    JOIN teams t ON ta.team_id = t.id
+   LEFT JOIN team_vacant_roles vr ON ta.role_id = vr.id
    JOIN users applicant ON ta.applicant_id = applicant.id
    LEFT JOIN team_members tm ON t.id = tm.team_id AND tm.user_id = $1
    WHERE ta.id = $2`,
@@ -1934,6 +2027,10 @@ const handleTeamApplication = async (req, res) => {
         const applicantToken = `${application.applicant_id}:${applicantName}`;
 
         const approvalSystemMessage = `✅ APPLICATION_APPROVED: ${teamToken} | ${approverToken} | ${applicantToken} | ${hasPersonalMessage}`;
+        const approvalTitle =
+          application.role_id && application.role_name
+            ? `Your application to ${application.team_name} for ${application.role_name} was approved!`
+            : `Your application to ${application.team_name} was approved!`;
 
         let approvalMessageResult = null;
         if (!isInternalRoleApp) {
@@ -1962,7 +2059,7 @@ const handleTeamApplication = async (req, res) => {
             await createNotification({
               userId: application.applicant_id,
               type: "application_approved",
-              title: `Your application to ${application.team_name} was approved!`,
+              title: approvalTitle,
               message: response || "Welcome to the team!",
               referenceType: "message",
               referenceId: approvalMessageResult?.rows[0]?.id || parseInt(applicationId),
@@ -1990,8 +2087,11 @@ const handleTeamApplication = async (req, res) => {
               io.to(`user:${application.applicant_id}`).emit("notification:new", {
                 type: "application_approved",
                 teamId: application.team_id,
-                title: `Your application to ${application.team_name} was approved!`,
+                title: approvalTitle,
                 actorName: approverName,
+                ...(application.role_id && application.role_name
+                  ? { roleId: application.role_id, roleName: application.role_name }
+                  : {}),
               });
               io.to(`team:${application.team_id}`).emit("notification:new", {
                 type: "member_joined",
@@ -2010,23 +2110,166 @@ const handleTeamApplication = async (req, res) => {
         }
         // === END NOTIFICATION ===
 
-        // Auto-fill the associated vacant role if the application targets one
+        // Auto-fill the associated vacant role if the application targets one.
+        // If the applicant already fills another role in this team, keep the
+        // target role open and convert the approval into a role invitation.
         let roleFilled = false;
         let filledRoleName = null;
+        let roleInvitationCreated = false;
+        let roleInvitationId = null;
+        let deferredByCurrentRoleName = null;
+        let deferredInviteSocketData = null;
 
         if (application.role_id && fillRole) {
-          const roleUpdateResult = await client.query(
-            `UPDATE team_vacant_roles
-             SET status = 'filled', filled_by = $1, updated_at = NOW()
-             WHERE id = $2 AND team_id = $3 AND status = 'open'
-             RETURNING id, role_name`,
-            [application.applicant_id, application.role_id, application.team_id],
+          const existingFilledRoleResult = await client.query(
+            `SELECT id, role_name
+             FROM team_vacant_roles
+             WHERE team_id = $1
+               AND filled_by = $2
+               AND status = 'filled'
+               AND id <> $3
+             ORDER BY updated_at DESC
+             LIMIT 1`,
+            [application.team_id, application.applicant_id, application.role_id],
           );
-          roleFilled = roleUpdateResult.rows.length > 0;
-          filledRoleName = roleFilled ? roleUpdateResult.rows[0].role_name : null;
+
+          const existingFilledRole = existingFilledRoleResult.rows[0] || null;
+
+          if (existingFilledRole) {
+            deferredByCurrentRoleName = existingFilledRole.role_name;
+
+            const existingInviteResult = await client.query(
+              `SELECT id
+               FROM team_invitations
+               WHERE team_id = $1
+                 AND invitee_id = $2
+                 AND role_id = $3
+                 AND status = 'pending'
+               LIMIT 1`,
+              [application.team_id, application.applicant_id, application.role_id],
+            );
+
+            if (existingInviteResult.rows.length > 0) {
+              roleInvitationId = existingInviteResult.rows[0].id;
+            } else if (application.role_status === "open") {
+              const invitationResult = await client.query(
+                `INSERT INTO team_invitations (team_id, inviter_id, invitee_id, message, status, role_id, created_at)
+                 VALUES ($1, $2, $3, $4, 'pending', $5, NOW())
+                 RETURNING id`,
+                [
+                  application.team_id,
+                  userId,
+                  application.applicant_id,
+                  `Your application for this role has been approved while you were already filling another role. You can accept this role offer once you leave your current role:`,
+                  application.role_id,
+                ],
+              );
+              roleInvitationId = invitationResult.rows[0].id;
+            }
+
+            roleInvitationCreated = roleInvitationId != null;
+
+            if (roleInvitationCreated) {
+              const deferredMessage = buildRoleApplicationDeferredInviteMessage({
+                teamId: application.team_id,
+                teamName: application.team_name,
+                roleId: application.role_id,
+                roleName: application.role_name,
+                applicantId: application.applicant_id,
+                applicantName,
+                approverId: userId,
+                approverName,
+                currentRoleId: existingFilledRole.id,
+                currentRoleName: existingFilledRole.role_name,
+              });
+
+              const deferredMessageResult = await client.query(
+                `INSERT INTO messages (sender_id, team_id, content, sent_at)
+                 VALUES ($1, $2, $3, NOW())
+                 RETURNING id, sender_id, team_id, content, sent_at`,
+                [userId, application.team_id, deferredMessage],
+              );
+              await emitInsertedMessage(req, deferredMessageResult.rows[0]);
+
+              // Collect recipient list before notifications (still in transaction).
+              // Must be outside the try/catch so socket emit is guaranteed even
+              // if createNotification or notifyTeamMembers fails.
+              const remainingMembersResult = await client.query(
+                `SELECT user_id
+                 FROM team_members
+                 WHERE team_id = $1
+                   AND user_id != $2`,
+                [application.team_id, application.applicant_id],
+              );
+              deferredInviteSocketData = {
+                applicantId: application.applicant_id,
+                teamId: application.team_id,
+                roleId: application.role_id,
+                roleName: application.role_name,
+                teamName: application.team_name,
+                approverName,
+                memberIds: remainingMembersResult.rows.map((r) => r.user_id),
+              };
+
+              try {
+                await createNotification({
+                  userId: application.applicant_id,
+                  type: "role_application_deferred_invite",
+                  title: `Your application for ${application.role_name} in ${application.team_name} is now a role offer`,
+                  message: `You can accept this offer once you leave ${existingFilledRole.role_name}.`,
+                  referenceType: "team_invitation",
+                  referenceId: roleInvitationId,
+                  teamId: application.team_id,
+                  actorId: userId,
+                });
+
+                await notifyTeamMembers({
+                  teamId: application.team_id,
+                  excludeUserId: application.applicant_id,
+                  type: "role_application_deferred_invite",
+                  title: `${applicantName}'s application for ${application.role_name} was approved as a role offer`,
+                  message: `${applicantName} already fills ${existingFilledRole.role_name}, so the new role remains available until they accept the offer.`,
+                  referenceType: "message",
+                  referenceId: deferredMessageResult.rows[0]?.id || roleInvitationId,
+                  actorId: userId,
+                });
+              } catch (notificationError) {
+                console.error("Error creating deferred role offer notification:", notificationError);
+              }
+            }
+          } else {
+            const roleUpdateResult = await client.query(
+              `UPDATE team_vacant_roles
+               SET status = 'filled', filled_by = $1, updated_at = NOW()
+               WHERE id = $2 AND team_id = $3 AND status = 'open'
+               RETURNING id, role_name`,
+              [application.applicant_id, application.role_id, application.team_id],
+            );
+            roleFilled = roleUpdateResult.rows.length > 0;
+            filledRoleName = roleFilled ? roleUpdateResult.rows[0].role_name : null;
+          }
         }
 
         await client.query("COMMIT");
+
+        // Emit deferred invite socket events after commit to avoid race condition
+        // where the frontend fetches invitations before the DB row is visible
+        if (deferredInviteSocketData) {
+          const io = req.app.get("io");
+          if (io) {
+            io.to(`user:${deferredInviteSocketData.applicantId}`).emit("notification:new", {
+              type: "role_application_deferred_invite",
+              teamId: deferredInviteSocketData.teamId,
+              roleId: deferredInviteSocketData.roleId,
+              roleName: deferredInviteSocketData.roleName,
+              title: `Your application for ${deferredInviteSocketData.roleName} in ${deferredInviteSocketData.teamName} is now a role offer`,
+              actorName: deferredInviteSocketData.approverName,
+            });
+            for (const memberId of deferredInviteSocketData.memberIds) {
+              io.to(`user:${memberId}`).emit("notification:updated");
+            }
+          }
+        }
 
         return res.status(200).json({
           success: true,
@@ -2036,6 +2279,9 @@ const handleTeamApplication = async (req, res) => {
             status: "approved",
             roleFilled,
             filledRoleName,
+            roleInvitationCreated,
+            roleInvitationId,
+            deferredByCurrentRoleName,
           },
         });
       } else if (action === "decline") {
@@ -2790,11 +3036,20 @@ const removeTeamMember = async (req, res) => {
           ? `${m.first_name} ${m.last_name}`
           : m?.username || "A member";
 
+      const teamResult = await db.pool.query(
+        `SELECT name FROM teams WHERE id = $1`,
+        [teamId],
+      );
+      const teamName = teamResult.rows[0]?.name || "the team";
+
       // Remove membership
       await db.pool.query(
         `DELETE FROM team_members WHERE team_id = $1 AND user_id = $2`,
         [teamId, memberId],
       );
+
+      const reopenedRoles = await reopenRolesFilledByMember(db.pool, teamId, memberId);
+      const roleEvents = [];
 
       // Insert appropriate messages
       if (isSelfRemoval) {
@@ -2808,12 +3063,6 @@ const removeTeamMember = async (req, res) => {
         await emitInsertedMessage(req, leaveMessageResult.rows[0]);
       } else {
         // Get team name and remover name for proper message formatting
-        const teamResult = await db.pool.query(
-          `SELECT name FROM teams WHERE id = $1`,
-          [teamId],
-        );
-        const teamName = teamResult.rows[0]?.name || "the team";
-
         const removerInfo = await db.pool.query(
           `SELECT first_name, last_name, username FROM users WHERE id = $1`,
           [userId],
@@ -2847,6 +3096,31 @@ const removeTeamMember = async (req, res) => {
         await emitInsertedMessage(req, teamChatMessageResult.rows[0]);
       }
 
+      for (const role of reopenedRoles) {
+        const roleMessageResult = await db.pool.query(
+          `INSERT INTO messages (sender_id, team_id, content, sent_at)
+           VALUES ($1, $2, $3, NOW())
+           RETURNING id, sender_id, team_id, content, sent_at`,
+          [
+            memberId,
+            teamId,
+            buildRoleReopenedLeaveMessage({
+              teamId,
+              teamName: teamName ?? "the team",
+              roleId: role.id,
+              roleName: role.role_name,
+              memberId,
+              memberName,
+            }),
+          ],
+        );
+        roleEvents.push({
+          roleId: role.id,
+          roleName: role.role_name,
+          messageRow: roleMessageResult.rows[0],
+        });
+      }
+
       // Cleanup archived team if empty
       try {
         await checkAndCleanupArchivedTeam(parseInt(teamId));
@@ -2877,11 +3151,30 @@ const removeTeamMember = async (req, res) => {
         io.to(`user:${memberId}`).emit("notification:updated");
       }
 
+      try {
+        await notifyRemainingMembersOfReopenedRoles({
+          req,
+          teamId,
+          teamName,
+          memberId,
+          memberName,
+          roleEvents,
+        });
+      } catch (roleNotificationError) {
+        console.error("Error creating role reopened notifications:", roleNotificationError);
+      }
+
       return res.status(200).json({
         success: true,
         message: isSelfRemoval
           ? "Successfully left the archived team"
           : "Member removed successfully",
+        data: {
+          reopenedRoles: roleEvents.map((event) => ({
+            id: event.roleId,
+            role_name: event.roleName,
+          })),
+        },
       });
     }
 
@@ -2960,6 +3253,7 @@ const removeTeamMember = async (req, res) => {
     let memberName = "A member";
     let removerName = "Someone";
     let teamChatMessageRow = null;
+    let roleEvents = [];
 
     try {
       await client.query("BEGIN");
@@ -2997,6 +3291,8 @@ const removeTeamMember = async (req, res) => {
         [teamId, memberId],
       );
 
+      const reopenedRoles = await reopenRolesFilledByMember(client, teamId, memberId);
+
       // Insert ONE team-chat system message
       let teamChatMessage;
       let senderForTeamChat;
@@ -3019,6 +3315,32 @@ const removeTeamMember = async (req, res) => {
       );
       teamChatMessageRow = teamChatMessageResult.rows[0];
 
+      for (const role of reopenedRoles) {
+        const roleMessageResult = await client.query(
+          `INSERT INTO messages (sender_id, team_id, content, sent_at)
+           VALUES ($1, $2, $3, NOW())
+           RETURNING id, sender_id, team_id, content, sent_at`,
+          [
+            memberId,
+            teamId,
+            buildRoleReopenedLeaveMessage({
+              teamId,
+              teamName,
+              roleId: role.id,
+              roleName: role.role_name,
+              memberId,
+              memberName,
+            }),
+          ],
+        );
+
+        roleEvents.push({
+          roleId: role.id,
+          roleName: role.role_name,
+          messageRow: roleMessageResult.rows[0],
+        });
+      }
+
       await client.query("COMMIT");
     } catch (dbError) {
       await client.query("ROLLBACK");
@@ -3030,6 +3352,19 @@ const removeTeamMember = async (req, res) => {
     // === After commit: notifications + DM ===
     const io = req.app.get("io");
     await emitInsertedMessage(req, teamChatMessageRow);
+
+    try {
+      await notifyRemainingMembersOfReopenedRoles({
+        req,
+        teamId,
+        teamName,
+        memberId,
+        memberName,
+        roleEvents,
+      });
+    } catch (roleNotificationError) {
+      console.error("Error creating role reopened notifications:", roleNotificationError);
+    }
 
     if (isSelfRemoval) {
       try {
@@ -3113,6 +3448,12 @@ const removeTeamMember = async (req, res) => {
     return res.status(200).json({
       success: true,
       message: "Member removed successfully",
+      data: {
+        reopenedRoles: roleEvents.map((event) => ({
+          id: event.roleId,
+          role_name: event.roleName,
+        })),
+      },
     });
   } catch (error) {
     console.error("Remove team member error:", error);

--- a/src/controllers/vacantRoleController.js
+++ b/src/controllers/vacantRoleController.js
@@ -1181,6 +1181,31 @@ const updateVacantRoleStatus = async (req, res) => {
         ? filled_by
         : null;
 
+    if (status === "filled" && normalizedFilledBy) {
+      const existingFilledRole = await db.pool.query(
+        `SELECT id, role_name
+         FROM team_vacant_roles
+         WHERE team_id = $1
+           AND filled_by = $2
+           AND status = 'filled'
+           AND id <> $3
+         ORDER BY updated_at DESC
+         LIMIT 1`,
+        [teamId, normalizedFilledBy, roleId],
+      );
+
+      if (existingFilledRole.rows.length > 0) {
+        return res.status(409).json({
+          success: false,
+          message: `This member is already filling ${existingFilledRole.rows[0].role_name} in this team. A member can only fill one role at a time.`,
+          data: {
+            currentRoleId: existingFilledRole.rows[0].id,
+            currentRoleName: existingFilledRole.rows[0].role_name,
+          },
+        });
+      }
+    }
+
     const result = await db.pool.query(
       `UPDATE team_vacant_roles
        SET status = $1,


### PR DESCRIPTION
## Summary

This PR updates the backend role invitation/application flow so a team member can only fill one vacant role at a time, while still allowing approved role applications to become pending role offers instead of being lost or incorrectly auto-filled.

It also reopens filled roles when a member leaves or is removed from a team, adds the related system messages/notifications/socket events, and includes a migration script to make pending team invitations role-aware.

## Changes

- Enforce one filled role per member per team.
- Add duplicate-role checks when directly marking a vacant role as filled.
- Add `409` responses when a user tries to accept or assign a role while already filling another role.
- Support role switching during invitation acceptance via `switchRoles` / `switch_roles`.
- Reopen the previously filled role when a user switches into a newly accepted role.
- Convert approved role applications into deferred role invitations when the applicant already fills another role.
- Keep the target role open until the applicant accepts the deferred role offer.
- Include current filled role context on pending invitation payloads.
- Reopen filled vacant roles when a member leaves or is removed from active or archived teams.
- Add role-reopened system messages, notifications, and socket updates for remaining team members.
- Add notification navigation for deferred role invitations.
- Add SQL script to replace the old broad team invitation uniqueness constraint with role-aware partial unique indexes.

## Backend Details

Touched files:

- `src/controllers/invitationController.js`
- `src/controllers/teamController.js`
- `src/controllers/notificationController.js`
- `src/controllers/vacantRoleController.js`
- `scripts/fix_team_invitations_unique_constraint.sql`

The migration script drops the old `(team_id, invitee_id)` unique constraint and replaces it with:

- one pending general invitation per user/team
- one pending role invitation per user/team/role

## Deployment Note

Run `scripts/fix_team_invitations_unique_constraint.sql` before relying on the deferred role invite flow in environments that still have the old broad invitation uniqueness constraint.

## Testing

Recommended verification:

- Accept a normal team invitation.
- Accept a role invitation when the user does not fill another role.
- Try accepting a role invitation while already filling another role and confirm the `409`.
- Accept the same role invitation with `switchRoles` enabled and confirm the old role reopens.
- Approve a role application for a user who already fills another role and confirm a pending role invitation is created.
- Remove or leave a team while filling a role and confirm the role reopens.
- Confirm role-reopened and deferred-invite notifications appear and route correctly.