### PR TITLE
Search Results Polish & Location Enrichment

### DIFF
--- a/src/controllers/searchController.js
+++ b/src/controllers/searchController.js
@@ -742,7 +742,7 @@ async function fetchOpenRoleSearchResults({
   }
 
   let roleDistanceSelect = "";
-  if (userLocation && (sort === "proximity" || hasValidMaxDistance)) {
+  if (userLocation) {
     roleDistanceSelect = buildDistanceSelectSQL("vr", userLocation);
   }
 
@@ -1099,7 +1099,7 @@ async function executeSearchQueries({
   teamCountParams.push(...teamCountFilters.params);
 
   let teamDistanceSelect = "";
-  if (userLocation && (sort === "proximity" || hasValidMaxDistance)) {
+  if (userLocation) {
     teamDistanceSelect = buildDistanceSelectSQL(
       "t",
       userLocation,
@@ -1133,6 +1133,7 @@ async function executeSearchQueries({
             ELSE t.max_members - COALESCE(COUNT(DISTINCT tm.user_id), 0)
           END as available_capacity,
           (SELECT COUNT(*) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_count,
+          (SELECT COALESCE(json_agg(vr.role_name ORDER BY vr.role_name ASC), '[]'::json) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_names,
           COALESCE(
   json_agg(
     DISTINCT jsonb_build_object(
@@ -1230,10 +1231,7 @@ ${teamDistanceSelect}
 
   let userDistanceSelect = "";
   const userDistanceGroupBy = "";
-  if (
-    userLocation &&
-    ((sort === "proximity" && direction !== "REMOTE") || hasValidMaxDistance)
-  ) {
+  if (userLocation) {
     userDistanceSelect = buildDistanceSelectSQL("u", userLocation);
   }
 
@@ -1597,6 +1595,7 @@ const searchController = {
           team.open_role_count !== null && team.open_role_count !== undefined
             ? parseInt(team.open_role_count, 10)
             : 0,
+        open_role_names: normalizeJsonArray(team.open_role_names),
       }));
 
       const usersWithFixedVisibility = userResults.rows.map((user) => ({
@@ -1963,6 +1962,7 @@ const searchController = {
           team.open_role_count !== null && team.open_role_count !== undefined
             ? parseInt(team.open_role_count, 10)
             : 0,
+        open_role_names: normalizeJsonArray(team.open_role_names),
       }));
 
       const usersWithFixedVisibility = userResults.rows.map((user) => ({

--- a/src/controllers/teamReadController.js
+++ b/src/controllers/teamReadController.js
@@ -68,7 +68,8 @@ const getTeamById = async (req, res) => {
              t.owner_id, t.teamavatar_url, t.is_remote, t.is_synthetic,
              t.created_at, t.updated_at, t.postal_code, t.city, t.country, t.state, t.district,
              COALESCE(COUNT(DISTINCT tm.user_id), 0) as current_members_count,
-             (SELECT COUNT(*) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_count
+             (SELECT COUNT(*) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_count,
+             (SELECT COALESCE(json_agg(vr.role_name ORDER BY vr.role_name ASC), '[]'::json) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_names
       FROM teams t
       LEFT JOIN team_members tm ON t.id = tm.team_id
       WHERE t.id = $1 AND t.archived_at IS NULL


### PR DESCRIPTION
Summary
Search response privacy: Exact GPS coordinates are now stripped from all search results for users, teams, and roles. They are replaced with rounded values (±0.1°) exposed as both latitude/longitude and approximate_latitude/approximate_longitude so existing map clients continue to work.
District field added to search: district is now included in team, user, and role search results, team detail responses, and the vacant role serializer. Distance calculation now runs for all searches whenever a user location is available (previously only for proximity sort or max-distance filters).
Open role names on teams: Team search results and GET /teams/:id now include an open_role_names array listing the names of all open vacant roles, enabling the frontend to display them without an extra round-trip.
Location derivation from postal code: New locationDerivation.js utility derives city, state, district, and country from a postal code offline (no geocoding API call needed), used as a fallback when a user or team is missing location text fields. Includes a backfill script and migration to add the district column.
Contact form endpoint: New POST /api/contact accepts name, email, topic, message, and up to 5 file attachments. Validated with Joi, gated by Cloudflare Turnstile, rate-limited, and delivered via SMTP.
Email transport switched to SMTP/Nodemailer: Resend is disabled pending custom domain verification; all transactional email (verification, password reset, contact form) now goes through Gmail SMTP. Resend code is preserved in comments for easy restoration.
Auth availability checks: New POST /auth/check-email and POST /auth/check-username endpoints for real-time registration form validation.
Email verification re-enforced: The SKIP_EMAIL_VERIFICATION bypass is removed. Registration now requires email confirmation; unverified accounts are cleaned up after 24 hours by a scheduled job.
Team visibility hardening: getAllTeams filters to public teams only and drops SELECT *. getTeamById returns 404 for private teams to non-members. Member location fields are conditionally redacted based on profile visibility and team membership.
Test plan
 Search for users/teams and confirm latitude/longitude in results are rounded to 1 decimal place and approximate_latitude/approximate_longitude are present and equal
 Confirm district appears in user, team, and role search results
 Confirm open_role_names is populated on team search results and GET /teams/:id
 Submit contact form with and without attachments; verify email arrives with correct replyTo
 Attempt to access a private team as a non-member — expect 404
 Register a new account and confirm email verification is required before login
 Verify unverified accounts older than 24 hours are deleted by the cleanup job
 Check POST /auth/check-email and POST /auth/check-username return correct available boolean