### PR TITLE
feat: Switch email transport to Nodemailer SMTP, retire Resend fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Contact the project owner for a demo login, or register a new account with a val
 
 ## Features
 
-- **Authentication** — JWT-based registration, login, email verification, and password reset. Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev).
+- **Authentication** — JWT-based registration, login, email verification, and password reset. Transactional auth emails are sent through Nodemailer SMTP. Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev).
 - **User Profiles** — CRUD with avatar uploads (ImageKit), interest tags, and badge portfolios
 - **Teams** — Create, join, manage members, assign roles, and archive teams
 - **Vacant Roles** — Post open positions on teams with desired tags, badges, and location preferences
@@ -52,7 +52,7 @@ Contact the project owner for a demo login, or register a new account with a val
 | Auth | JSON Web Tokens (jsonwebtoken, bcrypt) |
 | Validation | Joi |
 | File Uploads | ImageKit + Multer |
-| Email | Resend |
+| Email | Nodemailer SMTP |
 | Scheduling | node-cron |
 | CAPTCHA | Cloudflare Turnstile |
 | Rate Limiting | express-rate-limit |
@@ -104,14 +104,18 @@ IMAGEKIT_PUBLIC_KEY=<your-public-key>
 IMAGEKIT_PRIVATE_KEY=<your-private-key>
 IMAGEKIT_URL_ENDPOINT=https://ik.imagekit.io/<your-id>
 
-# Resend (email service)
-RESEND_API_KEY=<resend-api-key>
+# SMTP email (Gmail SMTP in the current deployment)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=<smtp-email-address>
+SMTP_PASS=<smtp-app-password>
 
 # Frontend URL (for CORS and email links)
 CLIENT_URL=http://localhost:5173
+FRONTEND_URL=http://localhost:5173
 
-# Skip email verification (set to "true" while no custom domain is configured)
-SKIP_EMAIL_VERIFICATION=true
+# Skip email verification for local development if needed
+SKIP_EMAIL_VERIFICATION=false
 
 # Cloudflare Turnstile (optional for local dev — if unset, CAPTCHA is skipped)
 # TURNSTILE_SECRET_KEY=<turnstile-secret-key>
@@ -197,7 +201,7 @@ Lomir-backend/
 │   │   ├── rateLimiter.js      # Rate limiting for auth endpoints
 │   │   └── uploadMiddleware.js # Multer wrapper for file/image uploads
 │   ├── services/
-│   │   └── emailService.js     # Resend transactional email
+│   │   └── emailService.js     # Nodemailer SMTP transactional email; Resend restore notes kept in comments
 │   ├── utils/
 │   │   ├── booleanSearchParser.js
 │   │   ├── imagekitUtils.js
@@ -348,6 +352,7 @@ Full transactional account deletion following the spec in `docs/USER_DELETION_SP
 - **`npm install` fails on bcrypt** — Install native build tools (see Prerequisites), then `rm -rf node_modules package-lock.json && npm install`
 - **CORS errors** — Make sure `CLIENT_URL` in `.env` matches your frontend origin (`http://localhost:5173`)
 - **Database connection issues** — Verify `DATABASE_URL` is correct and you have internet access
+- **SMTP transport is not configured** — Set `SMTP_HOST`, `SMTP_USER`, and `SMTP_PASS`; `SMTP_PORT` defaults to `587`
 - **Port already in use** — `lsof -i :5001` to find the process, `kill -9 <PID>` to free the port
 - **CAPTCHA not loading locally** — This is expected. If `TURNSTILE_SECRET_KEY` is unset, registration skips CAPTCHA.
 
@@ -357,3 +362,4 @@ Full transactional account deletion following the spec in `docs/USER_DELETION_SP
 
 - **Frontend repo:** [Lomir-frontend](https://github.com/KasparSinitsin/Lomir-frontend)
 - **Deletion spec:** [`docs/USER_DELETION_SPEC.md`](docs/USER_DELETION_SPEC.md)
+- **Email verification restore guide:** [`docs/RESTORE_EMAIL_VERIFICATION_GUIDE.md`](docs/RESTORE_EMAIL_VERIFICATION_GUIDE.md)

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -1,4 +1,5 @@
-const { Resend } = require("resend");
+// Resend transport — commented out, restore when custom domain is verified (see docs/RESTORE_EMAIL_VERIFICATION_GUIDE.md)
+// const { Resend } = require("resend");
 const nodemailer = require("nodemailer");
 
 const useSmtp = Boolean(
@@ -16,37 +17,41 @@ const smtpTransporter = useSmtp
     })
   : null;
 
-// Use test email for development, our domain for production later
-const FROM_EMAIL = "onboarding@resend.dev";
+// const FROM_EMAIL = "onboarding@resend.dev";
 const SMTP_FROM = `Lomir <${process.env.SMTP_USER}>`;
-const getResendClient = () => new Resend(process.env.RESEND_API_KEY);
+// const getResendClient = () => new Resend(process.env.RESEND_API_KEY);
 
 const sendEmail = async ({ to, subject, html, replyTo }) => {
-  if (useSmtp) {
-    const info = await smtpTransporter.sendMail({
-      from: SMTP_FROM,
-      to,
-      subject,
-      html,
-      replyTo,
-    });
-
-    return { success: true, messageId: info?.messageId };
+  if (!smtpTransporter) {
+    throw new Error(
+      "SMTP transport is not configured. Set SMTP_HOST, SMTP_USER, and SMTP_PASS environment variables.",
+    );
   }
 
-  const { data, error } = await getResendClient().emails.send({
-    from: `Lomir <${FROM_EMAIL}>`,
+  const info = await smtpTransporter.sendMail({
+    from: SMTP_FROM,
     to,
     subject,
     html,
+    replyTo,
   });
 
-  if (error) {
-    console.error("Resend error:", error);
-    return { success: false };
-  }
+  return { success: true, messageId: info?.messageId };
 
-  return { success: true, messageId: data?.id };
+  // Resend fallback — preserve for future restoration when a custom domain is verified.
+  // const { data, error } = await getResendClient().emails.send({
+  //   from: `Lomir <${FROM_EMAIL}>`,
+  //   to,
+  //   subject,
+  //   html,
+  // });
+  //
+  // if (error) {
+  //   console.error("Resend error:", error);
+  //   return { success: false };
+  // }
+  //
+  // return { success: true, messageId: data?.id };
 };
 
 const escapeHtml = (value = "") =>


### PR DESCRIPTION
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Makes Nodemailer with Gmail SMTP the sole active email transport for all transactional emails (password reset, email verification, contact form). The previous Resend SDK code is preserved as comments for future restoration when a custom domain is purchased. Missing SMTP configuration now throws a clear error instead of silently falling back to Resend.</p>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">Changes</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">src/services/emailService.js</code></strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2">Commented out Resend import, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">FROM_EMAIL</code> constant, and <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">getResendClient()</code> factory (preserved for future use with a custom domain — see <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">docs/RESTORE_EMAIL_VERIFICATION_GUIDE.md</code>)</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Updated <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">sendEmail()</code> to use only the Nodemailer SMTP transport</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Added explicit error if <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SMTP_HOST</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SMTP_USER</code>, or <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SMTP_PASS</code> environment variables are missing</li>
</ul>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">Environment variables (already deployed)</h3>
<div class="overflow-x-auto w-full px-2 mb-6">
Variable | Value | Location
-- | -- | --
SMTP_HOST | smtp.gmail.com | Render
SMTP_PORT | 587 | Render
SMTP_USER | applomir@gmail.com | Render
SMTP_PASS | Gmail App Password | Render

</div>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">Benefits</h3>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2">Password resets now work for all users, not just the Resend account holder</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Email verification is transport-ready (still behind <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SKIP_EMAIL_VERIFICATION</code> flag, activatable without code changes)</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2">Clear failure mode when SMTP is misconfigured — no silent fallback to a broken Resend sandbox</li></ul>