### PR TITLE
Refactor/console log match cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Lomir-backend/
 │   │   ├── searchQueryBuilder.js # Shared search distance/filter/sort SQL builders
 │   │   ├── socketMessageEmitter.js
 │   │   ├── turnstileVerify.js  # Cloudflare Turnstile CAPTCHA verification
-│   │   ├── vacantRoleSerializer.js
+│   │   ├── vacantRoleSerializer.js    # Serializes vacant role rows; builds creator and filled_by user sub-objects (id, name, avatar_url, is_public)
 │   │   ├── badgeVisibilityUtils.js # Helpers for badge award visibility (hidden/shown state)
 │   │   └── geocodingUtil.js    # resolveLocationData (full enrichment) + geocodeAddress (coords only)
 │   ├── jobs/
@@ -226,7 +226,7 @@ Lomir-backend/
 │   └── database/
 │       └── migrations/
 ├── scripts/                    # SQL seed, migration, and utility scripts
-│   ├── migrate-cloudinary-to-imagekit.js
+│   ├── migrate-cloudinary-to-imagekit.js   # One-time migration (already run): converted Cloudinary URLs to ImageKit URLs in the database
 │   ├── add-location-district-columns.sql  # Migration: adds district column to teams/users/roles
 │   └── backfill-location-data.js         # One-off script to backfill district/state from geocoding
 ├── test/                       # Controller unit tests
@@ -258,7 +258,7 @@ All routes are prefixed with `/api`.
 | `/api/auth` | Register, login, email verification, password reset; `POST /auth/check-email` and `/auth/check-username` for real-time availability checks |
 | `/api/users` | User CRUD, tags, badges, avatar, account deletion with preview |
 | `/api/teams` | Team CRUD, members, applications, invitations, badge awards; `DELETE /invitations/:id/role` cancels only the role portion of a pending invitation |
-| `/api/teams/:teamId/vacant-roles` | Vacant role CRUD and status management. Supports `?ids=1,2,3` for bulk filtering (bypasses the default status filter so polling can detect roles that transitioned to filled/closed) |
+| `/api/teams/:teamId/vacant-roles` | Vacant role CRUD and status management. Supports `?ids=1,2,3` for bulk filtering (bypasses the default status filter so polling can detect roles that transitioned to filled/closed). Role responses include `is_public` on the `creator` and `filled_by` user sub-objects. |
 | `/api/search/global` | Keyword/boolean search across teams, users, and roles with tag/badge/location/role filtering |
 | `/api/search/all` | Initial search-page data without a required keyword, using the same filtering/sorting core |
 | `/api/matching` | Role ↔ user matching scores and candidate lists |

--- a/src/controllers/vacantRoleController.js
+++ b/src/controllers/vacantRoleController.js
@@ -9,11 +9,13 @@ const VACANT_ROLE_SELECT = `SELECT vr.*,
               u.first_name AS creator_first_name,
               u.last_name AS creator_last_name,
               u.username AS creator_username,
+              u.is_public AS creator_is_public,
               fu.id AS filled_by_user_id,
               fu.first_name AS filled_by_user_first_name,
               fu.last_name AS filled_by_user_last_name,
               fu.username AS filled_by_user_username,
-              fu.avatar_url AS filled_by_user_avatar_url
+              fu.avatar_url AS filled_by_user_avatar_url,
+              fu.is_public AS filled_by_user_is_public
        FROM team_vacant_roles vr
        JOIN users u ON vr.created_by = u.id
        LEFT JOIN users fu ON vr.filled_by = fu.id`;

--- a/src/utils/vacantRoleSerializer.js
+++ b/src/utils/vacantRoleSerializer.js
@@ -4,6 +4,7 @@ const FILLED_BY_USER_COLUMN_NAMES = [
   "filled_by_user_last_name",
   "filled_by_user_username",
   "filled_by_user_avatar_url",
+  "filled_by_user_is_public",
 ];
 
 const buildFilledByUserFromRow = (row, prefix = "") => {
@@ -19,6 +20,7 @@ const buildFilledByUserFromRow = (row, prefix = "") => {
     last_name: row[`${prefix}filled_by_user_last_name`] ?? null,
     username: row[`${prefix}filled_by_user_username`] ?? null,
     avatar_url: row[`${prefix}filled_by_user_avatar_url`] ?? null,
+    is_public: row[`${prefix}filled_by_user_is_public`] ?? null,
   };
 };
 


### PR DESCRIPTION
What
Adds is_public to the creator and filled_by user sub-objects returned by all vacant role endpoints.

Files changed:

src/controllers/vacantRoleController.js — VACANT_ROLE_SELECT query now selects u.is_public AS creator_is_public and fu.is_public AS filled_by_user_is_public
src/utils/vacantRoleSerializer.js — filled_by_user_is_public added to the column name list and mapped onto the filled_by user object
Why
The frontend needs to know whether a user's profile is public before linking to it. Without this field, the client had no way to conditionally render a profile link (or a non-linked display name) for the role creator or the user who filled the role.

Documentation
README.md updated: added is_public note to the /api/teams/:teamId/vacant-roles route entry, added a description for vacantRoleSerializer.js in the project structure, and annotated the Cloudinary→ImageKit migration script as a one-time migration already run.
Test plan
 GET /api/teams/:teamId/vacant-roles — verify creator.is_public and filled_by.is_public are present in responses
 Open role (no filled_by) — filled_by should remain null, no regression
 Closed/filled role — filled_by.is_public reflects the filling user's actual visibility setting
 npm test passes