### PR TITLE
ui/LoginFormFix

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -457,7 +457,7 @@ const authController = {
       if (!user) {
         return res.status(401).json({
           success: false,
-          message: "Invalid email or password",
+          message: "Invalid email",
         });
       }
 
@@ -484,7 +484,7 @@ const authController = {
       if (!isValidPassword) {
         return res.status(401).json({
           success: false,
-          message: "Invalid email or password",
+          message: "Invalid password",
         });
       }
 


### PR DESCRIPTION
Summary
Split the generic "Invalid email or password" response into two distinct messages: "Invalid email" when no account exists for the given email, and "Invalid password" when the account exists but the password is wrong — enabling the frontend to display each error on the correct field

Test plan
 POST /api/auth/login with an unknown email → 401 { message: "Invalid email" }
 POST /api/auth/login with a valid email and wrong password → 401 { message: "Invalid password" }
 POST /api/auth/login with correct credentials → 200 and token