### PR TITLE
Add scheduled cleanup for expired unverified accounts and update mess…

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -530,7 +530,7 @@ const authController = {
         // ── INTERIM (disabled): if (!user.email_verified && process.env.SKIP_EMAIL_VERIFICATION !== "true") {
         return res.status(403).json({
           success: false,
-          message: "Please verify your email before logging in",
+          message: "Please verify your email before logging in. Check your inbox for the verification link — it expires 24 hours after registration.",
           requiresVerification: true,
         });
       }

--- a/src/jobs/cleanupUnverifiedAccounts.js
+++ b/src/jobs/cleanupUnverifiedAccounts.js
@@ -1,0 +1,44 @@
+const cron = require("node-cron");
+const db = require("../config/database");
+
+const BUFFER_HOURS = 1;
+
+const cleanupUnverifiedAccounts = () => {
+  cron.schedule("0 */6 * * *", async () => {
+    try {
+      const result = await db.query(
+        `
+        WITH expired_users AS (
+          SELECT id FROM users
+          WHERE email_verified = FALSE
+            AND verification_token_expires IS NOT NULL
+            AND verification_token_expires < NOW() - INTERVAL '${BUFFER_HOURS} hours'
+        ),
+        deleted_tags AS (
+          DELETE FROM user_tags
+          WHERE user_id IN (SELECT id FROM expired_users)
+        )
+        DELETE FROM users
+        WHERE id IN (SELECT id FROM expired_users)
+        RETURNING id, email, created_at
+        `,
+      );
+
+      const count = result.rowCount || 0;
+      if (count > 0) {
+        console.log(
+          `[Cleanup] Deleted ${count} unverified account(s):`,
+          result.rows.map((r) => ({ id: r.id, email: r.email, created: r.created_at })),
+        );
+      } else if (process.env.NODE_ENV !== "production") {
+        console.log("[Cleanup] No expired unverified accounts to delete.");
+      }
+    } catch (error) {
+      console.error("[Cleanup] Error cleaning up unverified accounts:", error);
+    }
+  });
+
+  console.log("[Cleanup] Unverified account cleanup job scheduled (every 6 hours).");
+};
+
+module.exports = cleanupUnverifiedAccounts;

--- a/src/server.js
+++ b/src/server.js
@@ -581,6 +581,9 @@ io.on("connection", (socket) => {
 // Initialize scheduled jobs
 initScheduledJobs();
 
+const cleanupUnverifiedAccounts = require("./jobs/cleanupUnverifiedAccounts");
+cleanupUnverifiedAccounts();
+
 // Start server
 server.listen(PORT, () => {
   console.log(`Server running on port ${PORT} with Socket.IO enabled`);

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -95,8 +95,13 @@ const emailService = {
             </div>
             
             <p style="font-size: 14px; color: #666; line-height: 1.6;">
-              This link will expire in 24 hours. If you didn't create a Lomir account, 
-              you can safely ignore this email.
+              This link will expire in <strong>24 hours</strong>. If you don't verify your account
+              within this time, your registration will be automatically deleted and you'll need
+              to sign up again.
+            </p>
+            <p style="font-size: 14px; color: #666; line-height: 1.6;">
+              If you didn't create a Lomir account, you can safely ignore this email —
+              the unverified account will be removed automatically.
             </p>
             
             <hr style="border: none; border-top: 1px solid #eee; margin: 32px 0;" />


### PR DESCRIPTION
Summary
Scheduled cleanup job (src/jobs/cleanupUnverifiedAccounts.js): runs every 6 hours and atomically deletes user_tags and users records for accounts whose verification_token_expires is more than 1 hour in the past and email_verified = FALSE. All deletions are logged as an audit trail.
Email/username availability checks (authController.js): two new endpoints (POST /api/auth/check-email, POST /api/auth/check-username) used by the registration form to give real-time feedback before submission.
Email verification enforced: removed the SKIP_EMAIL_VERIFICATION bypass; Nodemailer/Gmail SMTP is now the active delivery path. Login with an unverified account returns a 403 with an updated message explaining the 24-hour deadline.
Verification email copy updated (emailService.js): users are now told that their registration will be automatically deleted if they don't verify within 24 hours.
Contact form endpoint (contactController.js, contactRoutes.js): accepts name, email, topic, message, and optional file attachments and forwards them to the Lomir inbox via SMTP.
Test plan
 Server logs [Cleanup] Unverified account cleanup job scheduled (every 6 hours). on startup
 Create a test account, manually set verification_token_expires to 2 hours ago in the DB, temporarily change the cron to */1 * * * *, and confirm the account and its user_tags are deleted
 Verified accounts are never deleted (the email_verified = FALSE guard)
 Resending verification resets verification_token_expires and keeps the account alive
 POST /api/auth/check-email and check-username return { available: true/false } correctly
 Login with an unverified account returns 403 with the updated message
 Verification email contains the updated expiry/deletion warning text
 Contact form endpoint forwards message + attachments to the configured SMTP inbox