### PR TITLE
feat: make new profiles hidden by default until email verified

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -413,12 +413,13 @@ const authController = {
         });
       }
 
-      // Mark email as verified and clear the token
+      // Mark email as verified, make profile public, and clear the token
       await db.query(
-        `UPDATE users 
-         SET email_verified = TRUE, 
-             verification_token = NULL, 
-             verification_token_expires = NULL 
+        `UPDATE users
+         SET email_verified = TRUE,
+             is_public = TRUE,
+             verification_token = NULL,
+             verification_token_expires = NULL
          WHERE id = $1`,
         [user.id],
       );

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -93,7 +93,7 @@ const userModel = {
           created_at,
           updated_at
         )
-        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,FALSE,TRUE,NOW(),NOW())
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,FALSE,FALSE,NOW(),NOW())
         RETURNING ${CREATED_USER_FIELDS}
         `,
         [

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -94,6 +94,13 @@ const emailService = {
               </a>
             </div>
             
+            <p style="font-size: 14px; color: #333; line-height: 1.6;">
+              Once verified, your profile will be set to <strong>public</strong> so other Lomir users can find you.
+              If you prefer to stay private, you can change this at any time in your
+              <a href="${process.env.FRONTEND_URL}/settings" style="color: #6366f1;">account settings</a>
+              after logging in.
+            </p>
+
             <p style="font-size: 14px; color: #666; line-height: 1.6;">
               This link will expire in <strong>24 hours</strong>. If you don't verify your account
               within this time, your registration will be automatically deleted and you'll need


### PR DESCRIPTION
Summary
New user accounts are created with is_public = FALSE, so profiles are hidden immediately after registration
On successful email verification, is_public is automatically set to TRUE, making the profile discoverable to other users
The verification email now includes a note explaining that the profile becomes public on verification and links to account settings for users who want to stay private
Why
Previously, a new account was publicly visible from the moment of registration, before the user had verified their email. This change ensures only confirmed accounts appear in search and discovery, reducing noise from incomplete or abandoned registrations.

Test plan
 Register a new account — confirm is_public is FALSE in the database immediately after signup
 Verify the email via the verification link — confirm is_public flips to TRUE
 Check the verification email includes the new privacy notice and settings link
 Confirm existing accounts and the manual is_public toggle in settings are unaffected