### PR TITLE
feat: expose city, country, state for invitees and applicants in API …

### DIFF
--- a/src/controllers/invitationController.js
+++ b/src/controllers/invitationController.js
@@ -640,7 +640,7 @@ const getTeamSentInvitations = async (req, res) => {
     filled_role.id as current_filled_role_id,
     filled_role.role_name as current_filled_role_name,
     u.id as invitee_id, u.username, u.first_name, u.last_name,
-    u.avatar_url, u.bio, u.postal_code, u.is_synthetic as invitee_is_synthetic,
+    u.avatar_url, u.bio, u.postal_code, u.city, u.country, u.state, u.is_synthetic as invitee_is_synthetic,
     u.latitude as invitee_latitude, u.longitude as invitee_longitude,
     inv.id as inviter_id,
     inv.username as inviter_username,
@@ -808,6 +808,9 @@ const getTeamSentInvitations = async (req, res) => {
         avatar_url: row.avatar_url,
         bio: row.bio,
         postal_code: row.postal_code,
+        city: row.city ?? null,
+        country: row.country ?? null,
+        state: row.state ?? null,
         is_synthetic: row.invitee_is_synthetic === true,
       },
       inviter: {

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -1851,6 +1851,9 @@ const getTeamApplications = async (req, res) => {
         bio: row.bio,
         avatar_url: row.avatar_url,
         postal_code: row.postal_code,
+        city: row.city ?? null,
+        country: row.country ?? null,
+        state: row.state ?? null,
         is_synthetic: row.applicant_is_synthetic === true,
       },
     }));


### PR DESCRIPTION
Summary
Location fields in API responses — city, country, and state are now included for invitees in getTeamSentInvitations and for applicants in getTeamApplications, supporting the frontend's updated user profile display
Deferred role invite flow — backend fixes and improvements to the deferred invite path, including a skipChatMessage option on role status updates and uniqueness constraint fixes for role invites
Location & role data in team invite lookup — getTeamsWhereUserCanInvite now returns location and user_role in its response
Notification payload overhaul — notification:new socket payloads for invitations and applications now include richer data (title, actorName); member_removed and application_approved payloads similarly enriched
Role change notifications — applicants and invitees are now notified when a role they applied/were invited to changes
Role event messages & deep-link notifications — real-time system message delivery for role-related events; notifications now include deep links
Search refactor — SQL filter builders, order builders, request parsing, and query execution core have been split into focused modules; legacy unused search routes removed
Test plan
 Invite a user to a role and confirm getTeamSentInvitations returns city, country, state on the invitee
 Apply to a team role and confirm getTeamApplications returns city, country, state on the applicant
 Trigger deferred role invite flow end-to-end; verify no duplicate invite constraint errors
 Change a role's details and confirm active applicants/invitees receive a notification
 Confirm notification:new socket events carry title and actorName for invitations, applications, approvals, and removals
 Run a search and verify results are correct and ordering is unchanged after the refactor
 Confirm legacy search routes return 404 / are gone