### PR TITLE
Security Hardening Part 2 — Authorization, File Validation, and Data Exposure

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -112,7 +112,9 @@ app.use((req, res) => {
 
 app.use((err, req, res, next) => {
   console.error(`[${new Date().toISOString()}] Error: ${err.message}`);
-  console.error(err.stack);
+  if (process.env.NODE_ENV !== "production") {
+    console.error(err.stack);
+  }
 
   const statusCode = err.statusCode || 500;
 

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -30,6 +30,14 @@ const registerSchema = Joi.object({
   district: Joi.string().allow("", null),
   country: Joi.string().allow("", null),
   avatar_url: Joi.string().uri().allow(null),
+  acceptedTerms: Joi.boolean().truthy("true").valid(true).required().messages({
+    "any.only": "Terms of Service must be accepted",
+    "any.required": "Terms of Service must be accepted",
+  }),
+  acceptedPrivacy: Joi.boolean().truthy("true").valid(true).required().messages({
+    "any.only": "Privacy Policy must be accepted",
+    "any.required": "Privacy Policy must be accepted",
+  }),
   turnstile_token: Joi.string().optional(),
   tags: Joi.array()
     .items(
@@ -77,7 +85,11 @@ const authController = {
         ...req.body,
         tags: tags || [],
         avatar_url: avatarUrl,
+        acceptedTerms: req.body.acceptedTerms ?? req.body.accepted_terms,
+        acceptedPrivacy: req.body.acceptedPrivacy ?? req.body.accepted_privacy,
       };
+      delete userData.accepted_terms;
+      delete userData.accepted_privacy;
 
       // Validate the payload
       const { error, value } = registerSchema.validate(userData);

--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -100,6 +100,22 @@ const recalculateUserTagBadgeCredits = async (client, userId, tagId) => {
   );
 };
 
+const BADGE_AWARD_RETURNING_FIELDS = `
+  id,
+  awarded_to_user_id,
+  badge_id,
+  awarded_by_user_id,
+  credits,
+  context_type,
+  context_id,
+  team_id,
+  tag_id,
+  custom_team_name,
+  project_name,
+  created_at,
+  updated_at
+`;
+
 /**
  * @description Award a badge to a user
  * @route POST /api/badges/award
@@ -294,7 +310,7 @@ const awardBadge = async (req, res) => {
       `INSERT INTO badge_awards
   (awarded_to_user_id, badge_id, awarded_by_user_id, credits, reason, context_type, context_id, team_id, tag_id, custom_team_name, project_name, created_at, updated_at)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW())
-       RETURNING *`,
+       RETURNING ${BADGE_AWARD_RETURNING_FIELDS}`,
       [
         awarded_to_user_id,
         badge_id,

--- a/src/controllers/invitationController.js
+++ b/src/controllers/invitationController.js
@@ -340,6 +340,7 @@ const getUserReceivedInvitations = async (req, res) => {
         u.first_name as inviter_first_name, u.last_name as inviter_last_name,
         u.avatar_url as inviter_avatar_url,
         u.is_synthetic as inviter_is_synthetic,
+        u.is_public as inviter_is_public,
         EXISTS (
           SELECT 1 FROM team_members tm
           WHERE tm.team_id = t.id AND tm.user_id = $1
@@ -590,6 +591,7 @@ const getUserReceivedInvitations = async (req, res) => {
         last_name: row.inviter_last_name,
         avatar_url: row.inviter_avatar_url,
         is_synthetic: row.inviter_is_synthetic === true,
+        is_public: row.inviter_is_public === true || row.inviter_is_public === "true",
       },
       is_internal: row.is_internal === true || row.is_internal === "true",
     }));
@@ -651,6 +653,7 @@ const getTeamSentInvitations = async (req, res) => {
     inv.last_name as inviter_last_name,
     inv.avatar_url as inviter_avatar_url,
     inv.is_synthetic as inviter_is_synthetic,
+    inv.is_public as inviter_is_public,
     EXISTS (
       SELECT 1 FROM team_members tm
       WHERE tm.team_id = ti.team_id AND tm.user_id = ti.invitee_id
@@ -825,6 +828,7 @@ const getTeamSentInvitations = async (req, res) => {
         last_name: row.inviter_last_name,
         avatar_url: row.inviter_avatar_url,
         is_synthetic: row.inviter_is_synthetic === true,
+        is_public: row.inviter_is_public === true || row.inviter_is_public === "true",
       },
       role_is_synthetic: row.role_is_synthetic === true,
       inviter_username: row.inviter_username,

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -3,6 +3,81 @@ const {
   deleteImageKitFile,
   isImageKitUrl,
 } = require("../utils/imagekitUtils");
+const { validateChatFileUrl } = require("../utils/fileValidation");
+
+const CHAT_FILE_RETENTION_DAYS = 60;
+
+const getChatFileExpiresAt = () =>
+  new Date(Date.now() + CHAT_FILE_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+
+const validateMessageFileInputs = async ({ imageUrl, fileUrl }) => {
+  let fileSize = null;
+  let fileExpiresAt = null;
+
+  if (imageUrl) {
+    const validation = await validateChatFileUrl(imageUrl, "chatImage");
+    if (!validation.valid) {
+      return { valid: false, message: validation.error };
+    }
+    fileSize = validation.size || null;
+    fileExpiresAt = getChatFileExpiresAt();
+  }
+
+  if (fileUrl) {
+    const validation = await validateChatFileUrl(fileUrl, "chatFile");
+    if (!validation.valid) {
+      return { valid: false, message: validation.error };
+    }
+    fileSize = validation.size || null;
+    fileExpiresAt = getChatFileExpiresAt();
+  }
+
+  return { valid: true, fileSize, fileExpiresAt };
+};
+
+const ensureTeamMessageAccess = async (teamId, userId) => {
+  const result = await db.query(
+    `SELECT 1
+     FROM team_members tm
+     JOIN teams t ON t.id = tm.team_id
+     WHERE tm.team_id = $1
+       AND tm.user_id = $2
+       AND t.archived_at IS NULL
+     LIMIT 1`,
+    [teamId, userId],
+  );
+
+  return result.rows.length > 0;
+};
+
+const ensureReplyMessageAccess = async ({ replyToId, userId, conversationId, type }) => {
+  if (!replyToId) return true;
+
+  const result =
+    type === "team"
+      ? await db.query(
+          `SELECT 1
+           FROM messages
+           WHERE id = $1
+             AND team_id = $2
+           LIMIT 1`,
+          [replyToId, conversationId],
+        )
+      : await db.query(
+          `SELECT 1
+           FROM messages
+           WHERE id = $1
+             AND team_id IS NULL
+             AND (
+               (sender_id = $2 AND receiver_id = $3)
+               OR (sender_id = $3 AND receiver_id = $2)
+             )
+           LIMIT 1`,
+          [replyToId, userId, conversationId],
+        );
+
+  return result.rows.length > 0;
+};
 
 const emitMessageReceived = async (req, messageRow, type, conversationId) => {
   const io = req.app.get("io");
@@ -403,6 +478,25 @@ const getConversationById = async (req, res) => {
         },
       });
     } else {
+      const participantCheck = await db.query(
+        `SELECT 1
+         FROM messages
+         WHERE team_id IS NULL
+           AND (
+             (sender_id = $1 AND receiver_id = $2)
+             OR (sender_id = $2 AND receiver_id = $1)
+           )
+         LIMIT 1`,
+        [userId, conversationId],
+      );
+
+      if (participantCheck.rows.length === 0) {
+        return res.status(404).json({
+          success: false,
+          message: "Conversation not found or access denied",
+        });
+      }
+
       // Get direct conversation partner details
       const userQuery = `
         SELECT
@@ -689,6 +783,7 @@ const sendMessage = async (req, res) => {
       reply_to_id: bodyReplyToIdSnake,
     } = req.body;
     const replyToId = bodyReplyToId || bodyReplyToIdSnake || null;
+    const messageType = type === "team" ? "team" : "direct";
 
     // Allow content OR imageUrl OR fileUrl (or combinations)
     if ((!content || content.trim() === "") && !imageUrl && !fileUrl) {
@@ -698,39 +793,57 @@ const sendMessage = async (req, res) => {
       });
     }
 
-    /**
-     * ✅ Fix 2: Backend - Block messages to archived teams
-     * Use the "targetTeamId" derived from:
-     * - conversationId when type === "team"
-     * - req.body.team_id (if some clients send it)
-     *
-     * (We use db.query here for consistency with the rest of this controller.
-     * If your database module exposes db.pool.query as well, you can swap it in.)
-     */
-    const targetTeamId =
-      type === "team" ? conversationId : req.body.team_id || req.body.teamId;
+    const fileValidation = await validateMessageFileInputs({ imageUrl, fileUrl });
+    if (!fileValidation.valid) {
+      return res.status(400).json({
+        success: false,
+        message: fileValidation.message,
+      });
+    }
 
-    if (targetTeamId) {
-      const teamCheck = await db.query(
-        `SELECT archived_at FROM teams WHERE id = $1`,
-        [targetTeamId],
-      );
-
-      if (teamCheck.rows.length > 0 && teamCheck.rows[0].archived_at) {
+    if (messageType === "team") {
+      const canAccessTeam = await ensureTeamMessageAccess(conversationId, userId);
+      if (!canAccessTeam) {
         return res.status(403).json({
           success: false,
-          message: "Cannot send messages to a deleted team",
+          message: "Not authorized to send messages to this team",
+        });
+      }
+    } else {
+      const recipientResult = await db.query(
+        `SELECT id FROM users WHERE id = $1`,
+        [conversationId],
+      );
+
+      if (recipientResult.rows.length === 0) {
+        return res.status(404).json({
+          success: false,
+          message: "Recipient not found",
         });
       }
     }
 
+    const replyAllowed = await ensureReplyMessageAccess({
+      replyToId,
+      userId,
+      conversationId,
+      type: messageType,
+    });
+
+    if (!replyAllowed) {
+      return res.status(403).json({
+        success: false,
+        message: "Not authorized to reply to this message",
+      });
+    }
+
     let messageResult;
 
-    if (type === "team") {
+    if (messageType === "team") {
       messageResult = await db.query(
-        `INSERT INTO messages (sender_id, team_id, content, reply_to_id, image_url, file_url, file_name, sent_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
-     RETURNING id, sender_id, team_id, content, reply_to_id, image_url, file_url, file_name, sent_at`,
+        `INSERT INTO messages (sender_id, team_id, content, reply_to_id, image_url, file_url, file_name, file_size, file_expires_at, sent_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+     RETURNING id, sender_id, team_id, content, reply_to_id, image_url, file_url, file_name, file_size, file_expires_at, sent_at`,
         [
           userId,
           conversationId,
@@ -739,13 +852,15 @@ const sendMessage = async (req, res) => {
           imageUrl || null,
           fileUrl || null,
           fileName || null,
+          fileValidation.fileSize,
+          fileValidation.fileExpiresAt,
         ],
       );
     } else {
       messageResult = await db.query(
-        `INSERT INTO messages (sender_id, receiver_id, content, reply_to_id, image_url, file_url, file_name, sent_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
-     RETURNING id, sender_id, receiver_id, content, reply_to_id, image_url, file_url, file_name, sent_at`,
+        `INSERT INTO messages (sender_id, receiver_id, content, reply_to_id, image_url, file_url, file_name, file_size, file_expires_at, sent_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+     RETURNING id, sender_id, receiver_id, content, reply_to_id, image_url, file_url, file_name, file_size, file_expires_at, sent_at`,
         [
           userId,
           conversationId,
@@ -754,6 +869,8 @@ const sendMessage = async (req, res) => {
           imageUrl || null,
           fileUrl || null,
           fileName || null,
+          fileValidation.fileSize,
+          fileValidation.fileExpiresAt,
         ],
       );
     }
@@ -761,7 +878,7 @@ const sendMessage = async (req, res) => {
     await emitMessageReceived(
       req,
       messageResult.rows[0],
-      type === "team" ? "team" : "direct",
+      messageType,
       conversationId,
     );
 
@@ -899,6 +1016,15 @@ const updateMessage = async (req, res) => {
         .json({ message: "Not authorized to edit this message" });
     }
 
+    if (msg.team_id) {
+      const canAccessTeam = await ensureTeamMessageAccess(msg.team_id, currentUserId);
+      if (!canAccessTeam) {
+        return res
+          .status(403)
+          .json({ message: "Not authorized to edit this message" });
+      }
+    }
+
     if (msg.deleted_at) {
       return res.status(400).json({ message: "Cannot edit a deleted message" });
     }
@@ -1021,6 +1147,15 @@ const deleteMessage = async (req, res) => {
       return res
         .status(403)
         .json({ message: "Not authorized to delete this message" });
+    }
+
+    if (msg.team_id) {
+      const canAccessTeam = await ensureTeamMessageAccess(msg.team_id, currentUserId);
+      if (!canAccessTeam) {
+        return res
+          .status(403)
+          .json({ message: "Not authorized to delete this message" });
+      }
     }
 
     const imageUrl = msg.image_url;

--- a/src/controllers/teamApplicationsController.js
+++ b/src/controllers/teamApplicationsController.js
@@ -50,6 +50,7 @@ const getUserPendingApplications = async (req, res) => {
     owner.last_name as owner_last_name,
     owner.avatar_url as owner_avatar_url,
     owner.is_synthetic as owner_is_synthetic,
+    owner.is_public as owner_is_public,
     u.latitude AS applicant_latitude, u.longitude AS applicant_longitude,
     EXISTS (
       SELECT 1 FROM team_members
@@ -262,6 +263,7 @@ const getUserPendingApplications = async (req, res) => {
         last_name: row.owner_last_name,
         avatar_url: row.owner_avatar_url,
         is_synthetic: row.owner_is_synthetic === true,
+        is_public: row.owner_is_public === true || row.owner_is_public === "true",
       },
     }));
 

--- a/src/controllers/teamBadgeController.js
+++ b/src/controllers/teamBadgeController.js
@@ -74,9 +74,13 @@ const getTeamBadgeAwards = async (req, res) => {
       LEFT JOIN teams t_ctx ON ba.team_id = t_ctx.id
       LEFT JOIN tags tag ON ba.tag_id = tag.id
       WHERE ba.tag_id IS NOT NULL
+        AND (
+          ba.awarded_to_user_id = $2
+          OR NOT (ba.id = ANY(COALESCE(recipient.hidden_award_ids, '{}'::INTEGER[])))
+        )
       ORDER BY ba.created_at DESC, ba.id DESC
       `,
-      [teamId],
+      [teamId, viewerId || null],
     );
 
     res.status(200).json({
@@ -122,6 +126,11 @@ const getTeamMemberBadges = async (req, res) => {
         JOIN badges b         ON ba.badge_id = b.id
         JOIN team_members tm  ON ba.awarded_to_user_id = tm.user_id
                              AND tm.team_id = $1
+        LEFT JOIN users recipient ON recipient.id = ba.awarded_to_user_id
+        WHERE (
+          ba.awarded_to_user_id = $2
+          OR NOT (ba.id = ANY(COALESCE(recipient.hidden_award_ids, '{}'::INTEGER[])))
+        )
         GROUP BY b.id, b.name, b.description, b.category, b.color,
                  b.image_url, b.cat_image_url
       ),
@@ -143,7 +152,7 @@ const getTeamMemberBadges = async (req, res) => {
       JOIN category_totals ct ON bt.category = ct.category
       ORDER BY bt.category, bt.total_credits DESC, bt.name
       `,
-      [teamId],
+      [teamId, viewerId || null],
     );
 
     const grandTotalCredits = result.rows.reduce(
@@ -217,6 +226,11 @@ const getMemberBadgesForTeams = async (req, res) => {
         JOIN badges b         ON ba.badge_id = b.id
         JOIN team_members tm  ON ba.awarded_to_user_id = tm.user_id
                              AND tm.team_id = ANY($1)
+        LEFT JOIN users recipient ON recipient.id = ba.awarded_to_user_id
+        WHERE (
+          ba.awarded_to_user_id = $2
+          OR NOT (ba.id = ANY(COALESCE(recipient.hidden_award_ids, '{}'::INTEGER[])))
+        )
         GROUP BY tm.team_id, b.id, b.name, b.description, b.category, b.color,
                  b.image_url, b.cat_image_url
       ),
@@ -240,7 +254,7 @@ const getMemberBadgesForTeams = async (req, res) => {
         ON bt.category = ct.category AND bt.team_id = ct.team_id
       ORDER BY bt.team_id, bt.category, bt.total_credits DESC, bt.name
       `,
-      [teamIds],
+      [teamIds, viewerId || null],
     );
 
     const dataByTeam = {};
@@ -324,9 +338,13 @@ const getTeamMemberBadgeAwards = async (req, res) => {
       LEFT JOIN users recipient ON ba.awarded_to_user_id = recipient.id
       LEFT JOIN teams t_ctx ON ba.team_id = t_ctx.id
       LEFT JOIN tags tag ON ba.tag_id = tag.id
+      WHERE (
+        ba.awarded_to_user_id = $2
+        OR NOT (ba.id = ANY(COALESCE(recipient.hidden_award_ids, '{}'::INTEGER[])))
+      )
       ORDER BY ba.created_at DESC, ba.id DESC
       `,
-      [teamId],
+      [teamId, viewerId || null],
     );
 
     res.status(200).json({

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -11,6 +11,28 @@ const { serializeEmbeddedVacantRole } = require("../utils/vacantRoleSerializer")
 const { deleteImageKitFile } = require("../utils/imagekitUtils");
 const { emitInsertedMessage } = require("../utils/socketMessageEmitter");
 
+const TEAM_RETURNING_FIELDS = `
+  id,
+  name,
+  description,
+  owner_id,
+  is_public,
+  max_members,
+  is_remote,
+  postal_code,
+  city,
+  state,
+  district,
+  country,
+  latitude,
+  longitude,
+  teamavatar_url,
+  is_synthetic,
+  archived_at,
+  created_at,
+  updated_at
+`;
+
 const permanentlyDeleteTeam = async (teamId) => {
   const client = await db.pool.connect();
 
@@ -258,7 +280,7 @@ const createTeam = async (req, res) => {
     teamavatar_url,
     is_synthetic
   ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
-  RETURNING *
+  RETURNING ${TEAM_RETURNING_FIELDS}
   `,
       [
         value.name, // $1
@@ -619,7 +641,7 @@ const updateTeam = async (req, res) => {
           UPDATE teams 
           SET ${updateFields.join(", ")}
           WHERE id = $${paramCounter}
-          RETURNING *
+          RETURNING ${TEAM_RETURNING_FIELDS}
         `;
 
         await client.query(updateQuery, queryParams);

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -331,23 +331,22 @@ const getUserById = async (req, res) => {
       }
 
       if (!sharesTeam) {
-        return res.status(200).json({
-          success: true,
-          data: {
-            id: user.id,
-            username: user.username,
-            avatar_url: user.avatar_url,
-            is_public: false,
-            profile_access: "limited",
-          },
+        return res.status(404).json({
+          success: false,
+          message: "User not found",
         });
       }
     }
 
     if (!isOwner) {
       const publicData = sanitizePublicUser(user);
-      if (user.badges !== undefined) publicData.badges = user.badges;
-      if (user.total_badge_credits !== undefined) publicData.total_badge_credits = user.total_badge_credits;
+      if (user.hide_badges) {
+        publicData.badges = [];
+        publicData.total_badge_credits = 0;
+      } else {
+        if (user.badges !== undefined) publicData.badges = user.badges;
+        if (user.total_badge_credits !== undefined) publicData.total_badge_credits = user.total_badge_credits;
+      }
       if (user.hide_badges !== undefined) publicData.hide_badges = user.hide_badges;
       if (user.updated_at !== undefined) publicData.updated_at = user.updated_at;
 
@@ -1591,6 +1590,38 @@ const getUserTags = async (req, res) => {
     const userId = req.params.id;
     const canViewHiddenAwards = Number(req.user?.id) === Number(userId);
 
+    const userVisibility = await pool.query(
+      `SELECT id, is_public, COALESCE(hide_badges, FALSE) AS hide_badges
+       FROM users
+       WHERE id = $1`,
+      [userId],
+    );
+
+    if (userVisibility.rows.length === 0) {
+      return res.status(404).json({ success: false, message: "User not found" });
+    }
+
+    const userRow = userVisibility.rows[0];
+    const userIsPublic =
+      userRow.is_public === true || userRow.is_public === "true";
+
+    if (!canViewHiddenAwards && !userIsPublic) {
+      let sharesTeam = false;
+      if (req.user) {
+        const teamCheck = await pool.query(
+          `SELECT 1 FROM team_members tm1
+           JOIN team_members tm2 ON tm1.team_id = tm2.team_id
+           WHERE tm1.user_id = $1 AND tm2.user_id = $2
+           LIMIT 1`,
+          [req.user.id, userId],
+        );
+        sharesTeam = teamCheck.rows.length > 0;
+      }
+      if (!sharesTeam) {
+        return res.status(404).json({ success: false, message: "User not found" });
+      }
+    }
+
     await ensureBadgeVisibilityColumns();
 
     const result = await pool.query(
@@ -1622,6 +1653,7 @@ const getUserTags = async (req, res) => {
               AND ba2.awarded_to_user_id = ut.user_id
               AND (
                 $2::BOOLEAN = TRUE
+                OR COALESCE(u.hide_badges, FALSE) = TRUE
                 OR NOT (ba2.id = ANY(COALESCE(u.hidden_award_ids, '{}'::INTEGER[])))
               )
             GROUP BY b2.category
@@ -1633,6 +1665,7 @@ const getUserTags = async (req, res) => {
           AND ba.awarded_to_user_id = ut.user_id
           AND (
             $2::BOOLEAN = TRUE
+            OR COALESCE(u.hide_badges, FALSE) = TRUE
             OR NOT (ba.id = ANY(COALESCE(u.hidden_award_ids, '{}'::INTEGER[])))
           )
       ) tag_award_stats ON TRUE
@@ -1643,7 +1676,15 @@ const getUserTags = async (req, res) => {
 
     res.status(200).json({
       success: true,
-      data: result.rows,
+      data: userRow.hide_badges && !canViewHiddenAwards
+        ? result.rows.map((row) => ({
+            ...row,
+            badge_credits: 0,
+            dominant_badge_category: null,
+            linked_badge_count: 0,
+            awarder_count: 0,
+          }))
+        : result.rows,
     });
   } catch (error) {
     console.error("Error fetching user tags:", error);
@@ -1862,6 +1903,42 @@ const getUserBadges = async (req, res) => {
   try {
     const userId = req.params.id;
     const canViewHiddenAwards = Number(req.user?.id) === Number(userId);
+
+    const userVisibility = await pool.query(
+      `SELECT id, is_public, COALESCE(hide_badges, FALSE) AS hide_badges
+       FROM users
+       WHERE id = $1`,
+      [userId],
+    );
+
+    if (userVisibility.rows.length === 0) {
+      return res.status(404).json({ success: false, message: "User not found" });
+    }
+
+    const userRow = userVisibility.rows[0];
+    const userIsPublic =
+      userRow.is_public === true || userRow.is_public === "true";
+
+    if (!canViewHiddenAwards && !userIsPublic) {
+      let sharesTeam = false;
+      if (req.user) {
+        const teamCheck = await pool.query(
+          `SELECT 1 FROM team_members tm1
+           JOIN team_members tm2 ON tm1.team_id = tm2.team_id
+           WHERE tm1.user_id = $1 AND tm2.user_id = $2
+           LIMIT 1`,
+          [req.user.id, userId],
+        );
+        sharesTeam = teamCheck.rows.length > 0;
+      }
+      if (!sharesTeam) {
+        return res.status(404).json({ success: false, message: "User not found" });
+      }
+    }
+
+    if (!canViewHiddenAwards && userRow.hide_badges) {
+      return res.status(200).json({ success: true, data: [] });
+    }
 
     await ensureBadgeVisibilityColumns();
 

--- a/src/controllers/vacantRoleController.js
+++ b/src/controllers/vacantRoleController.js
@@ -5,6 +5,28 @@ const { serializeVacantRole } = require("../utils/vacantRoleSerializer");
 const { createNotification } = require("./notificationController");
 const { emitInsertedMessage } = require("../utils/socketMessageEmitter");
 
+const VACANT_ROLE_FIELDS = `
+  id,
+  team_id,
+  created_by,
+  role_name,
+  bio,
+  postal_code,
+  city,
+  country,
+  state,
+  district,
+  latitude,
+  longitude,
+  max_distance_km,
+  is_remote,
+  status,
+  is_synthetic,
+  filled_by,
+  created_at,
+  updated_at
+`;
+
 const VACANT_ROLE_SELECT = `SELECT vr.*,
               u.first_name AS creator_first_name,
               u.last_name AS creator_last_name,
@@ -17,6 +39,7 @@ const VACANT_ROLE_SELECT = `SELECT vr.*,
               fu.avatar_url AS filled_by_user_avatar_url,
               fu.is_public AS filled_by_user_is_public
        FROM team_vacant_roles vr
+       JOIN teams t ON t.id = vr.team_id
        JOIN users u ON vr.created_by = u.id
        LEFT JOIN users fu ON vr.filled_by = fu.id`;
 
@@ -28,6 +51,26 @@ const VACANT_ROLE_STATUS_SELECT = `SELECT vr.*,
               fu.avatar_url AS filled_by_user_avatar_url
        FROM team_vacant_roles vr
        LEFT JOIN users fu ON vr.filled_by = fu.id`;
+
+const toApproxCoord = (value) => {
+  if (value === null || value === undefined || value === "") return null;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.round(numeric * 10) / 10;
+};
+
+const withApproximateRoleLocation = (role) => {
+  const approximateLatitude = toApproxCoord(role.latitude);
+  const approximateLongitude = toApproxCoord(role.longitude);
+
+  return {
+    ...role,
+    latitude: approximateLatitude,
+    longitude: approximateLongitude,
+    approximate_latitude: approximateLatitude,
+    approximate_longitude: approximateLongitude,
+  };
+};
 
 const fetchRoleTags = async (clientOrPool, roleId) => {
   const result = await clientOrPool.query(
@@ -361,6 +404,7 @@ const getVacantRoles = async (req, res) => {
     const { teamId } = req.params;
     const statusFilter = req.query.status || "open"; // default: only open roles
     const idsParam = req.query.ids;
+    const viewerId = req.user?.id;
 
     const filterIds = idsParam
       ? String(idsParam)
@@ -380,15 +424,35 @@ const getVacantRoles = async (req, res) => {
           `${VACANT_ROLE_SELECT}
            WHERE vr.team_id = $1
              AND vr.id = ANY($2::int[])
+             AND t.archived_at IS NULL
+             AND (
+               t.is_public = TRUE
+               OR EXISTS (
+                 SELECT 1
+                 FROM team_members tm
+                 WHERE tm.team_id = t.id
+                   AND tm.user_id = $3
+               )
+             )
            ORDER BY vr.created_at DESC`,
-          [teamId, filterIds],
+          [teamId, filterIds, viewerId || null],
         )
       : await db.pool.query(
           `${VACANT_ROLE_SELECT}
            WHERE vr.team_id = $1
              AND ($2 = 'all' OR vr.status = $2)
+             AND t.archived_at IS NULL
+             AND (
+               t.is_public = TRUE
+               OR EXISTS (
+                 SELECT 1
+                 FROM team_members tm
+                 WHERE tm.team_id = t.id
+                   AND tm.user_id = $3
+               )
+             )
            ORDER BY vr.created_at DESC`,
-          [teamId, statusFilter],
+          [teamId, statusFilter, viewerId || null],
         );
 
     const roles = rolesResult.rows;
@@ -478,12 +542,12 @@ const getVacantRoles = async (req, res) => {
       const badges = badgesByRole[role.id] || [];
 
       if (!req.user) {
-        return serializeVacantRole(role, {
+        return withApproximateRoleLocation(serializeVacantRole(role, {
           tags,
           badges,
           desiredTags: tags,
           desiredBadges: badges,
-        });
+        }));
       }
 
       const roleTagIds = tags.map((t) => t.tag_id);
@@ -511,7 +575,7 @@ const getVacantRoles = async (req, res) => {
         WEIGHTS.badges * badgeScore +
         WEIGHTS.distance * distanceScore;
 
-      return serializeVacantRole(role, {
+      return withApproximateRoleLocation(serializeVacantRole(role, {
         tags,
         badges,
         desiredTags: tags,
@@ -529,7 +593,7 @@ const getVacantRoles = async (req, res) => {
           max_distance_km: role.max_distance_km,
           is_within_range: isWithinRange,
         },
-      });
+      }));
     });
 
     res.status(200).json({
@@ -555,37 +619,21 @@ const getVacantRoleById = async (req, res) => {
     const { teamId, roleId } = req.params;
     const viewerId = req.user?.id;
 
-    // Check parent team visibility before revealing any role data
-    const teamResult = await db.pool.query(
-      'SELECT is_public FROM teams WHERE id = $1 AND archived_at IS NULL',
-      [teamId],
-    );
-
-    if (teamResult.rows.length === 0) {
-      return res.status(404).json({ success: false, message: "Role not found" });
-    }
-
-    const teamIsPublic =
-      teamResult.rows[0].is_public === true ||
-      teamResult.rows[0].is_public === 'true';
-
-    if (!teamIsPublic) {
-      if (!viewerId) {
-        return res.status(404).json({ success: false, message: "Role not found" });
-      }
-      const memberCheck = await db.pool.query(
-        'SELECT 1 FROM team_members WHERE team_id = $1 AND user_id = $2',
-        [teamId, viewerId],
-      );
-      if (memberCheck.rows.length === 0) {
-        return res.status(404).json({ success: false, message: "Role not found" });
-      }
-    }
-
     const roleResult = await db.pool.query(
       `${VACANT_ROLE_SELECT}
-       WHERE vr.id = $1 AND vr.team_id = $2`,
-      [roleId, teamId],
+       WHERE vr.id = $1
+         AND vr.team_id = $2
+         AND t.archived_at IS NULL
+         AND (
+           t.is_public = TRUE
+           OR EXISTS (
+             SELECT 1
+             FROM team_members tm
+             WHERE tm.team_id = t.id
+               AND tm.user_id = $3
+           )
+         )`,
+      [roleId, teamId, viewerId || null],
     );
 
     if (roleResult.rows.length === 0) {
@@ -602,12 +650,12 @@ const getVacantRoleById = async (req, res) => {
 
     res.status(200).json({
       success: true,
-      data: serializeVacantRole(role, {
+      data: withApproximateRoleLocation(serializeVacantRole(role, {
         tags,
         badges,
         desiredTags: tags,
         desiredBadges: badges,
-      }),
+      })),
     });
   } catch (error) {
     console.error("Error fetching vacant role:", error);
@@ -710,7 +758,7 @@ const createVacantRole = async (req, res) => {
           latitude, longitude, max_distance_km, is_remote,
           is_synthetic
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-        RETURNING *`,
+        RETURNING ${VACANT_ROLE_FIELDS}`,
         [
           teamId,
           userId,
@@ -867,7 +915,9 @@ const updateVacantRole = async (req, res) => {
 
     // Verify role exists and belongs to this team
     const existingRole = await db.pool.query(
-      `SELECT * FROM team_vacant_roles WHERE id = $1 AND team_id = $2`,
+      `SELECT ${VACANT_ROLE_FIELDS}
+       FROM team_vacant_roles
+       WHERE id = $1 AND team_id = $2`,
       [roleId, teamId],
     );
 
@@ -942,7 +992,7 @@ const updateVacantRole = async (req, res) => {
           is_remote       = $11,
           updated_at      = NOW()
         WHERE id = $12 AND team_id = $13
-        RETURNING *`,
+        RETURNING ${VACANT_ROLE_FIELDS}`,
         [
           role_name?.trim() || null,
           bio?.trim() || null,
@@ -1274,7 +1324,7 @@ const updateVacantRoleStatus = async (req, res) => {
            filled_by = $2,
            updated_at = NOW()
        WHERE id = $3 AND team_id = $4
-       RETURNING *`,
+       RETURNING ${VACANT_ROLE_FIELDS}`,
       [status, normalizedFilledBy, roleId, teamId],
     );
 

--- a/src/jobs/fileCleanupScheduler.js
+++ b/src/jobs/fileCleanupScheduler.js
@@ -5,6 +5,9 @@ const {
   cleanupExpiredFiles,
   createExpirationNotifications,
 } = require('../utils/fileCleanup');
+const {
+  cleanupExpiredPasswordResetTokens,
+} = require('../utils/tokenCleanup');
 
 /**
  * Initialize all scheduled jobs
@@ -42,10 +45,25 @@ const initScheduledJobs = () => {
     timezone: 'Europe/Berlin'
   });
 
+  // Run expired password-reset token cleanup hourly
+  cron.schedule('15 * * * *', async () => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('[SCHEDULER] Running password reset token cleanup...');
+    }
+    try {
+      await cleanupExpiredPasswordResetTokens();
+    } catch (error) {
+      console.error('[SCHEDULER] Password reset token cleanup failed:', error);
+    }
+  }, {
+    timezone: 'Europe/Berlin'
+  });
+
   if (process.env.NODE_ENV !== 'production') {
     console.log('[SCHEDULER] Scheduled jobs initialized:');
     console.log('  - File cleanup: Daily at 2:00 AM');
     console.log('  - Expiration notifications: Daily at 9:00 AM');
+    console.log('  - Password reset token cleanup: Hourly at minute 15');
   }
 };
 

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -3,6 +3,66 @@ const bcrypt = require("bcrypt");
 
 const SALT_ROUNDS = 10;
 
+const CREATED_USER_FIELDS = `
+  id,
+  username,
+  email,
+  first_name,
+  last_name,
+  bio,
+  postal_code,
+  city,
+  state,
+  district,
+  country,
+  avatar_url,
+  email_verified,
+  is_public,
+  is_synthetic,
+  created_at,
+  updated_at
+`;
+
+const AUTH_USER_FIELDS = `
+  id,
+  username,
+  email,
+  password_hash,
+  email_verified,
+  first_name,
+  last_name,
+  bio,
+  postal_code,
+  city,
+  state,
+  district,
+  country,
+  avatar_url,
+  is_public,
+  is_synthetic,
+  created_at,
+  updated_at
+`;
+
+const CURRENT_USER_FIELDS = `
+  id,
+  username,
+  email,
+  first_name,
+  last_name,
+  bio,
+  postal_code,
+  city,
+  state,
+  district,
+  country,
+  avatar_url,
+  is_public,
+  is_synthetic,
+  created_at,
+  updated_at
+`;
+
 const userModel = {
   // ==============================
   // CREATE USER
@@ -34,7 +94,7 @@ const userModel = {
           updated_at
         )
         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,FALSE,TRUE,NOW(),NOW())
-        RETURNING *
+        RETURNING ${CREATED_USER_FIELDS}
         `,
         [
           userData.username,
@@ -66,7 +126,9 @@ const userModel = {
   // ==============================
   async findByEmail(email) {
     const result = await db.query(
-      `SELECT * FROM users WHERE lower(email) = lower($1)`,
+      `SELECT ${AUTH_USER_FIELDS}
+       FROM users
+       WHERE lower(email) = lower($1)`,
       [email],
     );
     return result.rows[0];
@@ -77,7 +139,9 @@ const userModel = {
   // ==============================
   async findByUsername(username) {
     const result = await db.query(
-      `SELECT * FROM users WHERE lower(username) = lower($1)`,
+      `SELECT id, username
+       FROM users
+       WHERE lower(username) = lower($1)`,
       [username],
     );
     return result.rows[0];
@@ -88,7 +152,9 @@ const userModel = {
   // ==============================
   async findById(id) {
     const result = await db.query(
-      `SELECT * FROM users WHERE id = $1`,
+      `SELECT ${CURRENT_USER_FIELDS}
+       FROM users
+       WHERE id = $1`,
       [id],
     );
     return result.rows[0];

--- a/src/server.js
+++ b/src/server.js
@@ -7,7 +7,78 @@ const app = require("./app");
 const http = require("http");
 const socketIo = require("socket.io");
 const { verifyToken } = require("./utils/jwtUtils");
+const db = require("./config/database");
 const PORT = process.env.PORT || 5001;
+
+const CHAT_FILE_RETENTION_DAYS = 60;
+
+const getChatFileExpiresAt = () =>
+  new Date(Date.now() + CHAT_FILE_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+
+const isActiveTeamMember = async (teamId, userId) => {
+  const result = await db.query(
+    `SELECT 1
+     FROM team_members tm
+     JOIN teams t ON t.id = tm.team_id
+     WHERE tm.team_id = $1
+       AND tm.user_id = $2
+       AND t.archived_at IS NULL
+     LIMIT 1`,
+    [teamId, userId],
+  );
+
+  return result.rows.length > 0;
+};
+
+const hasDirectConversationAccess = async (userId, conversationId) => {
+  const result = await db.query(
+    `SELECT 1
+     FROM messages
+     WHERE team_id IS NULL
+       AND (
+         (sender_id = $1 AND receiver_id = $2)
+         OR (sender_id = $2 AND receiver_id = $1)
+       )
+     LIMIT 1`,
+    [userId, conversationId],
+  );
+
+  return result.rows.length > 0;
+};
+
+const userExists = async (userId) => {
+  const result = await db.query(`SELECT id FROM users WHERE id = $1`, [userId]);
+  return result.rows.length > 0;
+};
+
+const canAccessReplyMessage = async ({ replyToId, userId, conversationId, type }) => {
+  if (!replyToId) return true;
+
+  const result =
+    type === "team"
+      ? await db.query(
+          `SELECT 1
+           FROM messages
+           WHERE id = $1
+             AND team_id = $2
+           LIMIT 1`,
+          [replyToId, conversationId],
+        )
+      : await db.query(
+          `SELECT 1
+           FROM messages
+           WHERE id = $1
+             AND team_id IS NULL
+             AND (
+               (sender_id = $2 AND receiver_id = $3)
+               OR (sender_id = $3 AND receiver_id = $2)
+             )
+           LIMIT 1`,
+          [replyToId, userId, conversationId],
+        );
+
+  return result.rows.length > 0;
+};
 
 // Create HTTP server
 const server = http.createServer(app);
@@ -78,7 +149,6 @@ io.on("connection", (socket) => {
   // Join user to all their team rooms
   const joinUserTeams = async () => {
     try {
-      const db = require("./config/database");
       const userTeamsResult = await db.query(
         `SELECT tm.team_id FROM team_members tm WHERE tm.user_id = $1`,
         [userId],
@@ -106,10 +176,14 @@ io.on("connection", (socket) => {
     try {
       const conversationId =
         typeof data === "object" ? data.conversationId : data;
-      const db = require("./config/database");
 
       const teamCheck = await db.query(
-        "SELECT 1 FROM team_members WHERE team_id = $1 AND user_id = $2",
+        `SELECT 1
+         FROM team_members tm
+         JOIN teams t ON t.id = tm.team_id
+         WHERE tm.team_id = $1
+           AND tm.user_id = $2
+           AND t.archived_at IS NULL`,
         [conversationId, userId],
       );
 
@@ -190,8 +264,7 @@ io.on("connection", (socket) => {
           return;
         }
         fileSize = validation.size || null;
-        // Set expiration to 60 days from now
-        fileExpiresAt = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000);
+        fileExpiresAt = getChatFileExpiresAt();
       }
 
       // Validate file URL and extract metadata
@@ -205,11 +278,9 @@ io.on("connection", (socket) => {
           return;
         }
         fileSize = validation.size || null;
-        // Set expiration to 60 days from now
-        fileExpiresAt = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000);
+        fileExpiresAt = getChatFileExpiresAt();
       }
 
-      const db = require("./config/database");
       const senderResult = await db.query(
         `SELECT username, first_name, last_name FROM users WHERE id = $1`,
         [userId],
@@ -219,12 +290,21 @@ io.on("connection", (socket) => {
       let replyTo = null;
 
       if (type === "team") {
-        const memberCheck = await db.query(
-          `SELECT tm.user_id FROM team_members tm WHERE tm.team_id = $1 AND tm.user_id = $2`,
-          [conversationId, userId],
-        );
-        if (memberCheck.rows.length === 0) {
+        const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+        if (!canAccessTeam) {
           socket.emit("error", { message: "Not authorized to send messages to this team" });
+          return;
+        }
+
+        const canReply = await canAccessReplyMessage({
+          replyToId,
+          userId,
+          conversationId,
+          type: "team",
+        });
+
+        if (!canReply) {
+          socket.emit("error", { message: "Not authorized to reply to this message" });
           return;
         }
 
@@ -300,6 +380,24 @@ io.on("connection", (socket) => {
 
         io.to(`team:${conversationId}`).emit("message:received", message);
       } else {
+        const recipientExists = await userExists(conversationId);
+        if (!recipientExists) {
+          socket.emit("error", { message: "Recipient not found" });
+          return;
+        }
+
+        const canReply = await canAccessReplyMessage({
+          replyToId,
+          userId,
+          conversationId,
+          type: "direct",
+        });
+
+        if (!canReply) {
+          socket.emit("error", { message: "Not authorized to reply to this message" });
+          return;
+        }
+
         messageResult = await db.query(
           `INSERT INTO messages (sender_id, receiver_id, content, reply_to_id, image_url, file_url, file_name, file_size, file_expires_at, sent_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
@@ -397,6 +495,16 @@ io.on("connection", (socket) => {
 
         for (const mentionedUserId of notified) {
           try {
+            if (type === "team") {
+              const mentionedMember = await isActiveTeamMember(
+                conversationId,
+                mentionedUserId,
+              );
+              if (!mentionedMember) continue;
+            } else if (String(mentionedUserId) !== String(conversationId)) {
+              continue;
+            }
+
             await createNotification({
               userId: mentionedUserId,
               type: "message_mention",
@@ -428,7 +536,7 @@ io.on("connection", (socket) => {
   });
 
   // Handle typing indicator - start
-  socket.on("typing:start", (data) => {
+  socket.on("typing:start", async (data) => {
     const { conversationId, type = "direct" } = data;
     if (process.env.NODE_ENV !== "production") {
       console.log(
@@ -437,6 +545,12 @@ io.on("connection", (socket) => {
     }
 
     if (type === "team") {
+      const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+      if (!canAccessTeam) {
+        socket.emit("error", { message: "Not authorized for this team conversation" });
+        return;
+      }
+
       // For team messages, broadcast to all team members except sender
       socket.to(`team:${conversationId}`).emit("typing:update", {
         conversationId: String(conversationId),
@@ -446,6 +560,12 @@ io.on("connection", (socket) => {
         type: "team",
       });
     } else {
+      const canAccessDirect = await hasDirectConversationAccess(userId, conversationId);
+      if (!canAccessDirect) {
+        socket.emit("error", { message: "Not authorized for this direct conversation" });
+        return;
+      }
+
       // For direct messages
       socket.to(`user:${conversationId}`).emit("typing:update", {
         conversationId: String(userId),
@@ -458,7 +578,7 @@ io.on("connection", (socket) => {
   });
 
   // Handle typing indicator - stop
-  socket.on("typing:stop", (data) => {
+  socket.on("typing:stop", async (data) => {
     const { conversationId, type = "direct" } = data;
     if (process.env.NODE_ENV !== "production") {
       console.log(
@@ -467,6 +587,12 @@ io.on("connection", (socket) => {
     }
 
     if (type === "team") {
+      const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+      if (!canAccessTeam) {
+        socket.emit("error", { message: "Not authorized for this team conversation" });
+        return;
+      }
+
       // For team messages, broadcast to all team members except sender
       socket.to(`team:${conversationId}`).emit("typing:update", {
         conversationId: String(conversationId),
@@ -476,6 +602,12 @@ io.on("connection", (socket) => {
         type: "team",
       });
     } else {
+      const canAccessDirect = await hasDirectConversationAccess(userId, conversationId);
+      if (!canAccessDirect) {
+        socket.emit("error", { message: "Not authorized for this direct conversation" });
+        return;
+      }
+
       // For direct messages
       socket.to(`user:${conversationId}`).emit("typing:update", {
         conversationId: String(userId),
@@ -491,7 +623,6 @@ io.on("connection", (socket) => {
   socket.on("message:read", async (data) => {
     try {
       const { conversationId, type = "direct" } = data;
-      const db = require("./config/database");
 
       if (process.env.NODE_ENV !== "production") {
         console.log(
@@ -500,6 +631,12 @@ io.on("connection", (socket) => {
       }
 
       if (type === "team") {
+        const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+        if (!canAccessTeam) {
+          socket.emit("error", { message: "Not authorized for this team conversation" });
+          return;
+        }
+
         const readStatusResult = await db.query(
           `WITH inserted_reads AS (
              INSERT INTO message_reads (message_id, user_id, read_at)
@@ -571,6 +708,12 @@ io.on("connection", (socket) => {
           });
         }
       } else {
+        const canAccessDirect = await hasDirectConversationAccess(userId, conversationId);
+        if (!canAccessDirect) {
+          socket.emit("error", { message: "Not authorized for this direct conversation" });
+          return;
+        }
+
         // Mark direct messages as read
         await db.query(
           `UPDATE messages

--- a/src/utils/fileValidation.js
+++ b/src/utils/fileValidation.js
@@ -60,7 +60,7 @@ const getFileSizeFromUrl = (url) => {
 
       request.on("timeout", () => {
         request.destroy();
-        console.warn(`[FILE VALIDATION] Timeout getting file size for: ${url}`);
+        console.warn("[FILE VALIDATION] Timeout getting file size");
         resolve(null);
       });
 
@@ -101,7 +101,7 @@ const validateChatFileUrl = async (url, type = "chatImage") => {
 
   // Must be an ImageKit URL
   if (!isImageKitUrl(url)) {
-    console.warn(`[FILE VALIDATION] Rejected non-ImageKit URL: ${url}`);
+    console.warn("[FILE VALIDATION] Rejected non-ImageKit URL");
     return { valid: false, error: "Files must be uploaded through Lomir" };
   }
 
@@ -130,7 +130,7 @@ const validateChatFileUrl = async (url, type = "chatImage") => {
 
   // If we can't verify size, allow it but log a warning
   if (fileSize === null) {
-    console.warn(`[FILE VALIDATION] Could not verify file size: ${url}`);
+    console.warn("[FILE VALIDATION] Could not verify file size");
     return { valid: true, warning: "Could not verify file size", filename };
   }
 

--- a/src/utils/tokenCleanup.js
+++ b/src/utils/tokenCleanup.js
@@ -1,0 +1,23 @@
+const db = require("../config/database");
+
+const cleanupExpiredPasswordResetTokens = async () => {
+  const result = await db.query(`
+    UPDATE users
+    SET password_reset_token = NULL,
+        password_reset_expires = NULL
+    WHERE password_reset_expires IS NOT NULL
+      AND password_reset_expires < NOW()
+  `);
+
+  if (process.env.NODE_ENV !== "production") {
+    console.log(
+      `[TOKEN CLEANUP] Cleared ${result.rowCount || 0} expired password reset token(s)`,
+    );
+  }
+
+  return { cleared: result.rowCount || 0 };
+};
+
+module.exports = {
+  cleanupExpiredPasswordResetTokens,
+};

--- a/src/utils/vacantRoleSerializer.js
+++ b/src/utils/vacantRoleSerializer.js
@@ -14,14 +14,20 @@ const buildFilledByUserFromRow = (row, prefix = "") => {
     return null;
   }
 
-  return {
+  const user = {
     id,
     first_name: row[`${prefix}filled_by_user_first_name`] ?? null,
     last_name: row[`${prefix}filled_by_user_last_name`] ?? null,
     username: row[`${prefix}filled_by_user_username`] ?? null,
     avatar_url: row[`${prefix}filled_by_user_avatar_url`] ?? null,
-    is_public: row[`${prefix}filled_by_user_is_public`] ?? null,
   };
+
+  const isPublic = row[`${prefix}filled_by_user_is_public`];
+  if (isPublic !== null && isPublic !== undefined) {
+    user.is_public = isPublic;
+  }
+
+  return user;
 };
 
 const stripFilledByUserColumns = (row, prefix = "") => {


### PR DESCRIPTION
Summary
Authorization guards across controllers — Badge, invitation, team badge, team application, and vacant role endpoints now verify that the requesting user is actually authorized (team member, owner, or participant) before returning or mutating data. Private user profiles return 404 to unauthenticated or unrelated callers rather than leaking existence.
WebSocket authorization — Team channel and DM connections now verify active team membership and conversation participation server-side before allowing access. Reply-to message IDs are validated against the actual conversation to prevent cross-conversation data access.
File validation in messaging — Uploaded chat image and file URLs are validated via validateChatFileUrl before being persisted. File size and a 60-day expiry timestamp are tracked; an hourly cleanup scheduler (fileCleanupScheduler) removes stale entries.
Vacant role location fuzzing — Coordinates for open roles are rounded to ~1 km precision before being returned to non-team-members, preventing exact location disclosure.
Explicit SELECT field lists in userModel — SELECT * replaced with named field constants (CREATED_USER_FIELDS, AUTH_USER_FIELDS, CURRENT_USER_FIELDS) to prevent accidental leakage of new columns (e.g. password_hash).
Scheduled password reset token cleanup — Expired tokens are purged hourly by a new cron job in server.js backed by utils/tokenCleanup.js.
Terms & Privacy acceptance enforced at registration — acceptedTerms and acceptedPrivacy are now required true values in the Joi registration schema.
Stack traces hidden in production — The global error handler only logs err.stack outside of production to avoid leaking internals.
Test plan
 Register without accepting ToS/Privacy → expect 400 validation error
 Fetch a private user's profile as an unrelated user → expect 404
 Fetch a private user's profile as a teammate → expect 200
 Send a WebSocket message to a team channel as a non-member → expect rejection
 Send a message with a reply-to ID from a different conversation → expect 403/rejection
 Upload a chat file and verify file_expires_at is set ~60 days out
 Confirm vacant role coordinates are approximate for external viewers
 Check no password_hash appears in /auth/me or user creation responses