### PR TITLE
Stabilize backend role invitation tests

### DIFF
--- a/test/invitationController.test.js
+++ b/test/invitationController.test.js
@@ -173,6 +173,7 @@ function buildRespondInvitationPoolQueryStub({ roleId = 9 } = {}) {
 function buildRespondInvitationClientStub({
   memberCount = "2",
   roleUpdateRows = [{ id: 9, role_name: "Backend Developer" }],
+  existingFilledRoleRows = [],
   isInternalMember = false,
 } = {}) {
   const calls = [];
@@ -191,6 +192,15 @@ function buildRespondInvitationClientStub({
 
       if (sql.includes("COUNT(*) as count FROM team_members")) {
         return { rows: [{ count: memberCount }] };
+      }
+
+      if (
+        sql.includes("SELECT id, role_name") &&
+        sql.includes("filled_by = $2") &&
+        sql.includes("status = 'filled'") &&
+        sql.includes("id <> $3")
+      ) {
+        return { rows: existingFilledRoleRows };
       }
 
       if (sql.includes("INSERT INTO team_members")) {
@@ -776,6 +786,10 @@ test("getTeamsWhereUserCanInvite includes teams where the invitee is already a m
           teamavatar_url: "https://example.com/alpha.png",
           max_members: 3,
           current_members_count: "3",
+          city: "Berlin",
+          country: "Germany",
+          is_remote: false,
+          user_role: "owner",
           is_invitee_member: true,
         },
         {
@@ -784,6 +798,10 @@ test("getTeamsWhereUserCanInvite includes teams where the invitee is already a m
           teamavatar_url: "https://example.com/beta.png",
           max_members: 4,
           current_members_count: "2",
+          city: null,
+          country: null,
+          is_remote: true,
+          user_role: "admin",
           is_invitee_member: false,
         },
       ],
@@ -808,6 +826,10 @@ test("getTeamsWhereUserCanInvite includes teams where the invitee is already a m
       max_members: 3,
       current_members_count: 3,
       available_spots: 0,
+      city: "Berlin",
+      country: "Germany",
+      is_remote: false,
+      user_role: "owner",
       is_invitee_member: true,
     },
     {
@@ -817,6 +839,10 @@ test("getTeamsWhereUserCanInvite includes teams where the invitee is already a m
       max_members: 4,
       current_members_count: 2,
       available_spots: 2,
+      city: null,
+      country: null,
+      is_remote: true,
+      user_role: "admin",
       is_invitee_member: false,
     },
   ]);

--- a/test/teamController.applyToJoinTeam.test.js
+++ b/test/teamController.applyToJoinTeam.test.js
@@ -210,6 +210,17 @@ function buildPoolQueryStubAsMember({ pendingRoleRows = [] } = {}) {
       return { rows: [{ first_name: "Test", last_name: "User", username: "testuser" }] };
     }
 
+    if (
+      sql.includes("SELECT user_id FROM team_members") &&
+      sql.includes("role IN ('owner', 'admin')")
+    ) {
+      return { rows: [{ user_id: 2 }] };
+    }
+
+    if (sql.includes("INSERT INTO notifications")) {
+      return { rows: [{ id: 501 }] };
+    }
+
     throw new Error(`Unexpected pool SQL in member stub: ${sql}`);
   };
 

--- a/test/vacantRoleController.test.js
+++ b/test/vacantRoleController.test.js
@@ -168,6 +168,15 @@ test("updateVacantRoleStatus persists filled_by and returns filled_by_user when 
       return { rows: [{ role: "owner" }] };
     }
 
+    if (
+      sql.includes("SELECT id, role_name") &&
+      sql.includes("filled_by = $2") &&
+      sql.includes("status = 'filled'") &&
+      sql.includes("id <> $3")
+    ) {
+      return { rows: [] };
+    }
+
     if (sql.includes("UPDATE team_vacant_roles")) {
       return {
         rows: [


### PR DESCRIPTION
Summary
stabilizes Invitation/VacantRole backend tests after recent role-filling behavior changes
updates test stubs for the “one filled role per member per team” collision check
updates getTeamsWhereUserCanInvite expectations for current location/role response fields
cleans up applyToJoinTeam notification stubs so the full test suite runs without caught error logs
Testing
node --test test/invitationController.test.js test/vacantRoleController.test.js
node --test test/teamController.applyToJoinTeam.test.js
npm test → 77/77 passing
node --check on changed test files
git diff --check