### PR TITLE
perf(teams): embed open_role_names in getUserTeams to kill TeamCard N+1

### DIFF
--- a/src/controllers/teamReadController.js
+++ b/src/controllers/teamReadController.js
@@ -258,6 +258,8 @@ const getUserTeams = async (req, res) => {
              t.is_remote,
              COALESCE(COUNT(DISTINCT tm.user_id), 0) AS current_members_count,
              (SELECT COUNT(*) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_count,
+             (SELECT COALESCE(json_agg(vr.role_name ORDER BY vr.role_name ASC), '[]'::json)
+                FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_names,
              (SELECT COUNT(*)::int FROM team_applications ta WHERE ta.team_id = t.id AND ta.status = 'pending'
                AND NOT EXISTS (
                  SELECT 1 FROM user_blocks ub


### PR DESCRIPTION
TeamCard renders each team's open-role count + names. The my-teams list endpoint embedded only the count, so every card fetched its open roles individually (a vacant-roles?status=open call per card → an N+1 across the MyTeams list).

getUserTeams now embeds open_role_names (json_agg of open role titles) alongside the existing open_role_count, mirroring the search controller which already embeds both. getTeamById already embedded names (unchanged).