### PR TITLE
Improve login error feedback with distinct messages

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -457,7 +457,7 @@ const authController = {
       if (!user) {
         return res.status(401).json({
           success: false,
-          message: "Invalid email or password",
+          message: "Invalid email",
         });
       }
 
@@ -484,7 +484,7 @@ const authController = {
       if (!isValidPassword) {
         return res.status(401).json({
           success: false,
-          message: "Invalid email or password",
+          message: "Invalid password",
         });
       }
 


### PR DESCRIPTION
**Summary**
Split the generic "Invalid email or password" error into two distinct messages: "Invalid email" and "Invalid password" in the login flow
Gives users clearer feedback about which credential is wrong, reducing frustration during login

**Changes**
[authController.js:457](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/controllers/authController.js#L457) — return "Invalid email" when no user is found for the given email
[authController.js:484](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/controllers/authController.js#L484) — return "Invalid password" when the email matches but the password check fails