### PR TITLE
Use httpOnly session cookie for auth instead of localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Contact the project owner for a demo login, or register a new account with a val
 
 ## Features
 
-- **Authentication** — JWT-based registration, login, email verification, and password reset. Transactional auth emails are sent through Nodemailer SMTP. Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev). Registration requires explicit acceptance of Terms of Service, acknowledgement of the Privacy Policy, and confirmation of minimum age (16+); the version of each legal document is stamped on the user row at sign-up.
+- **Authentication** — JWT-based registration, login, email verification, and password reset. The session JWT is delivered as an `httpOnly`, `sameSite` cookie (never in the response body or readable by frontend JavaScript); auth middleware and the Socket.IO handshake read it from the cookie, with the `Authorization: Bearer` header kept as a fallback for API clients. Transactional auth emails are sent through Nodemailer SMTP. Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev). Registration requires explicit acceptance of Terms of Service, acknowledgement of the Privacy Policy, and confirmation of minimum age (16+); the version of each legal document is stamped on the user row at sign-up.
 - **User Profiles** — CRUD with avatar uploads (ImageKit), interest tags, badge portfolios, and user-controlled public/private visibility. Verified accounts remain private by default until the user opts in to public visibility.
 - **User Blocking** — Authenticated users can manage a private blocklist. Block relationships hide profiles and user-search results where requester context is available, suppress team application visibility, disable direct messaging, and exclude blocked users from team chat realtime events where needed.
 - **Teams** — Create, join, manage members, assign roles, and archive teams
@@ -39,7 +39,7 @@ Contact the project owner for a demo login, or register a new account with a val
 - **Account Deletion** — Full transactional account deletion with impact preview, automatic team ownership transfer, role reopening, and "Former Lomir User" handling for preserved references
 - **Contact Form & Reports** — Public `/api/contact` endpoint with Joi validation, Turnstile CAPTCHA, in-memory file attachments (up to 3 files, 5 MB each, 10 MB total), and SMTP forwarding. Abuse/content reports are persisted in `contact_reports` with a reference ID before email forwarding, so reports are not lost if SMTP delivery fails; unexpected body fields are stripped defensively so multipart attachment fields cannot break validation; rate-limited to 5 submissions/hr
 - **Geocoding** — Location enrichment via Nominatim: resolves a full location object (postal code, city, district, state, country, coordinates) from partial input. Built-in postal-code-to-district lookup for Berlin and Frankfurt (200+ mappings) used as a fast offline fallback before the API call. Works with country alone — does not require both postal code and city.
-- **Security** — Helmet security headers, request body size cap (1 MB), rate limiting on auth and contact endpoints, CORS allowlist, password policy enforcement, Socket.IO conversation/message authorization, production error message scrubbing
+- **Security** — `httpOnly` cookie sessions (JWT not exposed to JavaScript), Helmet security headers, request body size cap (1 MB), rate limiting on auth, contact, and geocoding endpoints, credentialed CORS allowlist (applied before body parsing), password policy enforcement, Socket.IO conversation/message authorization, production error message scrubbing
 
 ---
 
@@ -212,7 +212,7 @@ Lomir-backend/
 │   │   └── api/
 │   │       └── tags.js
 │   ├── middlewares/
-│   │   ├── auth.js             # JWT authentication middleware
+│   │   ├── auth.js             # Reads the session JWT from the httpOnly cookie (Bearer header fallback)
 │   │   ├── rateLimiter.js      # Rate limiting for auth endpoints
 │   │   └── uploadMiddleware.js # Multer wrapper for file/image uploads
 │   ├── models/
@@ -225,6 +225,7 @@ Lomir-backend/
 │   │   ├── fileValidation.js
 │   │   ├── fileCleanup.js      # File expiry check + ImageKit deletion helpers (used by scheduler)
 │   │   ├── jwtUtils.js
+│   │   ├── authCookie.js       # httpOnly session-cookie set/clear options + handshake cookie parsing
 │   │   ├── locationDerivation.js # Offline postal-code → city/district/state lookup (Berlin, Frankfurt)
 │   │   ├── matchingScorer.js   # Shared scoring utilities
 │   │   ├── searchQueryBuilder.js # Shared search distance/filter/sort SQL builders
@@ -272,7 +273,7 @@ All routes are prefixed with `/api`.
 
 | Prefix | Description |
 |---|---|
-| `/api/auth` | Register (requires `acceptedTerms`, `acceptedPrivacy`, `confirmedAge16`), login, email verification, password reset; `POST /auth/check-username` for rate-limited username availability checks |
+| `/api/auth` | Register (requires `acceptedTerms`, `acceptedPrivacy`, `confirmedAge16`), login (sets the httpOnly session cookie), `POST /auth/logout` (clears it), email verification, password reset; `POST /auth/check-username` for rate-limited username availability checks |
 | `/api/users` | User CRUD, tags, badges, avatar, self-only blocklist endpoints, account deletion with preview |
 | `/api/teams` | Team CRUD, members, applications, invitations, badge awards; `DELETE /invitations/:id/role` cancels only the role portion of a pending invitation |
 | `/api/teams/:teamId/vacant-roles` | Vacant role CRUD and status management. Supports `?ids=1,2,3` for bulk filtering (bypasses the default status filter so polling can detect roles that transitioned to filled/closed). Role responses include `is_public` on the `creator` and `filled_by` user sub-objects. |
@@ -326,7 +327,7 @@ Blocklist routes are self-only: `:id` must match the authenticated user. When ei
 
 ## Real-Time Events (Socket.IO)
 
-The server uses Socket.IO for real-time features. Clients authenticate via JWT token in the handshake.
+The server uses Socket.IO for real-time features. Clients authenticate from the httpOnly session cookie sent with the handshake (the browser sends it automatically via `withCredentials`); an explicit handshake auth token is still accepted as a fallback.
 
 **Key events:**
 
@@ -418,7 +419,7 @@ Full transactional account deletion following the spec in `docs/USER_DELETION_SP
 | Error message scrubbing | Internal error details (`error.message`, stack traces) only included in responses when `NODE_ENV === "development"` |
 | Logging | All debug `console.log` gated behind `NODE_ENV !== "production"`; errors and warnings always logged |
 | SQL injection | Parameterized queries throughout |
-| Auth | JWT on all protected routes, bcrypt with 10 salt rounds |
+| Auth | JWT on all protected routes, carried in an `httpOnly` `sameSite` cookie so it is not exposed to frontend JavaScript (XSS-resistant); bcrypt with 10 salt rounds |
 | Legal consent | Registration requires `acceptedTerms`, `acceptedPrivacy`, and `confirmedAge16` (all must be `true`). The version of each document (`accepted_terms_version`, `accepted_privacy_version`, `confirmed_age_16_version`) and the acceptance timestamp are stored on the user row for audit purposes. |
 | User data exposure | Public user listings return only public profiles (`is_public = TRUE`) with an explicit column allowlist; auth-aware profile/search reads also exclude users in a block relationship with the requester where supported; newly verified users remain private until they opt in; no `SELECT *` on user rows |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@imagekit/nodejs": "^7.4.0",
         "axios": "^1.9.0",
         "bcrypt": "^5.1.1",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.7",
@@ -566,12 +567,25 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/cookie-signature": {
@@ -744,15 +758,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/engine.io/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/engine.io/node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@imagekit/nodejs": "^7.4.0",
     "axios": "^1.9.0",
     "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
     "dotenv": "^16.4.7",

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const cors = require("cors");
 const helmet = require("helmet");
+const cookieParser = require("cookie-parser");
 const dotenv = require("dotenv");
 const { buildErrorResponse } = require("./utils/errorResponse");
 
@@ -11,10 +12,6 @@ const app = express();
 if (process.env.NODE_ENV === "production") {
   app.set("trust proxy", 1);
 }
-
-app.use(helmet());
-app.use(express.json({ limit: "1mb" }));
-app.use(express.urlencoded({ extended: true, limit: "1mb" }));
 
 const explicitOrigins = [
   "http://localhost:5173",
@@ -82,6 +79,14 @@ const corsOptions = {
 
 app.use(cors(corsOptions));
 app.options(/.*/, cors(corsOptions));
+
+// Body parsing and other middleware run AFTER CORS so that error responses
+// (e.g. for a malformed/empty body) still carry the CORS headers — otherwise
+// the browser blocks the response and the client only sees a network error.
+app.use(helmet());
+app.use(express.json({ limit: "1mb" }));
+app.use(express.urlencoded({ extended: true, limit: "1mb" }));
+app.use(cookieParser());
 
 if (process.env.NODE_ENV !== "production") {
   app.use((req, res, next) => {

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -2,6 +2,7 @@ const Joi = require("joi");
 const crypto = require("crypto");
 const userModel = require("../models/userModel");
 const { generateToken } = require("../utils/jwtUtils");
+const { setAuthCookie, clearAuthCookie } = require("../utils/authCookie");
 const emailService = require("../services/emailService");
 const db = require("../config/database");
 const { resolveLocationData } = require("../utils/geocodingUtil");
@@ -548,11 +549,14 @@ const authController = {
 
       const token = generateToken(user);
 
+      // Deliver the session token as an httpOnly cookie instead of in the
+      // response body, so it is never readable by frontend JavaScript.
+      setAuthCookie(res, token);
+
       res.status(200).json({
         success: true,
         message: "Login successful",
         data: {
-          token,
           user: {
             id: user.id,
             username: user.username,
@@ -578,6 +582,18 @@ const authController = {
         ...(process.env.NODE_ENV === "development" && { error: error.message }),
       });
     }
+  },
+
+  /**
+   * Log out: clear the session cookie. Stateless JWTs are not server-side
+   * revocable, so logout simply removes the cookie from the browser.
+   */
+  async logout(req, res) {
+    clearAuthCookie(res);
+    res.status(200).json({
+      success: true,
+      message: "Logged out successfully",
+    });
   },
 
   /**

--- a/src/middlewares/auth.js
+++ b/src/middlewares/auth.js
@@ -1,4 +1,17 @@
 const { verifyToken } = require('../utils/jwtUtils');
+const { AUTH_COOKIE_NAME } = require('../utils/authCookie');
+
+/**
+ * Extract the session token, preferring the httpOnly cookie and falling back
+ * to the Authorization header (for API clients / backward compatibility).
+ */
+const getTokenFromRequest = (req) => {
+  const cookieToken = req.cookies && req.cookies[AUTH_COOKIE_NAME];
+  if (cookieToken) return cookieToken;
+
+  const authHeader = req.headers['authorization'];
+  return authHeader && authHeader.split(' ')[1]; // Format: "Bearer TOKEN"
+};
 
 /**
  * Middleware to authenticate JWT token
@@ -7,15 +20,9 @@ const authenticateToken = (req, res, next) => {
   if (process.env.NODE_ENV !== 'production') {
     console.log(`Request to ${req.method} ${req.path}`);
   }
-  
-  // Get the token from the Authorization header
-  const authHeader = req.headers['authorization'];
-  if (process.env.NODE_ENV !== 'production') {
-    console.log("Authorization header:", authHeader ? "Present" : "Missing");
-  }
-  
-  const token = authHeader && authHeader.split(' ')[1]; // Format: "Bearer TOKEN"
-  
+
+  const token = getTokenFromRequest(req);
+
   if (!token) {
     if (process.env.NODE_ENV !== 'production') {
       console.log("No token provided in request");
@@ -54,15 +61,9 @@ const optionalAuthenticateToken = (req, res, next) => {
   if (process.env.NODE_ENV !== 'production') {
     console.log(`Request to ${req.method} ${req.path} (optional auth)`);
   }
-  
-  // Get the token from the Authorization header
-  const authHeader = req.headers['authorization'];
-  if (process.env.NODE_ENV !== 'production') {
-    console.log("Authorization header:", authHeader ? "Present" : "Missing");
-  }
-  
-  const token = authHeader && authHeader.split(' ')[1]; // Format: "Bearer TOKEN"
-  
+
+  const token = getTokenFromRequest(req);
+
   if (!token) {
     if (process.env.NODE_ENV !== 'production') {
       console.log("No token provided, continuing as unauthenticated user");

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -21,6 +21,9 @@ router.post(
 // Login existing user
 router.post("/login", authLimiter, authController.login);
 
+// Log out (clears the session cookie)
+router.post("/logout", authController.logout);
+
 router.post(
   "/check-username",
   usernameAvailabilityLimiter,

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,7 @@ const app = require("./app");
 const http = require("http");
 const socketIo = require("socket.io");
 const { verifyToken } = require("./utils/jwtUtils");
+const { getTokenFromCookieHeader } = require("./utils/authCookie");
 const db = require("./config/database");
 const userModel = require("./models/userModel");
 const PORT = process.env.PORT || 5001;
@@ -126,7 +127,11 @@ app.set("io", io);
 
 // Socket.IO middleware for authentication
 io.use((socket, next) => {
-  const token = socket.handshake.auth.token;
+  // Prefer the httpOnly session cookie sent with the handshake; fall back to
+  // an explicit auth token (backward compatibility / non-browser clients).
+  const token =
+    getTokenFromCookieHeader(socket.handshake.headers.cookie) ||
+    socket.handshake.auth.token;
 
   if (!token) {
     return next(new Error("Authentication error: Token missing"));

--- a/src/utils/authCookie.js
+++ b/src/utils/authCookie.js
@@ -1,0 +1,64 @@
+const cookie = require("cookie");
+
+// Name of the httpOnly cookie that carries the session JWT.
+const AUTH_COOKIE_NAME = "token";
+
+// Keep the cookie lifetime aligned with the JWT expiry (default 7 days).
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+const isProduction = () => process.env.NODE_ENV === "production";
+
+/**
+ * Cookie attributes for the session token.
+ *
+ * In production the frontend (Vercel) and backend (Render) live on different
+ * domains, so the cookie must be cross-site: `sameSite: "none"` with
+ * `secure: true` (browsers reject SameSite=None without Secure). Locally both
+ * run on localhost, where `sameSite: "lax"` works over plain HTTP.
+ *
+ * `clear` omits `maxAge`/`expires` so the same attributes can be reused to
+ * delete the cookie (the attributes must match for the browser to remove it).
+ */
+const buildCookieOptions = ({ clear = false } = {}) => {
+  const options = {
+    httpOnly: true,
+    secure: isProduction(),
+    sameSite: isProduction() ? "none" : "lax",
+    path: "/",
+  };
+
+  if (!clear) {
+    options.maxAge = SEVEN_DAYS_MS;
+  }
+
+  return options;
+};
+
+const setAuthCookie = (res, token) => {
+  res.cookie(AUTH_COOKIE_NAME, token, buildCookieOptions());
+};
+
+const clearAuthCookie = (res) => {
+  res.clearCookie(AUTH_COOKIE_NAME, buildCookieOptions({ clear: true }));
+};
+
+/**
+ * Read the session token from a raw Cookie header string. Used by the Socket.IO
+ * handshake, which is not processed by the cookie-parser Express middleware.
+ */
+const getTokenFromCookieHeader = (cookieHeader) => {
+  if (!cookieHeader) return null;
+  try {
+    const parsed = cookie.parse(cookieHeader);
+    return parsed[AUTH_COOKIE_NAME] || null;
+  } catch (error) {
+    return null;
+  }
+};
+
+module.exports = {
+  AUTH_COOKIE_NAME,
+  setAuthCookie,
+  clearAuthCookie,
+  getTokenFromCookieHeader,
+};


### PR DESCRIPTION
Summary
Stops storing the JWT in localStorage. The session now lives in a backend-set httpOnly cookie that JavaScript cannot read, closing the XSS token-theft vector. Auth state is derived from the backend instead of a JS-held token.

Changes
[AuthContext](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/contexts/AuthContext.jsx) — removes the localStorage token; restores the session on load via GET /api/auth/me (cookie sent automatically with withCredentials); login/register set user state directly; logout calls POST /api/auth/logout to clear the cookie.
[api.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/services/api.js) — drops the Authorization header injection from localStorage; relies on withCredentials (already enabled).
[socketService.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/services/socketService.js) — connects with withCredentials: true (no token passed); the handshake cookie authenticates the socket.
[imagekit.js](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/config/imagekit.js) — fetches upload auth params with credentials: "include" instead of a localStorage token.
[VerifyEmail.jsx](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/pages/VerifyEmail.jsx) — removes a dead localStorage token write.
[Privacy notice](vscode-webview://08695vdto9e99coplh4v08hmcse27bkpju4fm620ibffv4jdlt8o/src/pages/LegalPlaceholderPage.jsx) — updated to describe the technically necessary httpOnly session cookie under TDDDG §25(2) (strictly necessary → no consent banner required); its own "last updated" date bumped. README updated.
Notes
No cookie banner is required: the session cookie is strictly necessary (TDDDG §25(2)). Client-side ImageKit uploads in authenticated areas (Profile, Chat, team modals) are intentionally kept and now rely on the cookie session.

Testing
Verified locally: login, session persistence across reload/navigation, realtime chat (socket cookie auth), avatar upload, and logout (cookie cleared, redirect to /login).