### PR TITLE
Enforce contact attachment limits server-side

### DIFF
--- a/src/controllers/contactController.js
+++ b/src/controllers/contactController.js
@@ -1,6 +1,7 @@
 const Joi = require("joi");
 const emailService = require("../services/emailService");
 const { verifyTurnstileToken } = require("../utils/turnstileVerify");
+const { validateContactAttachments } = require("../utils/contactAttachments");
 
 const contactSchema = Joi.object({
   name: Joi.string().trim().min(1).max(120).required(),
@@ -29,6 +30,14 @@ const contactController = {
           success: false,
           message: "Invalid input data",
           errors: error.details.map((detail) => detail.message),
+        });
+      }
+
+      const attachmentValidation = validateContactAttachments(req.files);
+      if (!attachmentValidation.valid) {
+        return res.status(400).json({
+          success: false,
+          message: attachmentValidation.error,
         });
       }
 

--- a/src/routes/contactRoutes.js
+++ b/src/routes/contactRoutes.js
@@ -3,30 +3,63 @@ const router = express.Router();
 const multer = require("multer");
 const contactController = require("../controllers/contactController");
 const { contactLimiter } = require("../middlewares/rateLimiter");
-const { FILE_LIMITS, ALLOWED_EXTENSIONS } = require("../utils/fileValidation");
-
-const CONTACT_ALLOWED_EXTENSIONS = new Set([
-  ...ALLOWED_EXTENSIONS.chatImage,
-  ...ALLOWED_EXTENSIONS.chatFile,
-]);
+const {
+  CONTACT_ATTACHMENT_LIMITS,
+  CONTACT_ATTACHMENT_MAX_MB,
+  validateContactAttachmentFile,
+} = require("../utils/contactAttachments");
 
 const contactUpload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: FILE_LIMITS.chatFile },
+  limits: {
+    fileSize: CONTACT_ATTACHMENT_LIMITS.maxBytesPerFile,
+    files: CONTACT_ATTACHMENT_LIMITS.maxFiles,
+  },
   fileFilter: (req, file, cb) => {
-    const ext = "." + file.originalname.split(".").pop().toLowerCase();
-    if (CONTACT_ALLOWED_EXTENSIONS.has(ext)) {
-      cb(null, true);
+    const error = validateContactAttachmentFile(file);
+    if (error) {
+      cb(new Error(error), false);
     } else {
-      cb(new Error("File type not supported."), false);
+      cb(null, true);
     }
   },
 });
 
+const uploadContactAttachments = contactUpload.array(
+  "attachments",
+  CONTACT_ATTACHMENT_LIMITS.maxFiles,
+);
+
+// Wrap multer so its errors return a clean 400 instead of a generic 500.
+const handleContactUpload = (req, res, next) => {
+  uploadContactAttachments(req, res, (err) => {
+    if (!err) {
+      return next();
+    }
+
+    let message = "Attachment upload failed.";
+
+    if (err instanceof multer.MulterError) {
+      if (err.code === "LIMIT_FILE_SIZE") {
+        message = `Each file must be ${CONTACT_ATTACHMENT_MAX_MB} MB or smaller.`;
+      } else if (
+        err.code === "LIMIT_FILE_COUNT" ||
+        err.code === "LIMIT_UNEXPECTED_FILE"
+      ) {
+        message = `You can attach up to ${CONTACT_ATTACHMENT_LIMITS.maxFiles} files.`;
+      }
+    } else if (err.message) {
+      message = err.message;
+    }
+
+    return res.status(400).json({ success: false, message });
+  });
+};
+
 router.post(
   "/",
   contactLimiter,
-  contactUpload.array("attachments", 5),
+  handleContactUpload,
   contactController.submitContactForm,
 );
 

--- a/src/utils/contactAttachments.js
+++ b/src/utils/contactAttachments.js
@@ -1,0 +1,167 @@
+// Contact form attachment rules - keep in sync with the frontend hardening in
+// Lomir-frontend/src/pages/Contact.jsx. These are the server-side enforcement
+// of the same limits so the rules cannot be bypassed by skipping the UI.
+
+const MEGABYTE = 1024 * 1024;
+
+const CONTACT_ATTACHMENT_LIMITS = {
+  maxFiles: 3,
+  maxBytesPerFile: 5 * MEGABYTE,
+  maxTotalBytes: 10 * MEGABYTE,
+};
+
+const CONTACT_ATTACHMENT_MAX_MB = CONTACT_ATTACHMENT_LIMITS.maxBytesPerFile / MEGABYTE;
+const CONTACT_ATTACHMENT_TOTAL_MAX_MB = CONTACT_ATTACHMENT_LIMITS.maxTotalBytes / MEGABYTE;
+
+const CONTACT_ALLOWED_LABEL = "JPG, PNG, WebP, PDF, TXT, CSV";
+
+const CONTACT_ALLOWED_FILE_TYPES = [
+  {
+    extensions: [".jpg", ".jpeg"],
+    mimeTypes: ["image/jpeg", "image/pjpeg"],
+  },
+  {
+    extensions: [".png"],
+    mimeTypes: ["image/png", "image/x-png"],
+  },
+  {
+    extensions: [".webp"],
+    mimeTypes: ["image/webp"],
+  },
+  {
+    extensions: [".pdf"],
+    mimeTypes: ["application/pdf", "application/x-pdf"],
+  },
+  {
+    extensions: [".txt"],
+    mimeTypes: ["text/plain"],
+  },
+  {
+    extensions: [".csv"],
+    mimeTypes: [
+      "text/csv",
+      "application/csv",
+      "application/vnd.ms-excel",
+      "text/plain",
+    ],
+  },
+];
+
+const CONTACT_ALLOWED_BY_EXTENSION = CONTACT_ALLOWED_FILE_TYPES.reduce(
+  (map, fileType) => {
+    fileType.extensions.forEach((extension) => {
+      map.set(extension, new Set(fileType.mimeTypes));
+    });
+    return map;
+  },
+  new Map(),
+);
+
+const getFileExtension = (fileName = "") => {
+  const match = fileName.toLowerCase().match(/\.[^.]+$/);
+  return match ? match[0] : "";
+};
+
+const hasUnsafeFileName = (fileName = "") => {
+  const trimmedFileName = fileName.trim();
+
+  return (
+    !trimmedFileName ||
+    fileName.length > 120 ||
+    trimmedFileName.startsWith(".") ||
+    /[\u0000-\u001f\u007f/\\]/.test(fileName)
+  );
+};
+
+const isAllowedAttachmentType = (fileName, mimeType) => {
+  const extension = getFileExtension(fileName);
+  const allowedMimeTypes = CONTACT_ALLOWED_BY_EXTENSION.get(extension);
+
+  if (!allowedMimeTypes) {
+    return false;
+  }
+
+  const normalizedMimeType = (mimeType || "").toLowerCase();
+  return !normalizedMimeType || allowedMimeTypes.has(normalizedMimeType);
+};
+
+/**
+ * Per-file validation used by the multer fileFilter (name + type only - the
+ * file size is not yet known at the fileFilter stage).
+ * @param {{ originalname: string, mimetype: string }} file
+ * @returns {string} empty string when valid, otherwise an error message
+ */
+const validateContactAttachmentFile = (file) => {
+  if (hasUnsafeFileName(file.originalname)) {
+    return "File name is not supported.";
+  }
+
+  if (!isAllowedAttachmentType(file.originalname, file.mimetype)) {
+    return `File type not supported. Accepted: ${CONTACT_ALLOWED_LABEL}.`;
+  }
+
+  return "";
+};
+
+/**
+ * Full validation of the uploaded files, run in the controller after multer
+ * has parsed the request. Enforces count, per-file size, empty files and the
+ * combined total size that multer cannot check on its own.
+ * @param {Array<{ originalname: string, mimetype: string, size: number }>} files
+ * @returns {{ valid: boolean, error?: string }}
+ */
+const validateContactAttachments = (files = []) => {
+  if (!files || files.length === 0) {
+    return { valid: true };
+  }
+
+  if (files.length > CONTACT_ATTACHMENT_LIMITS.maxFiles) {
+    return {
+      valid: false,
+      error: `You can attach up to ${CONTACT_ATTACHMENT_LIMITS.maxFiles} files.`,
+    };
+  }
+
+  let totalBytes = 0;
+
+  for (const file of files) {
+    const fileError = validateContactAttachmentFile(file);
+    if (fileError) {
+      return { valid: false, error: `${file.originalname}: ${fileError}` };
+    }
+
+    if (!file.size || file.size <= 0) {
+      return {
+        valid: false,
+        error: `${file.originalname}: File is empty and cannot be attached.`,
+      };
+    }
+
+    if (file.size > CONTACT_ATTACHMENT_LIMITS.maxBytesPerFile) {
+      return {
+        valid: false,
+        error: `${file.originalname}: Each file must be ${CONTACT_ATTACHMENT_MAX_MB} MB or smaller.`,
+      };
+    }
+
+    totalBytes += file.size;
+  }
+
+  if (totalBytes > CONTACT_ATTACHMENT_LIMITS.maxTotalBytes) {
+    return {
+      valid: false,
+      error: `Attachments must be ${CONTACT_ATTACHMENT_TOTAL_MAX_MB} MB total or smaller.`,
+    };
+  }
+
+  return { valid: true };
+};
+
+module.exports = {
+  CONTACT_ATTACHMENT_LIMITS,
+  CONTACT_ATTACHMENT_MAX_MB,
+  CONTACT_ATTACHMENT_TOTAL_MAX_MB,
+  CONTACT_ALLOWED_LABEL,
+  validateContactAttachmentFile,
+  validateContactAttachments,
+};


### PR DESCRIPTION
Summary
This branch bundles a round of security hardening, the new user-blocking feature, legal-consent tracking, and several auth/profile-privacy and contact-form improvements for the Lomir backend.

Highlights
User blocking (feature/BlockUsers)

New user_blocks table (composite PK, ON DELETE CASCADE, self-block guard, reverse-lookup index) via [create_user_blocks.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/database/migrations/create_user_blocks.js)
Endpoints under /api/users/:id/blocks to list, block, unblock, and fetch block relationships — all self-only/authenticated ([userRoutes.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/routes/userRoutes.js), [userController.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/controllers/userController.js), [userModel.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/models/userModel.js))
Security hardening

Sanitized backend error responses via a shared [errorResponse.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/utils/errorResponse.js) helper (+ tests)
Login no longer leaks whether email vs. password failed
Removed sensitive email data from JWT payloads ([jwtUtils.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/utils/jwtUtils.js))
Tightened authorization, file validation, and data exposure across controllers and the WebSocket layer
Account-deletion system messages are now anonymized
Profile privacy

New profiles are hidden by default until email is verified, and stay private after verification until the user opts in
Legal consent

Versioned legal-consent captured at registration ([add_legal_consent_to_users.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/database/migrations/add_legal_consent_to_users.js), [legalDocuments.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/config/legalDocuments.js), + model tests)
Contact form & email

New /api/contact endpoint with SMTP delivery and multi-file attachments, with server-side attachment count/size limits ([contactController.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/controllers/contactController.js), [contactAttachments.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/utils/contactAttachments.js))
Accounts & jobs

Scheduled cleanup of expired unverified accounts ([cleanupUnverifiedAccounts.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/jobs/cleanupUnverifiedAccounts.js)); email/username availability checks; restored email-verification enforcement
Search & geocoding

Open role names included in team responses; geocoding/location-derivation refactor ([locationDerivation.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/utils/locationDerivation.js), backfill script, + tests)
Testing
Adds/updates tests for login behavior, error sanitization, legal consent, location derivation, search, and user deletion.

A note: this branch is quite far ahead of main and contains several already-merged PRs (#250 blocking, #251 privacy notice, etc.), so the diff spans many themes rather than just blocking. If you intended this PR to cover only one feature, let me know which and I'll scope the description to those commits.