### PR TITLE
Harden auth endpoints against email enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ All routes are prefixed with `/api`.
 
 | Prefix | Description |
 |---|---|
-| `/api/auth` | Register (requires `acceptedTerms`, `acceptedPrivacy`, `confirmedAge16`), login, email verification, password reset; `POST /auth/check-email` and `/auth/check-username` for real-time availability checks |
+| `/api/auth` | Register (requires `acceptedTerms`, `acceptedPrivacy`, `confirmedAge16`), login, email verification, password reset; `POST /auth/check-username` for rate-limited username availability checks |
 | `/api/users` | User CRUD, tags, badges, avatar, self-only blocklist endpoints, account deletion with preview |
 | `/api/teams` | Team CRUD, members, applications, invitations, badge awards; `DELETE /invitations/:id/role` cancels only the role portion of a pending invitation |
 | `/api/teams/:teamId/vacant-roles` | Vacant role CRUD and status management. Supports `?ids=1,2,3` for bulk filtering (bypasses the default status filter so polling can detect roles that transitioned to filled/closed). Role responses include `is_public` on the `creator` and `filled_by` user sub-objects. |

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -62,7 +62,30 @@ const loginSchema = Joi.object({
   password: Joi.string().min(6).required(),
 });
 
+const usernameAvailabilitySchema = Joi.object({
+  username: Joi.string().alphanum().min(3).max(30).required(),
+});
+
 const INVALID_LOGIN_MESSAGE = "Invalid email or password";
+const GENERIC_REGISTRATION_VERIFICATION_MESSAGE =
+  "If this email address can be used for registration, a verification link will be sent.";
+const GENERIC_RESEND_VERIFICATION_MESSAGE =
+  "If an account exists with this email and still needs verification, a verification link will be sent.";
+
+const sendGenericRegistrationVerificationResponse = (res) =>
+  res.status(201).json({
+    success: true,
+    message: GENERIC_REGISTRATION_VERIFICATION_MESSAGE,
+    data: {
+      requiresVerification: true,
+    },
+  });
+
+const sendGenericResendVerificationResponse = (res) =>
+  res.status(200).json({
+    success: true,
+    message: GENERIC_RESEND_VERIFICATION_MESSAGE,
+  });
 
 const authController = {
   /**
@@ -158,10 +181,7 @@ const authController = {
       ]);
 
       if (existingUserByEmail) {
-        return res.status(400).json({
-          success: false,
-          message: "User with this email already exists",
-        });
+        return sendGenericRegistrationVerificationResponse(res);
       }
 
       if (existingUserByUsername) {
@@ -281,21 +301,8 @@ const authController = {
         // Still return success - user was created, they can request a new email
       }
 
-      // Return success WITHOUT a JWT token (user must verify email first)
-      res.status(201).json({
-        success: true,
-        message:
-          "Registration successful! Please check your email to verify your account.",
-        data: {
-          requiresVerification: true,
-          user: {
-            id: user.id,
-            username: user.username,
-            email: user.email,
-            is_synthetic: user.is_synthetic,
-          },
-        },
-      });
+      // Return success WITHOUT a JWT token (user must verify email first).
+      return sendGenericRegistrationVerificationResponse(res);
     } catch (error) {
       console.error("Registration error:", error);
 
@@ -311,10 +318,7 @@ const authController = {
         }
 
         if (constraint === "users_email_unique_ci") {
-          return res.status(400).json({
-            success: false,
-            message: "User with this email already exists",
-          });
+          return sendGenericRegistrationVerificationResponse(res);
         }
 
         return res.status(400).json({
@@ -332,54 +336,20 @@ const authController = {
     }
   },
 
-  async checkEmail(req, res) {
-    try {
-      const { email } = req.body;
-
-      if (!email) {
-        return res.status(400).json({
-          success: false,
-          message: "Email is required",
-        });
-      }
-
-      const result = await db.query(
-        `SELECT id FROM users WHERE LOWER(email) = LOWER($1)`,
-        [email],
-      );
-
-      const available = result.rows.length === 0;
-
-      res.status(200).json({
-        success: true,
-        available,
-        ...(available
-          ? {}
-          : { message: "This email address is already registered." }),
-      });
-    } catch (error) {
-      console.error("Check email error:", error);
-      res.status(500).json({
-        success: false,
-        message: "Error checking email availability",
-      });
-    }
-  },
-
   async checkUsername(req, res) {
     try {
-      const { username } = req.body;
+      const { error, value } = usernameAvailabilitySchema.validate(req.body);
 
-      if (!username) {
+      if (error) {
         return res.status(400).json({
           success: false,
-          message: "Username is required",
+          message: "Invalid username format",
         });
       }
 
       const result = await db.query(
         `SELECT id FROM users WHERE LOWER(username) = LOWER($1)`,
-        [username],
+        [value.username],
       );
 
       const available = result.rows.length === 0;
@@ -486,22 +456,14 @@ const authController = {
       );
 
       if (result.rows.length === 0) {
-        // Don't reveal if email exists or not
-        return res.status(200).json({
-          success: true,
-          message:
-            "If an account exists with this email, a verification link has been sent.",
-        });
+        return sendGenericResendVerificationResponse(res);
       }
 
       const user = result.rows[0];
 
       // Check if already verified
       if (user.email_verified) {
-        return res.status(400).json({
-          success: false,
-          message: "Email is already verified. You can log in.",
-        });
+        return sendGenericResendVerificationResponse(res);
       }
 
       // Generate new verification token
@@ -525,17 +487,9 @@ const authController = {
 
       if (!emailResult.success) {
         console.error("Failed to resend verification email");
-        return res.status(500).json({
-          success: false,
-          message: "Failed to send verification email. Please try again later.",
-        });
       }
 
-      res.status(200).json({
-        success: true,
-        message:
-          "If an account exists with this email, a verification link has been sent.",
-      });
+      return sendGenericResendVerificationResponse(res);
     } catch (error) {
       console.error("Resend verification error:", error);
       res.status(500).json({

--- a/src/middlewares/rateLimiter.js
+++ b/src/middlewares/rateLimiter.js
@@ -28,6 +28,12 @@ const registerLimiter = createRateLimiter({
   message: "Too many registration attempts. Please try again later.",
 });
 
+const usernameAvailabilityLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 20,
+  message: "Too many username checks. Please try again later.",
+});
+
 const contactLimiter = createRateLimiter({
   windowMs: 60 * 60 * 1000,
   max: 5,
@@ -37,5 +43,6 @@ const contactLimiter = createRateLimiter({
 module.exports = {
   authLimiter,
   registerLimiter,
+  usernameAvailabilityLimiter,
   contactLimiter,
 };

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -3,7 +3,11 @@ const router = express.Router();
 
 const authController = require("../controllers/authController");
 const auth = require("../middlewares/auth");
-const { authLimiter, registerLimiter } = require("../middlewares/rateLimiter");
+const {
+  authLimiter,
+  registerLimiter,
+  usernameAvailabilityLimiter,
+} = require("../middlewares/rateLimiter");
 const { upload } = require("../middlewares/uploadMiddleware");
 
 // Register a new user (with optional avatar upload)
@@ -17,8 +21,11 @@ router.post(
 // Login existing user
 router.post("/login", authLimiter, authController.login);
 
-router.post("/check-email", authLimiter, authController.checkEmail);
-router.post("/check-username", authLimiter, authController.checkUsername);
+router.post(
+  "/check-username",
+  usernameAvailabilityLimiter,
+  authController.checkUsername,
+);
 
 // Email verification routes (query-param based: /verify-email?token=...)
 router.get("/verify-email", authController.verifyEmail);

--- a/test/authController.login.test.js
+++ b/test/authController.login.test.js
@@ -3,9 +3,17 @@ const assert = require("node:assert/strict");
 
 const authController = require("../src/controllers/authController");
 const userModel = require("../src/models/userModel");
+const emailService = require("../src/services/emailService");
+const db = require("../src/config/database");
 
 const originalFindByEmail = userModel.findByEmail;
+const originalFindByUsername = userModel.findByUsername;
 const originalVerifyPassword = userModel.verifyPassword;
+const originalCreateUser = userModel.createUser;
+const originalSendVerificationEmail = emailService.sendVerificationEmail;
+const originalDbQuery = db.query;
+const originalTurnstileSecret = process.env.TURNSTILE_SECRET_KEY;
+const originalConsoleError = console.error;
 
 const createResponse = () => ({
   statusCode: 200,
@@ -28,9 +36,32 @@ const createLoginRequest = (overrides = {}) => ({
   },
 });
 
+const createRegisterRequest = (overrides = {}) => ({
+  body: {
+    username: "janedoe",
+    email: "jane@example.com",
+    password: "secret123",
+    acceptedTerms: true,
+    acceptedPrivacy: true,
+    confirmedAge16: true,
+    ...overrides,
+  },
+});
+
 test.afterEach(() => {
   userModel.findByEmail = originalFindByEmail;
+  userModel.findByUsername = originalFindByUsername;
   userModel.verifyPassword = originalVerifyPassword;
+  userModel.createUser = originalCreateUser;
+  emailService.sendVerificationEmail = originalSendVerificationEmail;
+  db.query = originalDbQuery;
+  console.error = originalConsoleError;
+
+  if (originalTurnstileSecret === undefined) {
+    delete process.env.TURNSTILE_SECRET_KEY;
+  } else {
+    process.env.TURNSTILE_SECRET_KEY = originalTurnstileSecret;
+  }
 });
 
 test("login returns a generic credential error when the email is unknown", async () => {
@@ -111,4 +142,143 @@ test("login asks for email verification only after the password is correct", asy
   assert.equal(res.body.success, false);
   assert.equal(res.body.requiresVerification, true);
   assert.match(res.body.message, /verify your email/i);
+});
+
+test("register returns a generic verification response when the email cannot create a new account", async () => {
+  delete process.env.TURNSTILE_SECRET_KEY;
+  userModel.findByEmail = async () => ({
+    id: 7,
+    email: "jane@example.com",
+    email_verified: true,
+  });
+  userModel.findByUsername = async () => null;
+  userModel.createUser = async () => {
+    throw new Error("createUser should not be called for an existing email");
+  };
+  db.query = async () => {
+    throw new Error("db.query should not be called for an existing email");
+  };
+
+  const res = createResponse();
+
+  await authController.register(createRegisterRequest(), res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.requiresVerification, true);
+  assert.equal(res.body.data.user, undefined);
+  assert.doesNotMatch(res.body.message, /already|exists|registered/i);
+});
+
+test("register returns the same generic verification response for a new account", async () => {
+  delete process.env.TURNSTILE_SECRET_KEY;
+  userModel.findByEmail = async () => null;
+  userModel.findByUsername = async () => null;
+  userModel.createUser = async (userData) => {
+    assert.equal(userData.email, "jane@example.com");
+    return {
+      id: 8,
+      username: "janedoe",
+      email: "jane@example.com",
+      is_synthetic: false,
+    };
+  };
+  db.query = async (sql) => {
+    assert.match(String(sql), /UPDATE users/i);
+    return { rows: [], rowCount: 1 };
+  };
+  emailService.sendVerificationEmail = async () => ({ success: true });
+
+  const res = createResponse();
+
+  await authController.register(createRegisterRequest(), res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.requiresVerification, true);
+  assert.equal(res.body.data.user, undefined);
+  assert.doesNotMatch(res.body.message, /already|exists|registered/i);
+});
+
+test("resendVerification returns a generic success when the account is already verified", async () => {
+  db.query = async () => ({
+    rows: [
+      {
+        id: 7,
+        username: "janedoe",
+        email: "jane@example.com",
+        email_verified: true,
+      },
+    ],
+  });
+  emailService.sendVerificationEmail = async () => {
+    throw new Error("sendVerificationEmail should not be called");
+  };
+
+  const res = createResponse();
+
+  await authController.resendVerification(
+    { body: { email: "jane@example.com" } },
+    res,
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.doesNotMatch(res.body.message, /already|verified|log in/i);
+});
+
+test("resendVerification returns the same generic success when the account is unknown", async () => {
+  db.query = async () => ({ rows: [] });
+  emailService.sendVerificationEmail = async () => {
+    throw new Error("sendVerificationEmail should not be called");
+  };
+
+  const res = createResponse();
+
+  await authController.resendVerification(
+    { body: { email: "jane@example.com" } },
+    res,
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.doesNotMatch(res.body.message, /already|verified|log in/i);
+});
+
+test("resendVerification stays generic when verification email delivery fails", async () => {
+  console.error = () => {};
+  db.query = async (sql) => {
+    const query = String(sql);
+
+    if (/FROM users/i.test(query)) {
+      return {
+        rows: [
+          {
+            id: 7,
+            username: "janedoe",
+            email: "jane@example.com",
+            email_verified: false,
+          },
+        ],
+      };
+    }
+
+    if (/UPDATE users/i.test(query)) {
+      return { rows: [], rowCount: 1 };
+    }
+
+    throw new Error(`Unexpected SQL: ${query}`);
+  };
+  emailService.sendVerificationEmail = async () => ({ success: false });
+
+  const res = createResponse();
+
+  await authController.resendVerification(
+    { body: { email: "jane@example.com" } },
+    res,
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.doesNotMatch(res.body.message, /failed|already|verified|log in/i);
 });


### PR DESCRIPTION
## Summary

- Removed the public `/api/auth/check-email` route.
- Kept `/api/auth/check-username` available with a dedicated rate limiter and server-side username format validation.
- Made registration responses generic when an email address cannot create a new account.
- Made resend-verification responses generic for unknown, already verified, and mail-delivery-failure cases.
- Updated auth route documentation and added focused AuthController regression tests.

## Testing

- Ran `node --test test/authController.login.test.js` successfully.
- Ran the full backend test suite; unrelated Invitation/VacantRole test stubs still fail, while the auth tests pass.
- Manually smoke-tested that `/check-email` is no longer called by the frontend and email existence is not revealed during registration/resend flows.