### PR TITLE
Rate-limit and cache public geocoding lookups

### DIFF
--- a/src/middlewares/rateLimiter.js
+++ b/src/middlewares/rateLimiter.js
@@ -40,9 +40,18 @@ const contactLimiter = createRateLimiter({
   message: "Too many messages. Please try again later.",
 });
 
+// Public postal-code lookup. Generous enough for typing-driven autofill, but
+// caps abuse of the endpoint and its upstream Nominatim (OSM) usage.
+const geocodingLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  message: "Too many location lookups. Please try again later.",
+});
+
 module.exports = {
   authLimiter,
   registerLimiter,
   usernameAvailabilityLimiter,
   contactLimiter,
+  geocodingLimiter,
 };

--- a/src/routes/geocodingRoutes.js
+++ b/src/routes/geocodingRoutes.js
@@ -1,7 +1,38 @@
 const express = require("express");
 const axios = require("axios");
 const { deriveLocationFromPostalCode } = require("../utils/locationDerivation");
+const { geocodingLimiter } = require("../middlewares/rateLimiter");
 const router = express.Router();
+
+// In-memory cache for postal-code lookups. Reduces duplicate outbound calls to
+// the Nominatim (OSM) service for repeated postal codes, which both respects
+// their usage policy and limits how often user-entered locations leave the
+// server. Entries expire after the TTL; the map is bounded to cap memory use.
+const GEOCODE_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const GEOCODE_CACHE_MAX_ENTRIES = 1000;
+const geocodeCache = new Map();
+
+function getCachedLocation(key) {
+  const entry = geocodeCache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    geocodeCache.delete(key);
+    return null;
+  }
+  return entry.value;
+}
+
+function setCachedLocation(key, value) {
+  // Evict the oldest entry once the cache is full (Map preserves insertion order).
+  if (geocodeCache.size >= GEOCODE_CACHE_MAX_ENTRIES) {
+    const oldestKey = geocodeCache.keys().next().value;
+    geocodeCache.delete(oldestKey);
+  }
+  geocodeCache.set(key, {
+    value,
+    expiresAt: Date.now() + GEOCODE_CACHE_TTL_MS,
+  });
+}
 
 // Helper function to detect country from postal code
 function detectCountryCode(postalCode) {
@@ -62,7 +93,7 @@ const postalCodeMapping = {
   "110 00": { city: "Prague", country: "Czech Republic" },
 };
 
-router.get("/postal-code/:code", async (req, res) => {
+router.get("/postal-code/:code", geocodingLimiter, async (req, res) => {
   try {
     const { code } = req.params;
     const requestedCountry = req.query.country || null;
@@ -72,6 +103,15 @@ router.get("/postal-code/:code", async (req, res) => {
       console.log(
         `Geocoding request for postal code: ${code}, detected country: ${detectedCountry}`
       );
+    }
+
+    const cacheKey = `${code}|${detectedCountry}`;
+    const cachedLocation = getCachedLocation(cacheKey);
+    if (cachedLocation) {
+      if (process.env.NODE_ENV !== "production") {
+        console.log(`Cache hit for ${cacheKey}`);
+      }
+      return res.json(cachedLocation);
     }
 
     const derivedLocation = deriveLocationFromPostalCode(code, detectedCountry);
@@ -110,10 +150,12 @@ router.get("/postal-code/:code", async (req, res) => {
         longitude: null,
       };
 
+      setCachedLocation(cacheKey, locationInfo);
       return res.json(locationInfo);
     }
 
     // If not in mapping, try Nominatim with proper country code
+    let nominatimErrored = false;
     try {
       if (process.env.NODE_ENV !== "production") {
         console.log(
@@ -168,9 +210,11 @@ router.get("/postal-code/:code", async (req, res) => {
         if (process.env.NODE_ENV !== "production") {
           console.log(`Nominatim success for ${code}:`, locationInfo.displayName);
         }
+        setCachedLocation(cacheKey, locationInfo);
         return res.json(locationInfo);
       }
     } catch (nominatimError) {
+      nominatimErrored = true;
       if (process.env.NODE_ENV !== "production") {
         console.log(`Nominatim failed for ${code}:`, nominatimError.message);
       }
@@ -180,14 +224,20 @@ router.get("/postal-code/:code", async (req, res) => {
     if (process.env.NODE_ENV !== "production") {
       console.log(`No geocoding results found for postal code: ${code}`);
     }
-    res.json({
+    const fallbackLocation = {
       city: null,
       state: null,
       country: null,
       displayName: code, // Just show the postal code
       latitude: null,
       longitude: null,
-    });
+    };
+    // Cache a definitive "no result" (Nominatim returned nothing), but never a
+    // transient failure (timeout/error), so lookups can succeed once it recovers.
+    if (!nominatimErrored) {
+      setCachedLocation(cacheKey, fallbackLocation);
+    }
+    res.json(fallbackLocation);
   } catch (error) {
     console.error("Geocoding service error:", error.message);
 


### PR DESCRIPTION
Summary
Hardens the public postal-code lookup endpoint (GET /api/geocoding/postal-code/:code) with a per-IP rate limiter and an in-memory TTL cache. Previously this unauthenticated endpoint had no rate limiting and called the upstream Nominatim (OSM) service on every cache-miss, with no reuse of results.

Motivation
Abuse / cost protection: An open, unauthenticated endpoint that proxies a third-party service can be hammered without limit.
Upstream usage policy: Nominatim's usage policy expects low request volumes and discourages repeated identical queries — caching reduces our outbound calls.
Privacy (data minimisation): User-entered postal codes are sent to a third party. Caching means a repeated code does not leave the server again for the duration of the cache entry.
Changes
[rateLimiter.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/middlewares/rateLimiter.js)

New geocodingLimiter: 60 requests / 15 min per IP, reusing the existing createRateLimiter factory and the shared 429 JSON response shape.
[geocodingRoutes.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/routes/geocodingRoutes.js)

Apply geocodingLimiter to the postal-code route.
Add a bounded in-memory cache (Map, 24 h TTL, max 1000 entries with oldest-entry eviction), keyed by code|country.
Serve cache hits immediately; cache successful resolutions from both the internal mapping and Nominatim.
Do not cache transient Nominatim failures (timeout/exception) — only definitive "no result" responses — so lookups recover automatically once the service is reachable again.
Notes
Per-IP limiting is correct behind the hosting proxy because app.set("trust proxy", 1) is already configured ([app.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/app.js)).
The cache is process-local and resets on restart; this is intentional and sufficient for the current single-instance deployment.
No frontend change required — [geocodingService.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/Lomir-frontend/src/services/geocodingService.js) already handles failed/empty lookups gracefully, so a 429 simply skips autofill.
Testing
Verified the limiter returns 200 for the first 60 requests in a window and 429 thereafter (per-IP, resets on restart).
Verified cache behaviour via dev logs: a repeated postal code logs Cache hit … instead of issuing a second Nominatim request.
Confirmed location autofill still works unchanged for both mapped (e.g. 55116) and Nominatim-resolved (e.g. 04109) postal codes.