### PR TITLE
security(auth): turnstile startup guard + dedicated account-change limiter

### DIFF
--- a/src/middlewares/rateLimiter.js
+++ b/src/middlewares/rateLimiter.js
@@ -28,6 +28,16 @@ const registerLimiter = createRateLimiter({
   message: "Too many registration attempts. Please try again later.",
 });
 
+// Authenticated account changes (change-email / change-password). Kept separate
+// from authLimiter so a user mistyping their current password can't burn through
+// the shared login budget (and vice versa); slightly more generous since these
+// already require an authenticated session plus the current password.
+const accountChangeLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 15,
+  message: "Too many account-change attempts. Please try again in 15 minutes.",
+});
+
 const usernameAvailabilityLimiter = createRateLimiter({
   windowMs: 60 * 60 * 1000,
   max: 20,
@@ -51,6 +61,7 @@ const geocodingLimiter = createRateLimiter({
 module.exports = {
   authLimiter,
   registerLimiter,
+  accountChangeLimiter,
   usernameAvailabilityLimiter,
   contactLimiter,
   geocodingLimiter,

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -6,6 +6,7 @@ const auth = require("../middlewares/auth");
 const {
   authLimiter,
   registerLimiter,
+  accountChangeLimiter,
   usernameAvailabilityLimiter,
 } = require("../middlewares/rateLimiter");
 const { upload } = require("../middlewares/uploadMiddleware");
@@ -46,18 +47,19 @@ router.get("/me", auth.authenticateToken, authController.getCurrentUser);
 router.post("/forgot-password", authLimiter, authController.forgotPassword);
 router.post("/reset-password", authLimiter, authController.resetPassword);
 
-// Change password (authenticated)
+// Change password (authenticated) — dedicated limiter so a mistyped current
+// password can't lock the user out of login (which uses authLimiter).
 router.put(
   "/change-password",
-  authLimiter,
+  accountChangeLimiter,
   auth.authenticateToken,
   authController.changePassword,
 );
 
-// Change email (authenticated)
+// Change email (authenticated) — same dedicated limiter as change-password.
 router.put(
   "/change-email",
-  authLimiter,
+  accountChangeLimiter,
   auth.authenticateToken,
   authController.changeEmail,
 );

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,22 @@ const { validateChatFileUrl } = require("./utils/fileValidation");
 
 require("dotenv").config();
 
+// Fail-closed security check (runs before any DB/job side effects): Turnstile
+// CAPTCHA on registration and the contact form is gated on TURNSTILE_SECRET_KEY
+// (see authController/contactController). If the key is missing, that protection
+// silently turns off (fail-open). In production, refuse to start so a
+// misconfigured deploy is caught immediately instead of running without CAPTCHA.
+// Non-production keeps the feature-flag behaviour (key optional → local dev runs
+// without it).
+if (process.env.NODE_ENV === "production" && !process.env.TURNSTILE_SECRET_KEY) {
+  console.error(
+    "FATAL: TURNSTILE_SECRET_KEY is not set in production — CAPTCHA protection " +
+      "on registration and the contact form would be silently disabled. " +
+      "Set TURNSTILE_SECRET_KEY and redeploy. Refusing to start.",
+  );
+  process.exit(1);
+}
+
 const app = require("./app");
 const http = require("http");
 const socketIo = require("socket.io");


### PR DESCRIPTION
Two backend defense-in-depth follow-ups:

- Fail-closed at startup in production if TURNSTILE_SECRET_KEY is missing, so a
  misconfigured deploy can't silently run with CAPTCHA disabled on registration
  and the contact form (both gate on the key). No-op outside production.

- Add a dedicated accountChangeLimiter (15 / 15 min) for /change-password and
  /change-email instead of sharing authLimiter (8 / 15 min) with login, so a
  user mistyping their current password can't lock themselves out of login.