### PR TITLE
Increase DB connection pool size and add timeouts

### DIFF
--- a/src/config/database.js
+++ b/src/config/database.js
@@ -9,7 +9,15 @@ types.setTypeParser(1114, (str) => new Date(str + 'Z'));
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+  // Increase pool size to handle bursts of concurrent requests.
+  // Default is 10, which gets exhausted when many API calls fire at once
+  // (especially with React StrictMode double-invoking effects in development).
+  max: 20,
+  // Close idle connections after 30 s to free up DB server resources
+  idleTimeoutMillis: 30000,
+  // Fail fast if the pool is busy rather than hanging indefinitely
+  connectionTimeoutMillis: 5000,
 });
 
 module.exports = {


### PR DESCRIPTION
## Summary

This PR updates the backend database pool configuration to better handle concurrent request bursts.

## Changes

- Increases the PostgreSQL connection pool size from the default `10` to `20`
- Adds `idleTimeoutMillis: 30000` so unused DB connections are released after 30 seconds
- Adds `connectionTimeoutMillis: 5000` so requests fail fast when the pool is busy instead of hanging indefinitely

## Why

The previous default pool size could be exhausted when many API calls fired at once, especially during development with React StrictMode double-invoking effects. These settings make connection handling more resilient and prevent requests from waiting indefinitely for a database connection.

## Testing

- Not run locally; configuration-only backend change