### PR TITLE
Add backend CSRF origin checks

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,8 @@ const helmet = require("helmet");
 const cookieParser = require("cookie-parser");
 const dotenv = require("dotenv");
 const { buildErrorResponse } = require("./utils/errorResponse");
+const { csrfProtection } = require("./middlewares/csrfProtection");
+const { isAllowedOrigin } = require("./utils/allowedOrigins");
 
 dotenv.config();
 
@@ -12,52 +14,6 @@ const app = express();
 if (process.env.NODE_ENV === "production") {
   app.set("trust proxy", 1);
 }
-
-const explicitOrigins = [
-  "http://localhost:5173",
-  "https://lomir-frontend.vercel.app",
-  process.env.CLIENT_URL,
-  process.env.FRONTEND_URL,
-  process.env.FRONTEND_ORIGIN,
-].filter(Boolean);
-
-const normalizeOrigin = (origin) => {
-  if (!origin) return origin;
-  return origin.replace(/\/$/, "");
-};
-
-const isAllowedOrigin = (origin) => {
-  if (!origin) return true;
-
-  const normalized = normalizeOrigin(origin);
-  const normalizedExplicit = explicitOrigins.map(normalizeOrigin);
-
-  if (normalizedExplicit.includes(normalized)) {
-    return true;
-  }
-
-  try {
-    const url = new URL(normalized);
-
-    if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
-      return true;
-    }
-
-    if (
-      url.protocol === "https:" &&
-      (url.hostname === "lomir-frontend.vercel.app" ||
-        /^lomir-frontend-[a-z0-9]+-juliabaurs-projects\.vercel\.app$/.test(
-          url.hostname
-        ))
-    ) {
-      return true;
-    }
-  } catch (error) {
-    return false;
-  }
-
-  return false;
-};
 
 const corsOptions = {
   origin(origin, callback) {
@@ -84,9 +40,10 @@ app.options(/.*/, cors(corsOptions));
 // (e.g. for a malformed/empty body) still carry the CORS headers — otherwise
 // the browser blocks the response and the client only sees a network error.
 app.use(helmet());
+app.use(cookieParser());
+app.use(csrfProtection);
 app.use(express.json({ limit: "1mb" }));
 app.use(express.urlencoded({ extended: true, limit: "1mb" }));
-app.use(cookieParser());
 
 if (process.env.NODE_ENV !== "production") {
   app.use((req, res, next) => {

--- a/src/middlewares/csrfProtection.js
+++ b/src/middlewares/csrfProtection.js
@@ -1,0 +1,84 @@
+const { AUTH_COOKIE_NAME } = require("../utils/authCookie");
+const {
+  getOriginFromReferer,
+  isAllowedOrigin,
+} = require("../utils/allowedOrigins");
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+const getHeader = (req, name) => {
+  if (typeof req.get === "function") {
+    return req.get(name);
+  }
+
+  return req.headers?.[name.toLowerCase()];
+};
+
+const hasSessionCookie = (req) =>
+  Boolean(req.cookies && req.cookies[AUTH_COOKIE_NAME]);
+
+const hasBearerToken = (req) => {
+  const authorization = getHeader(req, "Authorization");
+  return /^Bearer\s+\S+/i.test(authorization || "");
+};
+
+const getRequestOrigin = (req) => {
+  const origin = getHeader(req, "Origin");
+  if (origin) {
+    return { source: "Origin", value: origin };
+  }
+
+  const refererOrigin = getOriginFromReferer(
+    getHeader(req, "Referer") || getHeader(req, "Referrer"),
+  );
+
+  if (refererOrigin) {
+    return { source: "Referer", value: refererOrigin };
+  }
+
+  return null;
+};
+
+const sendForbidden = (res, message) =>
+  res.status(403).json({
+    success: false,
+    message,
+  });
+
+const csrfProtection = (req, res, next) => {
+  if (SAFE_METHODS.has(req.method)) {
+    return next();
+  }
+
+  const requestOrigin = getRequestOrigin(req);
+
+  if (requestOrigin) {
+    if (isAllowedOrigin(requestOrigin.value)) {
+      return next();
+    }
+
+    console.warn(
+      `CSRF blocked: ${requestOrigin.source} ${requestOrigin.value} is not allowed for ${req.method} ${req.originalUrl}`,
+    );
+
+    return sendForbidden(res, "Request origin is not allowed.");
+  }
+
+  // Non-browser API clients often have no Origin/Referer. Keep those working
+  // unless the request relies on the browser session cookie, which is the CSRF
+  // risk introduced by SameSite=None cross-site cookies.
+  if (hasSessionCookie(req) && !hasBearerToken(req)) {
+    console.warn(
+      `CSRF blocked: missing Origin/Referer for cookie-authenticated ${req.method} ${req.originalUrl}`,
+    );
+
+    return sendForbidden(res, "Request origin is required.");
+  }
+
+  return next();
+};
+
+module.exports = {
+  csrfProtection,
+  getRequestOrigin,
+};

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ const http = require("http");
 const socketIo = require("socket.io");
 const { verifyToken } = require("./utils/jwtUtils");
 const { getTokenFromCookieHeader } = require("./utils/authCookie");
+const { isAllowedOrigin } = require("./utils/allowedOrigins");
 const db = require("./config/database");
 const userModel = require("./models/userModel");
 const PORT = process.env.PORT || 5001;
@@ -101,20 +102,7 @@ const server = http.createServer(app);
 const io = socketIo(server, {
   cors: {
     origin: (origin, callback) => {
-      if (!origin) return callback(null, true);
-      try {
-        const url = new URL(origin);
-        if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
-          return callback(null, true);
-        }
-      } catch (_) {}
-      const allowed = [
-        "https://lomir-frontend.vercel.app",
-        process.env.CLIENT_URL,
-        process.env.FRONTEND_URL,
-        process.env.FRONTEND_ORIGIN,
-      ].filter(Boolean);
-      if (allowed.includes(origin)) return callback(null, true);
+      if (isAllowedOrigin(origin)) return callback(null, true);
       callback(new Error("Not allowed by CORS"));
     },
     methods: ["GET", "POST"],

--- a/src/utils/allowedOrigins.js
+++ b/src/utils/allowedOrigins.js
@@ -1,0 +1,66 @@
+const DEFAULT_ALLOWED_ORIGINS = [
+  "http://localhost:5173",
+  "https://lomir-frontend.vercel.app",
+];
+
+const getExplicitOrigins = () =>
+  [
+    ...DEFAULT_ALLOWED_ORIGINS,
+    process.env.CLIENT_URL,
+    process.env.FRONTEND_URL,
+    process.env.FRONTEND_ORIGIN,
+  ].filter(Boolean);
+
+const normalizeOrigin = (origin) => {
+  if (!origin) return origin;
+  return String(origin).trim().replace(/\/+$/, "");
+};
+
+const isAllowedOrigin = (origin) => {
+  if (!origin) return true;
+
+  const normalized = normalizeOrigin(origin);
+  const normalizedExplicit = getExplicitOrigins().map(normalizeOrigin);
+
+  if (normalizedExplicit.includes(normalized)) {
+    return true;
+  }
+
+  try {
+    const url = new URL(normalized);
+
+    if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+      return true;
+    }
+
+    if (
+      url.protocol === "https:" &&
+      (url.hostname === "lomir-frontend.vercel.app" ||
+        /^lomir-frontend-[a-z0-9]+-juliabaurs-projects\.vercel\.app$/.test(
+          url.hostname,
+        ))
+    ) {
+      return true;
+    }
+  } catch (error) {
+    return false;
+  }
+
+  return false;
+};
+
+const getOriginFromReferer = (referer) => {
+  if (!referer) return null;
+
+  try {
+    return new URL(referer).origin;
+  } catch (error) {
+    return null;
+  }
+};
+
+module.exports = {
+  getOriginFromReferer,
+  isAllowedOrigin,
+  normalizeOrigin,
+};

--- a/test/csrfProtection.test.js
+++ b/test/csrfProtection.test.js
@@ -1,0 +1,154 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { csrfProtection } = require("../src/middlewares/csrfProtection");
+const { AUTH_COOKIE_NAME } = require("../src/utils/authCookie");
+
+const createRequest = ({
+  method = "POST",
+  headers = {},
+  cookies = {},
+  originalUrl = "/api/users/1",
+} = {}) => {
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+
+  return {
+    method,
+    headers: normalizedHeaders,
+    cookies,
+    originalUrl,
+    get(name) {
+      return normalizedHeaders[name.toLowerCase()];
+    },
+  };
+};
+
+const createResponse = () => ({
+  statusCode: 200,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const runMiddleware = (req) => {
+  const res = createResponse();
+  let nextCalled = false;
+
+  csrfProtection(req, res, () => {
+    nextCalled = true;
+  });
+
+  return { res, nextCalled };
+};
+
+const withSilencedWarnings = (fn) => {
+  const originalWarn = console.warn;
+  console.warn = () => {};
+
+  try {
+    return fn();
+  } finally {
+    console.warn = originalWarn;
+  }
+};
+
+test("csrfProtection skips safe methods", () => {
+  const { res, nextCalled } = runMiddleware(
+    createRequest({
+      method: "GET",
+      headers: { Origin: "https://evil.example" },
+      cookies: { [AUTH_COOKIE_NAME]: "session-token" },
+    }),
+  );
+
+  assert.equal(nextCalled, true);
+  assert.equal(res.body, null);
+});
+
+test("csrfProtection allows mutating requests from an allowed Origin", () => {
+  const { res, nextCalled } = runMiddleware(
+    createRequest({
+      headers: { Origin: "https://lomir-frontend.vercel.app" },
+      cookies: { [AUTH_COOKIE_NAME]: "session-token" },
+    }),
+  );
+
+  assert.equal(nextCalled, true);
+  assert.equal(res.body, null);
+});
+
+test("csrfProtection allows mutating requests from an allowed Referer", () => {
+  const { res, nextCalled } = runMiddleware(
+    createRequest({
+      headers: {
+        Referer: "https://lomir-frontend.vercel.app/profile/settings",
+      },
+      cookies: { [AUTH_COOKIE_NAME]: "session-token" },
+    }),
+  );
+
+  assert.equal(nextCalled, true);
+  assert.equal(res.body, null);
+});
+
+test("csrfProtection rejects mutating requests from a disallowed Origin", () => {
+  const { res, nextCalled } = withSilencedWarnings(() =>
+    runMiddleware(
+      createRequest({
+        headers: { Origin: "https://evil.example" },
+        cookies: { [AUTH_COOKIE_NAME]: "session-token" },
+      }),
+    ),
+  );
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Request origin is not allowed.",
+  });
+});
+
+test("csrfProtection rejects cookie-authenticated mutating requests without Origin or Referer", () => {
+  const { res, nextCalled } = withSilencedWarnings(() =>
+    runMiddleware(
+      createRequest({
+        cookies: { [AUTH_COOKIE_NAME]: "session-token" },
+      }),
+    ),
+  );
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(res.body, {
+    success: false,
+    message: "Request origin is required.",
+  });
+});
+
+test("csrfProtection allows non-browser mutating requests without browser origin headers", () => {
+  const { res, nextCalled } = runMiddleware(createRequest());
+
+  assert.equal(nextCalled, true);
+  assert.equal(res.body, null);
+});
+
+test("csrfProtection allows bearer-token API clients without browser origin headers", () => {
+  const { res, nextCalled } = runMiddleware(
+    createRequest({
+      headers: { Authorization: "Bearer api-token" },
+      cookies: { [AUTH_COOKIE_NAME]: "session-token" },
+    }),
+  );
+
+  assert.equal(nextCalled, true);
+  assert.equal(res.body, null);
+});


### PR DESCRIPTION
Summary
adds backend CSRF protection for state-changing requests using Origin/Referer validation
centralizes allowed origin handling for REST CORS and Socket.IO
blocks cookie-authenticated mutating requests without browser origin headers
keeps Bearer-token and non-browser API clients working
adds focused middleware tests for allowed and blocked CSRF scenarios
Testing
node --test test/csrfProtection.test.js
npm test
Known baseline remains: 72/77 pass, 5 existing Invitation/VacantRole stub failures.
Manual smoke tests:UI login/session and state-changing actions passed
disallowed origin returns 403 Request origin is not allowed.
cookie request without Origin/Referer returns 403 Request origin is required.