### PR TITLE
Add auth availability checks for email and username

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -288,6 +288,72 @@ const authController = {
     }
   },
 
+  async checkEmail(req, res) {
+    try {
+      const { email } = req.body;
+
+      if (!email) {
+        return res.status(400).json({
+          success: false,
+          message: "Email is required",
+        });
+      }
+
+      const result = await db.query(
+        `SELECT id FROM users WHERE LOWER(email) = LOWER($1)`,
+        [email],
+      );
+
+      const available = result.rows.length === 0;
+
+      res.status(200).json({
+        success: true,
+        available,
+        ...(available
+          ? {}
+          : { message: "This email address is already registered." }),
+      });
+    } catch (error) {
+      console.error("Check email error:", error);
+      res.status(500).json({
+        success: false,
+        message: "Error checking email availability",
+      });
+    }
+  },
+
+  async checkUsername(req, res) {
+    try {
+      const { username } = req.body;
+
+      if (!username) {
+        return res.status(400).json({
+          success: false,
+          message: "Username is required",
+        });
+      }
+
+      const result = await db.query(
+        `SELECT id FROM users WHERE LOWER(username) = LOWER($1)`,
+        [username],
+      );
+
+      const available = result.rows.length === 0;
+
+      res.status(200).json({
+        success: true,
+        available,
+        ...(available ? {} : { message: "This username is already taken." }),
+      });
+    } catch (error) {
+      console.error("Check username error:", error);
+      res.status(500).json({
+        success: false,
+        message: "Error checking username availability",
+      });
+    }
+  },
+
   /**
    * Verify user's email address
    */

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -17,6 +17,9 @@ router.post(
 // Login existing user
 router.post("/login", authLimiter, authController.login);
 
+router.post("/check-email", authLimiter, authController.checkEmail);
+router.post("/check-username", authLimiter, authController.checkUsername);
+
 // Email verification routes (query-param based: /verify-email?token=...)
 router.get("/verify-email", authController.verifyEmail);
 router.post(


### PR DESCRIPTION
## Summary

Adds backend availability checks for registration fields so the frontend can show clearer validation feedback before submitting the full registration form.

## Changes

- Added `POST /auth/check-email` to check whether an email address is already registered.
- Added `POST /auth/check-username` to check whether a username is already taken.
- Both checks are case-insensitive and use the existing `authLimiter`.
- Returns `available: true/false` plus user-friendly messages when the value is already in use.

## Testing

- Ran `npm test`.
- Current suite fails in unrelated invitation, user deletion, and vacant role tests due to existing test stub/query mismatches; no failures are in the changed auth availability endpoints.