### PR TITLE
Restore email verification enforcement for registration and login

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -179,38 +179,39 @@ const authController = {
         );
       }
 
-      // ── INTERIM: skip email verification when flag is set ──
-      if (process.env.SKIP_EMAIL_VERIFICATION === "true") {
-        await db.query(`UPDATE users SET email_verified = TRUE WHERE id = $1`, [
-          user.id,
-        ]);
-
-        const token = generateToken(user);
-
-        return res.status(201).json({
-          success: true,
-          message: "Registration successful!",
-          data: {
-            token,
-            user: {
-              id: user.id,
-              username: user.username,
-              email: user.email,
-              first_name: user.first_name,
-              last_name: user.last_name,
-              bio: user.bio,
-              postal_code: user.postal_code,
-              city: user.city,
-              country: user.country,
-              avatar_url: user.avatar_url,
-              is_public: user.is_public,
-              is_synthetic: user.is_synthetic,
-              created_at: user.created_at,
-            },
-          },
-        });
-      }
-      // ── END INTERIM ──
+      // ── INTERIM BYPASS (disabled — email verification now active via Nodemailer/Gmail SMTP) ──
+      // Restore this block if email delivery becomes unavailable and registration needs to work without verification.
+      // if (process.env.SKIP_EMAIL_VERIFICATION === "true") {
+      //   await db.query(`UPDATE users SET email_verified = TRUE WHERE id = $1`, [
+      //     user.id,
+      //   ]);
+      //
+      //   const token = generateToken(user);
+      //
+      //   return res.status(201).json({
+      //     success: true,
+      //     message: "Registration successful!",
+      //     data: {
+      //       token,
+      //       user: {
+      //         id: user.id,
+      //         username: user.username,
+      //         email: user.email,
+      //         first_name: user.first_name,
+      //         last_name: user.last_name,
+      //         bio: user.bio,
+      //         postal_code: user.postal_code,
+      //         city: user.city,
+      //         country: user.country,
+      //         avatar_url: user.avatar_url,
+      //         is_public: user.is_public,
+      //         is_synthetic: user.is_synthetic,
+      //         created_at: user.created_at,
+      //       },
+      //     },
+      //   });
+      // }
+      // ── END INTERIM BYPASS ──
 
       // Generate verification token
       const verificationToken = crypto.randomBytes(32).toString("hex");
@@ -458,14 +459,9 @@ const authController = {
         });
       }
 
-      // // Check if email is verified
-      // if (!user.email_verified) {
-
-      // Check if email is verified (skip when verification is disabled)
-      if (
-        !user.email_verified &&
-        process.env.SKIP_EMAIL_VERIFICATION !== "true"
-      ) {
+      // Original — enforce email verification for all users
+      if (!user.email_verified) {
+        // ── INTERIM (disabled): if (!user.email_verified && process.env.SKIP_EMAIL_VERIFICATION !== "true") {
         return res.status(403).json({
           success: false,
           message: "Please verify your email before logging in",


### PR DESCRIPTION
## Summary

This PR restores email verification enforcement for registration and login now that email delivery is available through Nodemailer/Gmail SMTP.

## Changes

- Disables the temporary registration bypass that auto-verified users when `SKIP_EMAIL_VERIFICATION=true`.
- Ensures new registrations always create a verification token, store its expiration, and send a verification email.
- Keeps registration responses token-free until the user verifies their email.
- Restores login blocking for unverified users with `403` and `requiresVerification: true`, regardless of the `SKIP_EMAIL_VERIFICATION` flag.
- Leaves the previous bypass block commented as an emergency fallback reference.

## Testing

- `git diff --check dev...HEAD` passed.
- `node -c src/controllers/authController.js` passed.
- `npm test` currently fails in unrelated existing tests for invitation, user deletion, and vacant role stubs: 41 passed, 7 failed.