### PR TITLE
acknowledgement-of-receipt email for abuse reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Contact the project owner for a demo login, or register a new account with a val
 - **Badge System** — 30 badges across 5 categories; award badges to teammates with reasons and context
 - **Notifications** — In-app notifications for invitations, applications, badge awards, messages, @mentions, and role lifecycle events; each notification deep-links to the exact message that triggered it; stale notifications are cleaned up automatically on member removal, role deletion, and team deletion
 - **Account Deletion** — Full transactional account deletion with impact preview, automatic team ownership transfer, role reopening, and "Former Lomir User" handling for preserved references
-- **Contact Form & Reports** — Public `/api/contact` endpoint with Joi validation, Turnstile CAPTCHA, in-memory file attachments (up to 3 files, 5 MB each, 10 MB total), and SMTP forwarding. Abuse/content reports are persisted in `contact_reports` with a reference ID before email forwarding, so reports are not lost if SMTP delivery fails; unexpected body fields are stripped defensively so multipart attachment fields cannot break validation; rate-limited to 5 submissions/hr
+- **Contact Form & Reports** — Public `/api/contact` endpoint with Joi validation, Turnstile CAPTCHA, in-memory file attachments (up to 3 files, 5 MB each, 10 MB total), and SMTP forwarding. Abuse/content reports are persisted in `contact_reports` with a reference ID before email forwarding, so reports are not lost if SMTP delivery fails; reporters also receive an automated acknowledgement-of-receipt email with their reference ID (sent only for `Report content or abuse` submissions, best-effort so a failed receipt never fails the request); unexpected body fields are stripped defensively so multipart attachment fields cannot break validation; rate-limited to 5 submissions/hr
 - **Geocoding** — Location enrichment via Nominatim: resolves a full location object (postal code, city, district, state, country, coordinates) from partial input. Built-in postal-code-to-district lookup for Berlin and Frankfurt (200+ mappings) used as a fast offline fallback before the API call. Works with country alone — does not require both postal code and city.
 - **Security** — `httpOnly` cookie sessions (JWT not exposed to JavaScript), CSRF origin/referer validation on all state-changing requests, Helmet security headers, request body size cap (1 MB), rate limiting on auth, contact, and geocoding endpoints, credentialed CORS allowlist (applied before body parsing), password policy enforcement, Socket.IO conversation/message authorization, production error message scrubbing
 
@@ -161,7 +161,7 @@ For contact/report work, run the focused contact suite:
 node --test test/contactController.test.js
 ```
 
-That suite covers abuse report persistence, reference ID responses, email-forwarding status updates, persistence failure handling, and the ordinary contact-message path.
+That suite covers abuse report persistence, reference ID responses, email-forwarding status updates, the reporter acknowledgement-of-receipt email (sent for reports, skipped for ordinary messages, and best-effort on failure), persistence failure handling, and the ordinary contact-message path.
 
 ---
 
@@ -219,7 +219,7 @@ Lomir-backend/
 │   │   ├── tagModel.js
 │   │   └── contactReportModel.js # Persistent abuse/content report records and email status updates
 │   ├── services/
-│   │   └── emailService.js     # Nodemailer SMTP transactional email; Resend restore notes kept in comments
+│   │   └── emailService.js     # Nodemailer SMTP transactional email (verification, password reset/changed, email-change, contact forwarding, report receipt)
 │   ├── utils/
 │   │   ├── booleanSearchParser.js
 │   │   ├── imagekitUtils.js
@@ -297,7 +297,7 @@ All routes are prefixed with `/api`.
 | `/api/imagekit` | Auth params for client-side ImageKit uploads |
 | `/api/tags` | Tag catalog (structured by category) |
 | `/api/geocoding` | Postal code → city/district/country/coordinates lookup |
-| `/api/contact` | Public contact form submission with optional file attachments forwarded by SMTP; `Report content or abuse` submissions are persisted first and return a `referenceId` |
+| `/api/contact` | Public contact form submission with optional file attachments forwarded by SMTP; `Report content or abuse` submissions are persisted first, return a `referenceId`, and trigger an automated acknowledgement-of-receipt email to the reporter |
 
 ---
 

--- a/src/controllers/contactController.js
+++ b/src/controllers/contactController.js
@@ -46,6 +46,19 @@ const updateReportEmailStatus = async (report, statusUpdate) => {
   }
 };
 
+// Acknowledge receipt to the reporter. Best-effort: the report is already
+// persisted and its reference ID shown on screen, so a failed receipt email
+// must never fail the request.
+const sendReportReceipt = async (report, { name, email }) => {
+  if (!report) return;
+
+  try {
+    await emailService.sendReportReceiptEmail(name, email, report.reference_code);
+  } catch (receiptError) {
+    console.error("Failed to send report receipt email:", receiptError);
+  }
+};
+
 const contactController = {
   async submitContactForm(req, res) {
     try {
@@ -148,6 +161,8 @@ const contactController = {
           emailError: emailError.message,
         });
       }
+
+      await sendReportReceipt(report, { name, email });
 
       if (report) {
         return res

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -308,6 +308,62 @@ const emailService = {
   },
 
   /**
+   * Acknowledge receipt of an abuse / illegal-content report to the reporter
+   */
+  async sendReportReceiptEmail(name, email, referenceCode) {
+    const safeName = escapeHtml(name || "there");
+    const safeReference = escapeHtml(referenceCode);
+
+    try {
+      const emailResult = await sendEmail({
+        to: email,
+        subject: `We received your Lomir report (${cleanHeaderValue(referenceCode)})`,
+        html: `
+          <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <h2 style="color: #6366f1; margin-bottom: 24px;">We received your report</h2>
+
+            <p style="font-size: 16px; color: #333; line-height: 1.6;">
+              Hi ${safeName}, thank you for reporting content or abuse on Lomir. This is an
+              automated confirmation that we have received your report and will review it.
+            </p>
+
+            <div style="background-color: #f8fafc; border: 1px solid #e5e7eb; border-radius: 8px; padding: 20px; margin: 24px 0;">
+              <p style="font-size: 14px; color: #333; line-height: 1.6; margin: 0;">
+                <strong>Reference ID:</strong> ${safeReference}
+              </p>
+            </div>
+
+            <p style="font-size: 16px; color: #333; line-height: 1.6;">
+              You do not need to do anything further. Please keep this reference ID in case you
+              want to refer to your report later. If you have more details to add, simply reply
+              to this email.
+            </p>
+
+            <hr style="border: none; border-top: 1px solid #eee; margin: 32px 0;" />
+
+            <p style="font-size: 12px; color: #999;">
+              This is an automated message confirming receipt. We review reports in line with our
+              Terms of Service and will take action where appropriate.
+            </p>
+          </div>
+        `,
+      });
+
+      if (!emailResult.success) {
+        return emailResult;
+      }
+
+      if (process.env.NODE_ENV !== "production") {
+        console.log("Report receipt email sent:", emailResult.messageId);
+      }
+      return { success: true, messageId: emailResult.messageId };
+    } catch (error) {
+      console.error("Email send error:", error);
+      return { success: false };
+    }
+  },
+
+  /**
    * Send contact form submission to Lomir inbox
    */
   async sendContactFormEmail(name, email, topic, message, attachments) {

--- a/test/contactController.test.js
+++ b/test/contactController.test.js
@@ -10,6 +10,7 @@ const REPORT_TOPIC = "Report content or abuse";
 const originalCreateReport = contactReportModel.createReport;
 const originalUpdateEmailStatus = contactReportModel.updateEmailStatus;
 const originalSendContactFormEmail = emailService.sendContactFormEmail;
+const originalSendReportReceiptEmail = emailService.sendReportReceiptEmail;
 const originalTurnstileSecret = process.env.TURNSTILE_SECRET_KEY;
 const originalConsoleError = console.error;
 
@@ -50,6 +51,7 @@ test.afterEach(() => {
   contactReportModel.createReport = originalCreateReport;
   contactReportModel.updateEmailStatus = originalUpdateEmailStatus;
   emailService.sendContactFormEmail = originalSendContactFormEmail;
+  emailService.sendReportReceiptEmail = originalSendReportReceiptEmail;
   console.error = originalConsoleError;
 
   if (originalTurnstileSecret === undefined) {
@@ -97,6 +99,12 @@ test("submitContactForm persists abuse reports and returns a reference id", asyn
     return { success: true, messageId: "mail-123" };
   };
 
+  const receiptCalls = [];
+  emailService.sendReportReceiptEmail = async (name, email, referenceCode) => {
+    receiptCalls.push({ name, email, referenceCode });
+    return { success: true, messageId: "receipt-123" };
+  };
+
   const res = createResponse();
 
   await contactController.submitContactForm(createContactRequest(), res);
@@ -105,6 +113,13 @@ test("submitContactForm persists abuse reports and returns a reference id", asyn
   assert.equal(res.body.success, true);
   assert.equal(res.body.data.referenceId, "RPT-20260616-ABCD1234");
   assert.match(res.body.message, /RPT-20260616-ABCD1234/);
+  assert.deepEqual(receiptCalls, [
+    {
+      name: "Jane Reporter",
+      email: "jane@example.com",
+      referenceCode: "RPT-20260616-ABCD1234",
+    },
+  ]);
   assert.deepEqual(statusUpdates, [
     {
       reportId: 12,
@@ -184,6 +199,9 @@ test("submitContactForm leaves ordinary contact messages mail-only", async () =>
     throw new Error("updateEmailStatus should not be called");
   };
   emailService.sendContactFormEmail = async () => ({ success: true });
+  emailService.sendReportReceiptEmail = async () => {
+    throw new Error("sendReportReceiptEmail should not be called");
+  };
 
   const res = createResponse();
 
@@ -202,4 +220,33 @@ test("submitContactForm leaves ordinary contact messages mail-only", async () =>
   assert.equal(res.body.success, true);
   assert.equal(reportCalled, false);
   assert.equal(res.body.data, undefined);
+});
+
+test("submitContactForm still confirms the report when the receipt email fails", async () => {
+  delete process.env.TURNSTILE_SECRET_KEY;
+  console.error = () => {};
+
+  contactReportModel.createReport = async () => ({
+    id: 14,
+    reference_code: "RPT-20260616-RCPT0001",
+  });
+  contactReportModel.updateEmailStatus = async (reportId, statusUpdate) => ({
+    id: reportId,
+    ...statusUpdate,
+  });
+  emailService.sendContactFormEmail = async () => ({
+    success: true,
+    messageId: "mail-456",
+  });
+  emailService.sendReportReceiptEmail = async () => {
+    throw new Error("receipt mailbox unavailable");
+  };
+
+  const res = createResponse();
+
+  await contactController.submitContactForm(createContactRequest(), res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.referenceId, "RPT-20260616-RCPT0001");
 });


### PR DESCRIPTION
## What

Anyone who submits a genuine report (with the exact topic “Report content or abuse”)
will now receive, in addition to the on-screen reference ID, an automatic
confirmation email containing this reference ID.

## Why

Strengthens the acknowledgment of receipt for the DSA reporting channel (Art. 16)—a small,
proportionate security enhancement for a non-commercial two-person app, without
creating new vulnerabilities.

## Details

- New `sendReportReceiptEmail(name, email, referenceCode)` in
  `emailService.js` (style/escaping like the other emails, header injection
  protection via `cleanHeaderValue`).
- Called in `contactController.js` via the fault-tolerant helper
  `sendReportReceipt` – **only** in the report branch.
- **Best-effort:** If sending fails, the request *does not* fail
  (the report is already persisted, the ID is displayed on the screen) – logging only.
- `email_status` is intentionally left unchanged (continues to track the operator’s
  email, not the reporter’s confirmation).
- No frontend/privacy changes required: contact-related email sending is
  already covered in the Privacy Policy.

## Tests

`test/contactController.test.js` extended: sent upon submission, **not**
for normal requests, best-effort in case of email errors → **83 tests passed**.

## Documentation

README updated (feature bullet point, test coverage, API table) + outdated
“Resend restore notes” note corrected.

Translated with DeepL.com (free version)