### PR TITLE
feat: Add contact form endpoint and Nodemailer SMTP transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.2",
         "node-cron": "^4.2.1",
+        "nodemailer": "^8.0.10",
         "pg": "^8.14.1",
         "resend": "^6.8.0",
         "socket.io": "^4.8.1",
@@ -1713,6 +1714,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
+      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.2",
     "node-cron": "^4.2.1",
+    "nodemailer": "^8.0.10",
     "pg": "^8.14.1",
     "resend": "^6.8.0",
     "socket.io": "^4.8.1",

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -232,7 +232,7 @@ const authController = {
       );
 
       if (!emailResult.success) {
-        console.error("Failed to send verification email:", emailResult.error);
+        console.error("Failed to send verification email");
         // Still return success - user was created, they can request a new email
       }
 
@@ -412,10 +412,7 @@ const authController = {
       );
 
       if (!emailResult.success) {
-        console.error(
-          "Failed to resend verification email:",
-          emailResult.error,
-        );
+        console.error("Failed to resend verification email");
         return res.status(500).json({
           success: false,
           message: "Failed to send verification email. Please try again later.",
@@ -616,10 +613,7 @@ const authController = {
       );
 
       if (!emailResult.success) {
-        console.error(
-          "Failed to send password reset email:",
-          emailResult.error,
-        );
+        console.error("Failed to send password reset email");
       }
 
       res.status(200).json({

--- a/src/controllers/contactController.js
+++ b/src/controllers/contactController.js
@@ -62,6 +62,7 @@ const contactController = {
           email,
           topic,
           message,
+          req.files,
         );
 
         if (!emailResult.success) {

--- a/src/controllers/contactController.js
+++ b/src/controllers/contactController.js
@@ -1,0 +1,86 @@
+const Joi = require("joi");
+const emailService = require("../services/emailService");
+const { verifyTurnstileToken } = require("../utils/turnstileVerify");
+
+const contactSchema = Joi.object({
+  name: Joi.string().trim().min(1).max(120).required(),
+  email: Joi.string().trim().email().required(),
+  topic: Joi.string().trim().max(150).allow("", null),
+  message: Joi.string().trim().min(1).max(5000).required(),
+  turnstile_token: Joi.string().optional(),
+});
+
+const successResponse = {
+  success: true,
+  message: "Your message has been sent. We'll get back to you soon.",
+};
+
+const contactController = {
+  async submitContactForm(req, res) {
+    try {
+      const { error, value } = contactSchema.validate(req.body);
+
+      if (error) {
+        if (process.env.NODE_ENV !== "production") {
+          console.warn("Contact form validation error:", error.details);
+        }
+
+        return res.status(400).json({
+          success: false,
+          message: "Invalid input data",
+          errors: error.details.map((detail) => detail.message),
+        });
+      }
+
+      const { name, email, topic, message, turnstile_token } = value;
+
+      if (process.env.TURNSTILE_SECRET_KEY) {
+        if (!turnstile_token) {
+          return res.status(400).json({
+            success: false,
+            message: "CAPTCHA verification is required",
+          });
+        }
+
+        const turnstileResult = await verifyTurnstileToken(turnstile_token);
+
+        if (!turnstileResult.success) {
+          if (process.env.NODE_ENV !== "production") {
+            console.warn("Turnstile verification failed:", turnstileResult.error);
+          }
+
+          return res.status(400).json({
+            success: false,
+            message: "CAPTCHA verification failed. Please try again.",
+          });
+        }
+      }
+
+      try {
+        const emailResult = await emailService.sendContactFormEmail(
+          name,
+          email,
+          topic,
+          message,
+        );
+
+        if (!emailResult.success) {
+          console.error("Failed to send contact form email");
+        }
+      } catch (emailError) {
+        console.error("Contact form email send error:", emailError);
+      }
+
+      return res.status(200).json(successResponse);
+    } catch (error) {
+      console.error("Contact form submission error:", error);
+
+      return res.status(500).json({
+        success: false,
+        message: "Failed to submit contact form",
+      });
+    }
+  },
+};
+
+module.exports = contactController;

--- a/src/middlewares/rateLimiter.js
+++ b/src/middlewares/rateLimiter.js
@@ -28,7 +28,14 @@ const registerLimiter = createRateLimiter({
   message: "Too many registration attempts. Please try again later.",
 });
 
+const contactLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  message: "Too many messages. Please try again later.",
+});
+
 module.exports = {
   authLimiter,
   registerLimiter,
+  contactLimiter,
 };

--- a/src/routes/contactRoutes.js
+++ b/src/routes/contactRoutes.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const contactController = require("../controllers/contactController");
+const { contactLimiter } = require("../middlewares/rateLimiter");
+
+router.post("/", contactLimiter, contactController.submitContactForm);
+
+module.exports = router;

--- a/src/routes/contactRoutes.js
+++ b/src/routes/contactRoutes.js
@@ -1,8 +1,33 @@
 const express = require("express");
 const router = express.Router();
+const multer = require("multer");
 const contactController = require("../controllers/contactController");
 const { contactLimiter } = require("../middlewares/rateLimiter");
+const { FILE_LIMITS, ALLOWED_EXTENSIONS } = require("../utils/fileValidation");
 
-router.post("/", contactLimiter, contactController.submitContactForm);
+const CONTACT_ALLOWED_EXTENSIONS = new Set([
+  ...ALLOWED_EXTENSIONS.chatImage,
+  ...ALLOWED_EXTENSIONS.chatFile,
+]);
+
+const contactUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: FILE_LIMITS.chatFile },
+  fileFilter: (req, file, cb) => {
+    const ext = "." + file.originalname.split(".").pop().toLowerCase();
+    if (CONTACT_ALLOWED_EXTENSIONS.has(ext)) {
+      cb(null, true);
+    } else {
+      cb(new Error("File type not supported."), false);
+    }
+  },
+});
+
+router.post(
+  "/",
+  contactLimiter,
+  contactUpload.array("attachments", 5),
+  contactController.submitContactForm,
+);
 
 module.exports = router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,6 +8,7 @@ const messageRoutes = require('./messageRoutes');
 const notificationRoutes = require('./notificationRoutes');
 const matchingRoutes = require('./matchingRoutes'); 
 const imagekitRoutes = require("./imagekitRoutes");
+const contactRoutes = require("./contactRoutes");
 
 const tagRoutes = require("./api/tags");
 const geocodingRoutes = require("./geocodingRoutes");
@@ -23,6 +24,7 @@ router.use('/messages', messageRoutes);
 router.use('/notifications', notificationRoutes);
 router.use('/matching', matchingRoutes); 
 router.use("/imagekit", imagekitRoutes);
+router.use("/contact", contactRoutes);
 router.use('/tags', tagRoutes);
 router.use('/geocoding', geocodingRoutes);
 

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -1,9 +1,65 @@
 const { Resend } = require("resend");
+const nodemailer = require("nodemailer");
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+const useSmtp = Boolean(
+  process.env.SMTP_HOST && process.env.SMTP_USER && process.env.SMTP_PASS,
+);
+const smtpTransporter = useSmtp
+  ? nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT || "587", 10),
+      secure: false, // STARTTLS
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    })
+  : null;
 
 // Use test email for development, our domain for production later
 const FROM_EMAIL = "onboarding@resend.dev";
+const SMTP_FROM = `Lomir <${process.env.SMTP_USER}>`;
+const getResendClient = () => new Resend(process.env.RESEND_API_KEY);
+
+const sendEmail = async ({ to, subject, html, replyTo }) => {
+  if (useSmtp) {
+    const info = await smtpTransporter.sendMail({
+      from: SMTP_FROM,
+      to,
+      subject,
+      html,
+      replyTo,
+    });
+
+    return { success: true, messageId: info?.messageId };
+  }
+
+  const { data, error } = await getResendClient().emails.send({
+    from: `Lomir <${FROM_EMAIL}>`,
+    to,
+    subject,
+    html,
+  });
+
+  if (error) {
+    console.error("Resend error:", error);
+    return { success: false };
+  }
+
+  return { success: true, messageId: data?.id };
+};
+
+const escapeHtml = (value = "") =>
+  String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const formatMessage = (value) => escapeHtml(value).replace(/\n/g, "<br/>");
+
+const cleanHeaderValue = (value = "") => String(value).replace(/[\r\n]+/g, " ");
 
 const emailService = {
   /**
@@ -13,8 +69,7 @@ const emailService = {
     const verificationUrl = `${process.env.FRONTEND_URL}/verify-email?token=${token}`;
 
     try {
-      const { data, error } = await resend.emails.send({
-        from: `Lomir <${FROM_EMAIL}>`,
+      const emailResult = await sendEmail({
         to: email,
         subject: "Verify your Lomir account",
         html: `
@@ -49,18 +104,17 @@ const emailService = {
         `,
       });
 
-      if (error) {
-        console.error("Resend error:", error);
-        return { success: false, error: error.message };
+      if (!emailResult.success) {
+        return emailResult;
       }
 
       if (process.env.NODE_ENV !== "production") {
-        console.log("Verification email sent:", data?.id);
+        console.log("Verification email sent:", emailResult.messageId);
       }
-      return { success: true, messageId: data?.id };
+      return { success: true, messageId: emailResult.messageId };
     } catch (error) {
       console.error("Email send error:", error);
-      return { success: false, error: error.message };
+      return { success: false };
     }
   },
 
@@ -71,8 +125,7 @@ const emailService = {
     const resetUrl = `${process.env.FRONTEND_URL}/reset-password?token=${token}`;
 
     try {
-      const { data, error } = await resend.emails.send({
-        from: `Lomir <${FROM_EMAIL}>`,
+      const emailResult = await sendEmail({
         to: email,
         subject: "Reset your Lomir password",
         html: `
@@ -108,18 +161,87 @@ const emailService = {
         `,
       });
 
-      if (error) {
-        console.error("Resend error:", error);
-        return { success: false, error: error.message };
+      if (!emailResult.success) {
+        return emailResult;
       }
 
       if (process.env.NODE_ENV !== "production") {
-        console.log("Password reset email sent:", data?.id);
+        console.log("Password reset email sent:", emailResult.messageId);
       }
-      return { success: true, messageId: data?.id };
+      return { success: true, messageId: emailResult.messageId };
     } catch (error) {
       console.error("Email send error:", error);
-      return { success: false, error: error.message };
+      return { success: false };
+    }
+  },
+
+  /**
+   * Send contact form submission to Lomir inbox
+   */
+  async sendContactFormEmail(name, email, topic, message) {
+    const safeName = escapeHtml(name);
+    const safeEmail = escapeHtml(email);
+    const safeTopic = escapeHtml(topic || "General inquiry");
+    const safeMessage = formatMessage(message);
+    const subjectTopic = cleanHeaderValue(topic || "General inquiry");
+
+    try {
+      if (!smtpTransporter) {
+        throw new Error("SMTP transport is not configured");
+      }
+
+      const info = await smtpTransporter.sendMail({
+        from: SMTP_FROM,
+        to: process.env.SMTP_USER,
+        replyTo: {
+          name: cleanHeaderValue(name),
+          address: email,
+        },
+        subject: `New Lomir contact form message: ${subjectTopic}`,
+        html: `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <h2 style="color: #6366f1; margin-bottom: 24px;">New Contact Form Message</h2>
+
+            <p style="font-size: 16px; color: #333; line-height: 1.6;">
+              A visitor sent a message through the Lomir contact form.
+            </p>
+
+            <div style="background-color: #f8fafc; border: 1px solid #e5e7eb; border-radius: 8px; padding: 20px; margin: 24px 0;">
+              <p style="font-size: 14px; color: #333; line-height: 1.6; margin: 0 0 12px;">
+                <strong>Name:</strong> ${safeName}
+              </p>
+              <p style="font-size: 14px; color: #333; line-height: 1.6; margin: 0 0 12px;">
+                <strong>Email:</strong> <a href="mailto:${safeEmail}" style="color: #6366f1;">${safeEmail}</a>
+              </p>
+              <p style="font-size: 14px; color: #333; line-height: 1.6; margin: 0;">
+                <strong>Topic:</strong> ${safeTopic}
+              </p>
+            </div>
+
+            <div style="margin: 24px 0;">
+              <h3 style="color: #333; font-size: 18px; margin-bottom: 12px;">Message</h3>
+              <p style="font-size: 16px; color: #333; line-height: 1.6; margin: 0;">
+                ${safeMessage}
+              </p>
+            </div>
+
+            <hr style="border: none; border-top: 1px solid #eee; margin: 32px 0;" />
+
+            <p style="font-size: 12px; color: #999;">
+              Reply directly to this email to respond to ${safeName}.
+            </p>
+          </div>
+        `,
+      });
+
+      if (process.env.NODE_ENV !== "production") {
+        console.log("Contact form email sent:", info?.messageId);
+      }
+
+      return { success: true, messageId: info?.messageId };
+    } catch (error) {
+      console.error("Contact form email send error:", error);
+      return { success: false };
     }
   },
 };

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -178,7 +178,7 @@ const emailService = {
   /**
    * Send contact form submission to Lomir inbox
    */
-  async sendContactFormEmail(name, email, topic, message) {
+  async sendContactFormEmail(name, email, topic, message, attachments) {
     const safeName = escapeHtml(name);
     const safeEmail = escapeHtml(email);
     const safeTopic = escapeHtml(topic || "General inquiry");
@@ -190,7 +190,7 @@ const emailService = {
         throw new Error("SMTP transport is not configured");
       }
 
-      const info = await smtpTransporter.sendMail({
+      const mailOptions = {
         from: SMTP_FROM,
         to: process.env.SMTP_USER,
         replyTo: {
@@ -232,7 +232,17 @@ const emailService = {
             </p>
           </div>
         `,
-      });
+      };
+
+      if (attachments?.length) {
+        mailOptions.attachments = attachments.map((file) => ({
+          filename: file.originalname,
+          content: file.buffer,
+          contentType: file.mimetype,
+        }));
+      }
+
+      const info = await smtpTransporter.sendMail(mailOptions);
 
       if (process.env.NODE_ENV !== "production") {
         console.log("Contact form email sent:", info?.messageId);


### PR DESCRIPTION
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Adds a public <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">POST /api/contact</code> endpoint for contact form submissions and introduces Nodemailer as an SMTP email transport alongside the existing Resend integration. When <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SMTP_HOST</code> is set, all email functions (verification, password reset, contact form) send via Gmail SMTP. When it's not set, verification and password reset fall back to Resend. This enables self-service password resets and email verification without a custom domain.</p>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">Changes</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>New files</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/controllers/contactController.js</code> — Validates form input with Joi (name, email, message required), verifies Turnstile token when <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">TURNSTILE_SECRET_KEY</code> is set, calls <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">emailService.sendContactFormEmail()</code>, returns 200 even if email delivery fails (error logged server-side)</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/routes/contactRoutes.js</code> — Mounts <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">POST /</code> with <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">contactLimiter</code> middleware</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Modified files</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/routes/index.js</code> — Registers contact routes at <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">/contact</code> (endpoint: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">POST /api/contact</code>)</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/middlewares/rateLimiter.js</code> — Added <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">contactLimiter</code> (5 requests per IP per hour)</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/services/emailService.js</code>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2">Added Nodemailer SMTP transport, activated when <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SMTP_HOST</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SMTP_USER</code>, and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SMTP_PASS</code> are set</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Unified <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">sendEmail()</code> helper that routes through SMTP or Resend based on env config</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">sendVerificationEmail</code> and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">sendPasswordResetEmail</code> now use SMTP when available, Resend as fallback</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Added <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">sendContactFormEmail()</code> — sends form data to <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SMTP_USER</code> (Lomir Gmail inbox) with visitor's email as <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Reply-To</code></li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">HTML sanitization via <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">escapeHtml()</code> and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">formatMessage()</code> helpers</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Header injection protection via <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">cleanHeaderValue()</code></li>
</ul>
</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/controllers/authController.js</code> — Updated email failure handling to match standardized <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">{ success: false }</code> return format</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">package.json</code> — Added <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">nodemailer</code> dependency</li>
</ul>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">Environment variables</h3>
<div class="overflow-x-auto w-full px-2 mb-6">
Variable | Value | Where
-- | -- | --
SMTP_HOST | smtp.gmail.com | .env, Render
SMTP_PORT | 587 | .env, Render
SMTP_USER | applomir@gmail.com | .env, Render
SMTP_PASS | Gmail App Password | .env, Render

</div>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">Benefits</h3>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2">Contact form submissions arrive in the Lomir Gmail inbox with Reply-To set for direct responses</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Password resets and email verification now work for real users (no longer blocked by Resend's free tier sandbox restriction)</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Rate limiting and Turnstile CAPTCHA protect the public endpoint from abuse</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">SMTP/Resend dual transport is non-breaking — removing SMTP vars reverts to Resend automatically</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Same <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">emailService</code> function signatures throughout — no changes needed in calling code when switching transports</li></ul>