### PR TITLE
Feature/block users

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Contact the project owner for a demo login, or register a new account with a val
 
 - **Authentication** — JWT-based registration, login, email verification, and password reset. Transactional auth emails are sent through Nodemailer SMTP. Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev). Registration requires explicit acceptance of Terms of Service, acknowledgement of the Privacy Policy, and confirmation of minimum age (16+); the version of each legal document is stamped on the user row at sign-up.
 - **User Profiles** — CRUD with avatar uploads (ImageKit), interest tags, badge portfolios, and user-controlled public/private visibility. Verified accounts remain private by default until the user opts in to public visibility.
+- **User Blocking** — Authenticated users can manage a private blocklist. Block relationships hide profiles and user-search results where requester context is available, suppress team application visibility, disable direct messaging, and exclude blocked users from team chat realtime events where needed.
 - **Teams** — Create, join, manage members, assign roles, and archive teams
 - **Vacant Roles** — Post open positions on teams with desired tags, badges, and location preferences
 - **Matching Engine** — Score users against roles (and vice versa) using weighted tag/badge/distance criteria
@@ -260,7 +261,7 @@ All routes are prefixed with `/api`.
 | Prefix | Description |
 |---|---|
 | `/api/auth` | Register (requires `acceptedTerms`, `acceptedPrivacy`, `confirmedAge16`), login, email verification, password reset; `POST /auth/check-email` and `/auth/check-username` for real-time availability checks |
-| `/api/users` | User CRUD, tags, badges, avatar, account deletion with preview |
+| `/api/users` | User CRUD, tags, badges, avatar, self-only blocklist endpoints, account deletion with preview |
 | `/api/teams` | Team CRUD, members, applications, invitations, badge awards; `DELETE /invitations/:id/role` cancels only the role portion of a pending invitation |
 | `/api/teams/:teamId/vacant-roles` | Vacant role CRUD and status management. Supports `?ids=1,2,3` for bulk filtering (bypasses the default status filter so polling can detect roles that transitioned to filled/closed). Role responses include `is_public` on the `creator` and `filled_by` user sub-objects. |
 | `/api/search/global` | Keyword/boolean search across teams, users, and roles with tag/badge/location/role filtering |
@@ -292,7 +293,22 @@ Supported search controls include:
 - `sortDir`: `asc`, `desc`, or `remote`
 - `tagIds`, `badgeIds`, `maxDistance`, `openRolesOnly`, `excludeOwnTeams`, `excludeTeamId`, `includeDemoData`
 
+Authenticated user searches automatically exclude users who are in a block relationship with the requester, in either direction.
+
 The team search response intentionally returns `teamavatarUrl` from the SQL alias `teamavatar_url as "teamavatarUrl"` for API compatibility with the frontend.
+
+---
+
+## User Blocking
+
+Blocking is stored in the `user_blocks` table and is treated as a mutual visibility boundary throughout the backend:
+
+- `GET /api/users/:id/blocks` — list users the authenticated user has blocked
+- `POST /api/users/:id/blocks` — block another user using `blockedId` or `blocked_id`
+- `DELETE /api/users/:id/blocks/:blockedId` — unblock a user
+- `GET /api/users/:id/block-relationships` — return every user ID in a block relationship with the authenticated user, in either direction
+
+Blocklist routes are self-only: `:id` must match the authenticated user. When either user has blocked the other, profiles are returned as not found, user search excludes the match, direct messages are blocked, unread/conversation counts skip blocked senders, and team-chat broadcasts such as messages, typing indicators, and read receipts exclude blocked user rooms where relevant.
 
 ---
 
@@ -309,6 +325,7 @@ The server uses Socket.IO for real-time features. Clients authenticate via JWT t
 | `message:read` | Client → Server | Mark messages as read |
 | `message:status` | Server → Client | Read receipt notification |
 | `typing:start` / `typing:stop` | Bidirectional | Typing indicators |
+| `blocks:updated` | Server → Client | Tells both affected users to re-sync block state after a block or unblock |
 | `users:online` | Server → Client | Updated list of online user IDs |
 | `team:member_left` | Server → Client | Member removal (e.g. account deletion) |
 | `team:member_kicked` | Server → Client | Emitted to the removed member to kick them from the team chat |
@@ -385,13 +402,13 @@ Full transactional account deletion following the spec in `docs/USER_DELETION_SP
 | CAPTCHA | Cloudflare Turnstile on registration and contact form (feature-flagged; skipped when `TURNSTILE_SECRET_KEY` is unset) |
 | CORS | Allowlist: exact match for production URL + regex for Vercel preview deploys |
 | Password policy | Min 8 chars, at least one letter and one number (registration, reset, change) |
-| Socket.IO authorization | `conversation:join` validates team membership or existing DM before admitting the socket; `message:new` (team type) verifies the sender is a current team member before inserting |
+| Socket.IO authorization | `conversation:join` validates team membership or existing DM before admitting the socket; direct conversations are denied when either user has blocked the other; `message:new` (team type) verifies the sender is a current team member before inserting |
 | Error message scrubbing | Internal error details (`error.message`, stack traces) only included in responses when `NODE_ENV === "development"` |
 | Logging | All debug `console.log` gated behind `NODE_ENV !== "production"`; errors and warnings always logged |
 | SQL injection | Parameterized queries throughout |
 | Auth | JWT on all protected routes, bcrypt with 10 salt rounds |
 | Legal consent | Registration requires `acceptedTerms`, `acceptedPrivacy`, and `confirmedAge16` (all must be `true`). The version of each document (`accepted_terms_version`, `accepted_privacy_version`, `confirmed_age_16_version`) and the acceptance timestamp are stored on the user row for audit purposes. |
-| User data exposure | `GET /api/users` returns only public profiles (`is_public = TRUE`) with an explicit column allowlist; newly verified users remain private until they opt in; no `SELECT *` on user rows |
+| User data exposure | Public user listings return only public profiles (`is_public = TRUE`) with an explicit column allowlist; auth-aware profile/search reads also exclude users in a block relationship with the requester where supported; newly verified users remain private until they opt in; no `SELECT *` on user rows |
 
 ---
 

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -4,6 +4,7 @@ const {
   isImageKitUrl,
 } = require("../utils/imagekitUtils");
 const { validateChatFileUrl } = require("../utils/fileValidation");
+const userModel = require("../models/userModel");
 
 const CHAT_FILE_RETENTION_DAYS = 60;
 
@@ -140,6 +141,11 @@ const getUnreadCount = async (req, res) => {
            MAX(sent_at) AS latest
          FROM messages
          WHERE receiver_id = $1 AND read_at IS NULL AND team_id IS NULL AND deleted_at IS NULL
+           AND NOT EXISTS (
+             SELECT 1 FROM user_blocks ub
+             WHERE (ub.blocker_id = messages.sender_id AND ub.blocked_id = $1)
+                OR (ub.blocked_id = messages.sender_id AND ub.blocker_id = $1)
+           )
          GROUP BY sender_id
        ),
        team_unread AS (
@@ -159,6 +165,11 @@ const getUnreadCount = async (req, res) => {
              WHERE mr.message_id = m.id
                AND mr.user_id = $1
            )
+           AND NOT EXISTS (
+             SELECT 1 FROM user_blocks ub
+             WHERE (ub.blocker_id = m.sender_id AND ub.blocked_id = $1)
+                OR (ub.blocked_id = m.sender_id AND ub.blocker_id = $1)
+           )
          GROUP BY m.team_id
        ),
        combined AS (
@@ -173,10 +184,17 @@ const getUnreadCount = async (req, res) => {
          (SELECT COUNT(*)::int FROM team_unread) AS team_count,
          (SELECT COUNT(DISTINCT m.sender_id)::int
           FROM messages m
-          WHERE (m.receiver_id = $1 AND m.read_at IS NULL AND m.team_id IS NULL AND m.deleted_at IS NULL)
-             OR (m.team_id IS NOT NULL AND m.sender_id != $1 AND m.deleted_at IS NULL
-                 AND EXISTS (SELECT 1 FROM team_members tm WHERE tm.team_id = m.team_id AND tm.user_id = $1)
-                 AND NOT EXISTS (SELECT 1 FROM message_reads mr WHERE mr.message_id = m.id AND mr.user_id = $1))
+          WHERE (
+                  (m.receiver_id = $1 AND m.read_at IS NULL AND m.team_id IS NULL AND m.deleted_at IS NULL)
+               OR (m.team_id IS NOT NULL AND m.sender_id != $1 AND m.deleted_at IS NULL
+                   AND EXISTS (SELECT 1 FROM team_members tm WHERE tm.team_id = m.team_id AND tm.user_id = $1)
+                   AND NOT EXISTS (SELECT 1 FROM message_reads mr WHERE mr.message_id = m.id AND mr.user_id = $1))
+                )
+            AND NOT EXISTS (
+              SELECT 1 FROM user_blocks ub
+              WHERE (ub.blocker_id = m.sender_id AND ub.blocked_id = $1)
+                 OR (ub.blocked_id = m.sender_id AND ub.blocker_id = $1)
+            )
          ) AS sender_count
        FROM combined`,
       [userId],
@@ -237,6 +255,13 @@ const startConversation = async (req, res) => {
       return res.status(404).json({
         success: false,
         message: "Recipient not found",
+      });
+    }
+
+    if (await userModel.isBlockedBetween(senderId, receiverId)) {
+      return res.status(403).json({
+        success: false,
+        message: "You can no longer message this user",
       });
     }
 
@@ -323,6 +348,11 @@ const getConversations = async (req, res) => {
       FROM latest_messages lm
       JOIN users u ON lm.partner_id = u.id
       LEFT JOIN unread_counts uc ON lm.partner_id = uc.partner_id
+      WHERE NOT EXISTS (
+        SELECT 1 FROM user_blocks ub
+        WHERE (ub.blocker_id = $1 AND ub.blocked_id = lm.partner_id)
+           OR (ub.blocked_id = $1 AND ub.blocker_id = lm.partner_id)
+      )
       ORDER BY lm.last_message_time DESC
     `;
 
@@ -336,23 +366,33 @@ const getConversations = async (req, res) => {
         FROM messages m
         JOIN team_members tm ON m.team_id = tm.team_id
         WHERE tm.user_id = $1 AND m.team_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM user_blocks ub
+            WHERE (ub.blocker_id = m.sender_id AND ub.blocked_id = $1)
+               OR (ub.blocked_id = m.sender_id AND ub.blocker_id = $1)
+          )
         GROUP BY m.team_id
       ),
       latest_team_messages AS (
-        SELECT 
+        SELECT
           tc.team_id,
           tc.last_message_time,
           m.content as last_message
         FROM team_conversations tc
         JOIN messages m ON m.team_id = tc.team_id AND m.sent_at = tc.last_message_time
+          AND NOT EXISTS (
+            SELECT 1 FROM user_blocks ub
+            WHERE (ub.blocker_id = m.sender_id AND ub.blocked_id = $1)
+               OR (ub.blocked_id = m.sender_id AND ub.blocker_id = $1)
+          )
       ),
       team_unread_counts AS (
-        SELECT 
+        SELECT
           m.team_id,
           COUNT(*) as unread_count
         FROM messages m
         JOIN team_members tm ON m.team_id = tm.team_id
-        WHERE tm.user_id = $1 
+        WHERE tm.user_id = $1
           AND m.sender_id != $1
           AND m.team_id IS NOT NULL
           AND NOT EXISTS (
@@ -360,6 +400,11 @@ const getConversations = async (req, res) => {
             FROM message_reads mr
             WHERE mr.message_id = m.id
               AND mr.user_id = $1
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM user_blocks ub
+            WHERE (ub.blocker_id = m.sender_id AND ub.blocked_id = $1)
+               OR (ub.blocked_id = m.sender_id AND ub.blocker_id = $1)
           )
         GROUP BY m.team_id
       )
@@ -478,6 +523,13 @@ const getConversationById = async (req, res) => {
         },
       });
     } else {
+      if (await userModel.isBlockedBetween(userId, conversationId)) {
+        return res.status(404).json({
+          success: false,
+          message: "Conversation not found or access denied",
+        });
+      }
+
       const participantCheck = await db.query(
         `SELECT 1
          FROM messages
@@ -618,6 +670,11 @@ const getMessages = async (req, res) => {
     FROM messages m
     LEFT JOIN users u ON m.sender_id = u.id
     LEFT JOIN messages rm ON m.reply_to_id = rm.id
+      AND NOT EXISTS (
+        SELECT 1 FROM user_blocks ubr
+        WHERE (ubr.blocker_id = rm.sender_id AND ubr.blocked_id = $2)
+           OR (ubr.blocked_id = rm.sender_id AND ubr.blocker_id = $2)
+      )
     LEFT JOIN users ru ON rm.sender_id = ru.id
     LEFT JOIN LATERAL (
       SELECT mr.read_at
@@ -646,6 +703,11 @@ const getMessages = async (req, res) => {
       LEFT JOIN users u ON u.id = mr.user_id
       WHERE mr.message_id = m.id
         AND mr.user_id != m.sender_id
+        AND NOT EXISTS (
+          SELECT 1 FROM user_blocks ubrd
+          WHERE (ubrd.blocker_id = mr.user_id AND ubrd.blocked_id = $2)
+             OR (ubrd.blocked_id = mr.user_id AND ubrd.blocker_id = $2)
+        )
     ) read_stats ON TRUE
     LEFT JOIN LATERAL (
       SELECT COUNT(*)::int as recipient_count
@@ -654,6 +716,11 @@ const getMessages = async (req, res) => {
         AND tm.user_id != m.sender_id
     ) recipient_stats ON TRUE
     WHERE m.team_id = $1
+      AND NOT EXISTS (
+        SELECT 1 FROM user_blocks ub
+        WHERE (ub.blocker_id = m.sender_id AND ub.blocked_id = $2)
+           OR (ub.blocked_id = m.sender_id AND ub.blocker_id = $2)
+      )
     ${before ? "AND m.id < $3" : ""}
     ORDER BY m.sent_at DESC, m.id DESC
     LIMIT $${before ? "4" : "3"}
@@ -662,8 +729,15 @@ const getMessages = async (req, res) => {
         ? [conversationId, userId, before, limit]
         : [conversationId, userId, limit];
     } else {
+      if (await userModel.isBlockedBetween(userId, conversationId)) {
+        return res.status(403).json({
+          success: false,
+          message: "You can no longer view this conversation",
+        });
+      }
+
       messagesQuery = `
-    SELECT 
+    SELECT
       m.id,
       m.sender_id,
       m.receiver_id,
@@ -819,6 +893,13 @@ const sendMessage = async (req, res) => {
         return res.status(404).json({
           success: false,
           message: "Recipient not found",
+        });
+      }
+
+      if (await userModel.isBlockedBetween(userId, conversationId)) {
+        return res.status(403).json({
+          success: false,
+          message: "You can no longer message this user",
         });
       }
     }

--- a/src/controllers/searchController.js
+++ b/src/controllers/searchController.js
@@ -378,6 +378,20 @@ function buildUserFilters(config, startParamIndex = 1) {
     whereFragments.push(` AND u.is_public = TRUE`);
   }
 
+  // Mutually hide blocked users: drop anyone the viewer has blocked or who has
+  // blocked the viewer from search results.
+  if (userId) {
+    whereFragments.push(`
+          AND NOT EXISTS (
+            SELECT 1 FROM user_blocks ub
+            WHERE (ub.blocker_id = u.id AND ub.blocked_id = $${nextParamIndex})
+               OR (ub.blocked_id = u.id AND ub.blocker_id = $${nextParamIndex})
+          )
+        `);
+    params.push(userId);
+    nextParamIndex++;
+  }
+
   if (!includeDemoData) {
     whereFragments.push(` AND u.is_synthetic IS NOT TRUE`);
   }

--- a/src/controllers/teamApplicationsController.js
+++ b/src/controllers/teamApplicationsController.js
@@ -464,8 +464,13 @@ const getTeamApplications = async (req, res) => {
        LEFT JOIN team_vacant_roles vr ON ta.role_id = vr.id
        LEFT JOIN users fu ON vr.filled_by = fu.id
        WHERE ta.team_id = $1 AND ta.status = 'pending'
+         AND NOT EXISTS (
+           SELECT 1 FROM user_blocks ub
+           WHERE (ub.blocker_id = ta.applicant_id AND ub.blocked_id = $2)
+              OR (ub.blocked_id = ta.applicant_id AND ub.blocker_id = $2)
+         )
        ORDER BY ta.created_at ASC`,
-      [teamId],
+      [teamId, userId],
     );
 
     // Batch-fetch role tags and badges for applications that reference a vacant role

--- a/src/controllers/teamReadController.js
+++ b/src/controllers/teamReadController.js
@@ -258,10 +258,20 @@ const getUserTeams = async (req, res) => {
              t.is_remote,
              COALESCE(COUNT(DISTINCT tm.user_id), 0) AS current_members_count,
              (SELECT COUNT(*) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_count,
-             (SELECT COUNT(*)::int FROM team_applications ta WHERE ta.team_id = t.id AND ta.status = 'pending') AS pending_applications_count,
+             (SELECT COUNT(*)::int FROM team_applications ta WHERE ta.team_id = t.id AND ta.status = 'pending'
+               AND NOT EXISTS (
+                 SELECT 1 FROM user_blocks ub
+                 WHERE (ub.blocker_id = ta.applicant_id AND ub.blocked_id = $1)
+                    OR (ub.blocked_id = ta.applicant_id AND ub.blocker_id = $1)
+               )) AS pending_applications_count,
              (SELECT COUNT(*)::int FROM team_invitations ti WHERE ti.team_id = t.id AND ti.status = 'pending') AS pending_sent_invitations_count,
              GREATEST(
-               (SELECT MAX(ta.created_at) FROM team_applications ta WHERE ta.team_id = t.id AND ta.status = 'pending'),
+               (SELECT MAX(ta.created_at) FROM team_applications ta WHERE ta.team_id = t.id AND ta.status = 'pending'
+                 AND NOT EXISTS (
+                   SELECT 1 FROM user_blocks ub
+                   WHERE (ub.blocker_id = ta.applicant_id AND ub.blocked_id = $1)
+                      OR (ub.blocked_id = ta.applicant_id AND ub.blocker_id = $1)
+                 )),
                (SELECT MAX(ti.created_at) FROM team_invitations ti WHERE ti.team_id = t.id AND ti.status = 'pending')
              ) AS latest_request_timestamp,
              tmr.role as user_role,

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -7,6 +7,7 @@ const {
 } = require("../utils/geocodingUtil");
 const { deleteImageKitFile } = require("../utils/imagekitUtils");
 const { ensureBadgeVisibilityColumns } = require("../utils/badgeVisibilityUtils");
+const userModel = require("../models/userModel");
 
 const PUBLIC_USER_FIELDS = `
   u.id, u.username, u.first_name, u.last_name, u.bio,
@@ -142,13 +143,27 @@ const getSuccessorCandidatesByTeam = async (queryable, teamIds, excludedUserId) 
  */
 const getUsers = async (req, res) => {
   try {
-    const result = await pool.query(`
+    const viewerId = req.user?.id ?? null;
+    // Hide anyone in a block relationship with the viewer (mutual). When the
+    // request is unauthenticated, viewerId is null and the filter is a no-op.
+    const blockFilter = viewerId
+      ? `AND NOT EXISTS (
+           SELECT 1 FROM user_blocks ub
+           WHERE (ub.blocker_id = u.id AND ub.blocked_id = $1)
+              OR (ub.blocked_id = u.id AND ub.blocker_id = $1)
+         )`
+      : "";
+    const result = await pool.query(
+      `
       SELECT ${PUBLIC_USER_FIELDS}
       FROM users u
       WHERE u.is_public = TRUE
+      ${blockFilter}
       ORDER BY u.created_at DESC
       LIMIT 50
-    `);
+    `,
+      viewerId ? [viewerId] : [],
+    );
 
     res.status(200).json({
       success: true,
@@ -315,6 +330,19 @@ const getUserById = async (req, res) => {
     }
 
     const user = result.rows[0];
+
+    // Blocked users are mutually hidden: if either party has blocked the other,
+    // present the profile as "not found" (same shape the frontend already uses
+    // for missing/private-non-shared profiles).
+    if (!isOwner && req.user) {
+      const blocked = await userModel.isBlockedBetween(req.user.id, userId);
+      if (blocked) {
+        return res.status(404).json({
+          success: false,
+          message: "User not found",
+        });
+      }
+    }
 
     if (!isOwner && !user.is_public) {
       // Teammates may see the full sanitized profile even if it is private
@@ -2004,6 +2032,151 @@ const getUserBadges = async (req, res) => {
   }
 };
 
+// ============================================================
+// USER BLOCKS
+// ============================================================
+
+// Guards that the authenticated user is acting on their own blocklist.
+const isSelf = (req) => Number(req.user?.id) === Number(req.params.id);
+
+// Tell both parties' clients (all devices) to re-sync block state in realtime,
+// so a block/unblock instantly hides/restores chats without a manual refresh.
+const emitBlocksUpdated = (req, blockerId, blockedId, blocked) => {
+  const io = req.app.get("io");
+  if (!io) return;
+  io.to(`user:${blockedId}`).emit("blocks:updated", {
+    withUserId: Number(blockerId),
+    blocked,
+  });
+  io.to(`user:${blockerId}`).emit("blocks:updated", {
+    withUserId: Number(blockedId),
+    blocked,
+  });
+};
+
+/**
+ * @description List users the current user has blocked.
+ * @route GET /api/users/:id/blocks
+ * @access Private (self only)
+ */
+const getBlockedUsers = async (req, res) => {
+  try {
+    if (!isSelf(req)) {
+      return res.status(403).json({ success: false, message: "Forbidden" });
+    }
+    const blocked = await userModel.getBlockedUsers(req.user.id);
+    res.status(200).json({ success: true, data: blocked });
+  } catch (error) {
+    console.error("Error fetching blocked users:", error);
+    res.status(500).json({
+      success: false,
+      message: "Error fetching blocked users",
+      ...(process.env.NODE_ENV === "development" && { error: error.message }),
+    });
+  }
+};
+
+/**
+ * @description Block a user.
+ * @route POST /api/users/:id/blocks
+ * @access Private (self only)
+ */
+const blockUser = async (req, res) => {
+  try {
+    if (!isSelf(req)) {
+      return res.status(403).json({ success: false, message: "Forbidden" });
+    }
+    const blockedId = Number(req.body.blocked_id ?? req.body.blockedId);
+    if (!blockedId || Number.isNaN(blockedId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "blockedId is required" });
+    }
+    if (blockedId === Number(req.user.id)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "You cannot block yourself" });
+    }
+
+    const target = await pool.query(`SELECT id FROM users WHERE id = $1`, [
+      blockedId,
+    ]);
+    if (target.rows.length === 0) {
+      return res
+        .status(404)
+        .json({ success: false, message: "User not found" });
+    }
+
+    await userModel.blockUser(req.user.id, blockedId);
+    emitBlocksUpdated(req, req.user.id, blockedId, true);
+    res
+      .status(201)
+      .json({ success: true, message: "User blocked successfully" });
+  } catch (error) {
+    console.error("Error blocking user:", error);
+    res.status(500).json({
+      success: false,
+      message: "Error blocking user",
+      ...(process.env.NODE_ENV === "development" && { error: error.message }),
+    });
+  }
+};
+
+/**
+ * @description Unblock a user.
+ * @route DELETE /api/users/:id/blocks/:blockedId
+ * @access Private (self only)
+ */
+const unblockUser = async (req, res) => {
+  try {
+    if (!isSelf(req)) {
+      return res.status(403).json({ success: false, message: "Forbidden" });
+    }
+    const blockedId = Number(req.params.blockedId);
+    if (!blockedId || Number.isNaN(blockedId)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Invalid blocked user id" });
+    }
+    await userModel.unblockUser(req.user.id, blockedId);
+    emitBlocksUpdated(req, req.user.id, blockedId, false);
+    res
+      .status(200)
+      .json({ success: true, message: "User unblocked successfully" });
+  } catch (error) {
+    console.error("Error unblocking user:", error);
+    res.status(500).json({
+      success: false,
+      message: "Error unblocking user",
+      ...(process.env.NODE_ENV === "development" && { error: error.message }),
+    });
+  }
+};
+
+/**
+ * @description Get every user id in a block relationship with the current user
+ *              (either direction) — used by the client to mutually anonymize
+ *              blocked users in shared teams.
+ * @route GET /api/users/:id/block-relationships
+ * @access Private (self only)
+ */
+const getBlockRelationships = async (req, res) => {
+  try {
+    if (!isSelf(req)) {
+      return res.status(403).json({ success: false, message: "Forbidden" });
+    }
+    const ids = await userModel.getBlockRelationshipIds(req.user.id);
+    res.status(200).json({ success: true, data: { ids } });
+  } catch (error) {
+    console.error("Error fetching block relationships:", error);
+    res.status(500).json({
+      success: false,
+      message: "Error fetching block relationships",
+      ...(process.env.NODE_ENV === "development" && { error: error.message }),
+    });
+  }
+};
+
 module.exports = {
   getUsers,
   getUserById,
@@ -2015,4 +2188,8 @@ module.exports = {
   updateUserTags,
   updateUserBadgeVisibility,
   getUserBadges,
+  getBlockedUsers,
+  blockUser,
+  unblockUser,
+  getBlockRelationships,
 };

--- a/src/database/migrations/create_user_blocks.js
+++ b/src/database/migrations/create_user_blocks.js
@@ -1,0 +1,27 @@
+const db = require("../../config/database");
+
+const createUserBlocks = async () => {
+  try {
+    await db.query(`
+      CREATE TABLE IF NOT EXISTS user_blocks (
+        blocker_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        blocked_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (blocker_id, blocked_id),
+        CHECK (blocker_id <> blocked_id)
+      )
+    `);
+    // Reverse lookups ("who has blocked me?") hit blocked_id, which is not the
+    // leading column of the primary key, so it needs its own index.
+    await db.query(`
+      CREATE INDEX IF NOT EXISTS idx_user_blocks_blocked_id
+        ON user_blocks (blocked_id)
+    `);
+    console.log("user_blocks table created (or already exists)");
+  } catch (error) {
+    console.error("Error creating user_blocks table:", error);
+    throw error;
+  }
+};
+
+module.exports = createUserBlocks;

--- a/src/database/migrations/index.js
+++ b/src/database/migrations/index.js
@@ -7,6 +7,7 @@ const createMessageReads = require("./create_message_reads");
 const addMessageEditColumns = require("./add_message_edit_columns");
 const addReplyToId = require("./add_reply_to_id");
 const addLegalConsentToUsers = require("./add_legal_consent_to_users");
+const createUserBlocks = require("./create_user_blocks");
 
 const runMigrations = async () => {
   try {
@@ -17,6 +18,7 @@ const runMigrations = async () => {
     await addMessageEditColumns();
     await addReplyToId();
     await addLegalConsentToUsers();
+    await createUserBlocks();
 
     console.log("All migrations completed successfully!");
   } catch (error) {

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -197,6 +197,72 @@ const userModel = {
   async verifyPassword(password, hash) {
     return bcrypt.compare(password, hash);
   },
+
+  // ==============================
+  // USER BLOCKS
+  // ==============================
+  async blockUser(blockerId, blockedId) {
+    await db.query(
+      `INSERT INTO user_blocks (blocker_id, blocked_id)
+       VALUES ($1, $2)
+       ON CONFLICT (blocker_id, blocked_id) DO NOTHING`,
+      [blockerId, blockedId],
+    );
+  },
+
+  async unblockUser(blockerId, blockedId) {
+    await db.query(
+      `DELETE FROM user_blocks
+       WHERE blocker_id = $1 AND blocked_id = $2`,
+      [blockerId, blockedId],
+    );
+  },
+
+  // Users that `blockerId` has blocked (these are the ones they can unblock),
+  // returned with the card fields the blocklist UI needs, newest first.
+  async getBlockedUsers(blockerId) {
+    const result = await db.query(
+      `SELECT u.id, u.username, u.first_name, u.last_name, u.avatar_url,
+              u.city, u.country, u.is_public, u.is_synthetic, ub.created_at,
+              COALESCE((
+                SELECT json_agg(t.name ORDER BY t.name ASC)
+                FROM teams t
+                JOIN team_members tm1 ON t.id = tm1.team_id AND tm1.user_id = ub.blocker_id
+                JOIN team_members tm2 ON t.id = tm2.team_id AND tm2.user_id = ub.blocked_id
+                WHERE t.archived_at IS NULL
+              ), '[]'::json) AS shared_teams
+       FROM user_blocks ub
+       JOIN users u ON u.id = ub.blocked_id
+       WHERE ub.blocker_id = $1
+       ORDER BY ub.created_at DESC`,
+      [blockerId],
+    );
+    return result.rows;
+  },
+
+  // Every user id in a block relationship with `userId` in EITHER direction —
+  // used to mutually hide/anonymize profiles across the app.
+  async getBlockRelationshipIds(userId) {
+    const result = await db.query(
+      `SELECT blocked_id AS id FROM user_blocks WHERE blocker_id = $1
+       UNION
+       SELECT blocker_id AS id FROM user_blocks WHERE blocked_id = $1`,
+      [userId],
+    );
+    return result.rows.map((row) => row.id);
+  },
+
+  // True when either user has blocked the other.
+  async isBlockedBetween(a, b) {
+    const result = await db.query(
+      `SELECT 1 FROM user_blocks
+       WHERE (blocker_id = $1 AND blocked_id = $2)
+          OR (blocker_id = $2 AND blocked_id = $1)
+       LIMIT 1`,
+      [a, b],
+    );
+    return result.rows.length > 0;
+  },
 };
 
 module.exports = userModel;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -38,6 +38,36 @@ router.delete(
   userController.deleteAvatar,
 );
 
+// === User Blocks ===
+
+// GET /api/users/:id/blocks - List users the current user has blocked
+// Access: Private (self only)
+router.get(
+  "/:id/blocks",
+  auth.authenticateToken,
+  userController.getBlockedUsers,
+);
+
+// POST /api/users/:id/blocks - Block a user
+// Access: Private (self only)
+router.post("/:id/blocks", auth.authenticateToken, userController.blockUser);
+
+// DELETE /api/users/:id/blocks/:blockedId - Unblock a user
+// Access: Private (self only)
+router.delete(
+  "/:id/blocks/:blockedId",
+  auth.authenticateToken,
+  userController.unblockUser,
+);
+
+// GET /api/users/:id/block-relationships - Ids in a block relationship (either direction)
+// Access: Private (self only)
+router.get(
+  "/:id/block-relationships",
+  auth.authenticateToken,
+  userController.getBlockRelationships,
+);
+
 // === User-Specific Sub-Resources ===
 
 // GET /api/users/:id/teams - Get teams associated with a specific user

--- a/src/server.js
+++ b/src/server.js
@@ -8,7 +8,15 @@ const http = require("http");
 const socketIo = require("socket.io");
 const { verifyToken } = require("./utils/jwtUtils");
 const db = require("./config/database");
+const userModel = require("./models/userModel");
 const PORT = process.env.PORT || 5001;
+
+// Socket rooms (`user:<id>`) to exclude when delivering `senderId`'s realtime
+// events, so blocked users never see each other's messages/typing in team chats.
+const getBlockedUserRooms = async (senderId) => {
+  const ids = await userModel.getBlockRelationshipIds(senderId);
+  return ids.map((id) => `user:${id}`);
+};
 
 const CHAT_FILE_RETENTION_DAYS = 60;
 
@@ -31,6 +39,11 @@ const isActiveTeamMember = async (teamId, userId) => {
 };
 
 const hasDirectConversationAccess = async (userId, conversationId) => {
+  // A block (either direction) revokes access to the DM conversation entirely.
+  if (await userModel.isBlockedBetween(userId, conversationId)) {
+    return false;
+  }
+
   const result = await db.query(
     `SELECT 1
      FROM messages
@@ -378,11 +391,23 @@ io.on("connection", (socket) => {
           type: "team",
         };
 
-        io.to(`team:${conversationId}`).emit("message:received", message);
+        const blockedRooms = await getBlockedUserRooms(userId);
+        const teamEmitter =
+          blockedRooms.length > 0
+            ? io.to(`team:${conversationId}`).except(blockedRooms)
+            : io.to(`team:${conversationId}`);
+        teamEmitter.emit("message:received", message);
       } else {
         const recipientExists = await userExists(conversationId);
         if (!recipientExists) {
           socket.emit("error", { message: "Recipient not found" });
+          return;
+        }
+
+        if (await userModel.isBlockedBetween(userId, conversationId)) {
+          socket.emit("error", {
+            message: "You can no longer message this user",
+          });
           return;
         }
 
@@ -551,8 +576,14 @@ io.on("connection", (socket) => {
         return;
       }
 
-      // For team messages, broadcast to all team members except sender
-      socket.to(`team:${conversationId}`).emit("typing:update", {
+      // For team messages, broadcast to all team members except sender and
+      // anyone in a block relationship with the typing user.
+      const blockedRooms = await getBlockedUserRooms(userId);
+      const typingEmitter =
+        blockedRooms.length > 0
+          ? socket.to(`team:${conversationId}`).except(blockedRooms)
+          : socket.to(`team:${conversationId}`);
+      typingEmitter.emit("typing:update", {
         conversationId: String(conversationId),
         userId,
         username: socket.username,
@@ -593,8 +624,14 @@ io.on("connection", (socket) => {
         return;
       }
 
-      // For team messages, broadcast to all team members except sender
-      socket.to(`team:${conversationId}`).emit("typing:update", {
+      // For team messages, broadcast to all team members except sender and
+      // anyone in a block relationship with the typing user.
+      const blockedRooms = await getBlockedUserRooms(userId);
+      const typingEmitter =
+        blockedRooms.length > 0
+          ? socket.to(`team:${conversationId}`).except(blockedRooms)
+          : socket.to(`team:${conversationId}`);
+      typingEmitter.emit("typing:update", {
         conversationId: String(conversationId),
         userId,
         username: socket.username,
@@ -691,9 +728,15 @@ io.on("connection", (socket) => {
           [conversationId, userId],
         );
 
-        // Emit read status update to the team room
+        // Emit read status update to the team room (excluding blocked users so
+        // the reader's identity stays hidden from anyone they've blocked).
         if (readStatusResult.rows.length > 0) {
-          socket.to(`team:${conversationId}`).emit("message:status", {
+          const blockedRooms = await getBlockedUserRooms(userId);
+          const readEmitter =
+            blockedRooms.length > 0
+              ? socket.to(`team:${conversationId}`).except(blockedRooms)
+              : socket.to(`team:${conversationId}`);
+          readEmitter.emit("message:status", {
             conversationId: String(conversationId),
             type: "team",
             readBy: userId,


### PR DESCRIPTION
## Summary

Adds backend support for user blocking.

- Adds a `user_blocks` migration with a composite primary key, self-block prevention, cascade cleanup, and reverse lookup index
- Adds self-only blocklist endpoints under `/api/users/:id` for listing, blocking, unblocking, and fetching mutual block relationship IDs
- Hides blocked relationships from auth-aware profile and user search results
- Filters blocked users out of team application visibility and pending application counts
- Prevents direct messages when either user has blocked the other
- Excludes blocked users from relevant team chat Socket.IO broadcasts, including messages, typing indicators, and read receipts
- Emits `blocks:updated` so both affected clients can refresh block state in realtime
- Updates the backend README with the new routes, search behavior, realtime event, and security notes

## Testing

- `node --test test/searchController.test.js` passed
- `git diff --check dev...HEAD` passed
- `npm test` currently fails: 46 passed, 7 failed in invitation, delete-user, and vacant-role suites due SQL stub / expected payload mismatches