### PR TITLE
chore(security): upgrade nodemailer 8 → 9.0.1 (GHSA-p6gq-j5cr-w38f)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.2",
         "node-cron": "^4.2.1",
-        "nodemailer": "^8.0.10",
+        "nodemailer": "^9.0.1",
         "pg": "^8.14.1",
         "socket.io": "^4.8.1",
         "uuid": "^11.1.0"
@@ -1475,9 +1475,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
-      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.2",
     "node-cron": "^4.2.1",
-    "nodemailer": "^8.0.10",
+    "nodemailer": "^9.0.1",
     "pg": "^8.14.1",
     "socket.io": "^4.8.1",
     "uuid": "^11.1.0"


### PR DESCRIPTION
Clears the only outstanding high-severity npm audit finding. API usage is unchanged (createTransport + sendMail with buffer attachments), so the major bump is transparent. npm audit 0/0, 83/83 tests pass, local contact- form mail send verified.