### PR TITLE
Session-cookie and auth hardening, a TeamCard N+1 fix, plus docs and some small chores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ logs
 *.swo
 *~
 
+# Claude Code local config (machine-specific; not shared via the repo)
+.claude/
+
 # OS generated files
 .DS_Store
 .DS_Store?

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Built with Node.js, Express, PostgreSQL (Neon), and Socket.IO.
 
 ### Accounts & Demo Content
 
-Anyone can **register their own account** directly in the app with a valid email address (email verification is required); new profiles stay private until the user makes them public in settings. A demo login can also be provided on request.
+To test the live demo, anyone can just **register their own account** directly in the deployed app — open the app, sign up with a valid email address, confirm it via the verification link sent to them, and log in (no need to contact the developers). New profiles stay private until the user makes them public in settings.
 
 > **Note on demo content:** Lomir currently shows many demo users, teams, and roles — while few real users have registered yet, this seed data gives visitors a realistic impression of the app's purpose and possibilities (and supports ongoing development and testing). It can be hidden at any time via the demo-data filter in the search page's filter settings.
 
@@ -424,7 +424,7 @@ Full transactional account deletion. Key highlights:
 | Security headers | Helmet middleware sets standard HTTP security headers (including HSTS) on every response |
 | CSRF protection | Global `csrfProtection` middleware validates the `Origin`/`Referer` of every state-changing request (non-`GET`/`HEAD`/`OPTIONS`) against the CORS allowlist; cookie-authenticated requests without an origin are rejected. Non-browser API clients using `Authorization: Bearer` are unaffected |
 | Request body cap | `express.json` and `express.urlencoded` limited to 1 MB |
-| Rate limiting | 8 req/15 min on login/password flows; 10 req/hr on registration; 20 req/hr on username availability; 5 req/hr on contact form; 60 req/15 min on geocoding |
+| Rate limiting | 8 req/15 min on login + password reset; 15 req/15 min on authenticated account changes (change email / change password); 10 req/hr on registration; 20 req/hr on username availability; 5 req/hr on contact form; 60 req/15 min on geocoding |
 | CAPTCHA | Cloudflare Turnstile on registration and the contact form |
 | CORS | Allowlist: exact match for production URL + regex for Vercel preview deploys |
 | Password policy | Min 8 chars, at least one letter and one number (registration, reset, change) |

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Built with Node.js, Express, PostgreSQL (Neon), and Socket.IO.
 | Backend  | Render   | [lomir-backend-knae.onrender.com](https://lomir-backend-knae.onrender.com) |
 | Database | Neon     | PostgreSQL (remote) |
 
-### Test Credentials
+### Accounts & Demo Content
 
-Contact the project owner for a demo login, or register a new account with a valid email address. Email verification is required, and new profiles stay private until the user changes visibility in settings.
+Anyone can **register their own account** directly in the app with a valid email address (email verification is required); new profiles stay private until the user makes them public in settings. A demo login can also be provided on request.
+
+> **Note on demo content:** Lomir currently shows many demo users, teams, and roles — while few real users have registered yet, this seed data gives visitors a realistic impression of the app's purpose and possibilities (and supports ongoing development and testing). It can be hidden at any time via the demo-data filter in the search page's filter settings.
 
 ---
 

--- a/src/controllers/teamReadController.js
+++ b/src/controllers/teamReadController.js
@@ -258,6 +258,8 @@ const getUserTeams = async (req, res) => {
              t.is_remote,
              COALESCE(COUNT(DISTINCT tm.user_id), 0) AS current_members_count,
              (SELECT COUNT(*) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_count,
+             (SELECT COALESCE(json_agg(vr.role_name ORDER BY vr.role_name ASC), '[]'::json)
+                FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_names,
              (SELECT COUNT(*)::int FROM team_applications ta WHERE ta.team_id = t.id AND ta.status = 'pending'
                AND NOT EXISTS (
                  SELECT 1 FROM user_blocks ub

--- a/src/middlewares/rateLimiter.js
+++ b/src/middlewares/rateLimiter.js
@@ -28,6 +28,16 @@ const registerLimiter = createRateLimiter({
   message: "Too many registration attempts. Please try again later.",
 });
 
+// Authenticated account changes (change-email / change-password). Kept separate
+// from authLimiter so a user mistyping their current password can't burn through
+// the shared login budget (and vice versa); slightly more generous since these
+// already require an authenticated session plus the current password.
+const accountChangeLimiter = createRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 15,
+  message: "Too many account-change attempts. Please try again in 15 minutes.",
+});
+
 const usernameAvailabilityLimiter = createRateLimiter({
   windowMs: 60 * 60 * 1000,
   max: 20,
@@ -51,6 +61,7 @@ const geocodingLimiter = createRateLimiter({
 module.exports = {
   authLimiter,
   registerLimiter,
+  accountChangeLimiter,
   usernameAvailabilityLimiter,
   contactLimiter,
   geocodingLimiter,

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -6,6 +6,7 @@ const auth = require("../middlewares/auth");
 const {
   authLimiter,
   registerLimiter,
+  accountChangeLimiter,
   usernameAvailabilityLimiter,
 } = require("../middlewares/rateLimiter");
 const { upload } = require("../middlewares/uploadMiddleware");
@@ -46,18 +47,19 @@ router.get("/me", auth.authenticateToken, authController.getCurrentUser);
 router.post("/forgot-password", authLimiter, authController.forgotPassword);
 router.post("/reset-password", authLimiter, authController.resetPassword);
 
-// Change password (authenticated)
+// Change password (authenticated) — dedicated limiter so a mistyped current
+// password can't lock the user out of login (which uses authLimiter).
 router.put(
   "/change-password",
-  authLimiter,
+  accountChangeLimiter,
   auth.authenticateToken,
   authController.changePassword,
 );
 
-// Change email (authenticated)
+// Change email (authenticated) — same dedicated limiter as change-password.
 router.put(
   "/change-email",
-  authLimiter,
+  accountChangeLimiter,
   auth.authenticateToken,
   authController.changeEmail,
 );

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,22 @@ const { validateChatFileUrl } = require("./utils/fileValidation");
 
 require("dotenv").config();
 
+// Fail-closed security check (runs before any DB/job side effects): Turnstile
+// CAPTCHA on registration and the contact form is gated on TURNSTILE_SECRET_KEY
+// (see authController/contactController). If the key is missing, that protection
+// silently turns off (fail-open). In production, refuse to start so a
+// misconfigured deploy is caught immediately instead of running without CAPTCHA.
+// Non-production keeps the feature-flag behaviour (key optional → local dev runs
+// without it).
+if (process.env.NODE_ENV === "production" && !process.env.TURNSTILE_SECRET_KEY) {
+  console.error(
+    "FATAL: TURNSTILE_SECRET_KEY is not set in production — CAPTCHA protection " +
+      "on registration and the contact form would be silently disabled. " +
+      "Set TURNSTILE_SECRET_KEY and redeploy. Refusing to start.",
+  );
+  process.exit(1);
+}
+
 const app = require("./app");
 const http = require("http");
 const socketIo = require("socket.io");

--- a/src/utils/authCookie.js
+++ b/src/utils/authCookie.js
@@ -11,10 +11,13 @@ const isProduction = () => process.env.NODE_ENV === "production";
 /**
  * Cookie attributes for the session token.
  *
- * In production the frontend (Vercel) and backend (Render) live on different
- * domains, so the cookie must be cross-site: `sameSite: "none"` with
- * `secure: true` (browsers reject SameSite=None without Secure). Locally both
- * run on localhost, where `sameSite: "lax"` works over plain HTTP.
+ * In production the app is served same-origin — Vercel reverse-proxies `/api/*`
+ * and `/socket.io/*` to the Render backend (see the frontend `vercel.json`), so
+ * the session cookie is first-party. `sameSite: "lax"` therefore suffices and is
+ * preferred: it keeps the cookie from being sent on cross-site requests at all
+ * (a stronger CSRF posture than `"none"`), while still covering the app's
+ * same-site navigations and XHR/fetch. `secure: true` in production (HTTPS);
+ * locally `sameSite: "lax"` works over plain HTTP on localhost.
  *
  * `clear` omits `maxAge`/`expires` so the same attributes can be reused to
  * delete the cookie (the attributes must match for the browser to remove it).
@@ -23,7 +26,7 @@ const buildCookieOptions = ({ clear = false } = {}) => {
   const options = {
     httpOnly: true,
     secure: isProduction(),
-    sameSite: isProduction() ? "none" : "lax",
+    sameSite: "lax",
     path: "/",
   };
 


### PR DESCRIPTION
## Summary
Release of the changes on `dev` ahead of `main`: session-cookie and auth
hardening, a TeamCard N+1 fix, plus docs and a chore.

## What's included

### Security — session cookie & auth hardening
- **Session cookie `sameSite=lax`.** Now that the app is served same-origin in
  production (the frontend reverse-proxies the API), the session cookie is
  first-party and no longer needs `sameSite=none`. `lax` means it is never sent
  on cross-site requests — a stronger CSRF posture. `secure` stays on in production.
- **Turnstile fail-closed startup guard.** In production the server refuses to
  start if `TURNSTILE_SECRET_KEY` is missing, so CAPTCHA protection on
  registration and the contact form can't be silently disabled by a misconfigured
  deploy. No-op outside production.
- **Dedicated account-change rate limiter.** `/change-email` and
  `/change-password` use their own limiter (15 / 15 min) instead of sharing the
  login limiter, so a mistyped current password can't lock a user out of login.

### Performance — TeamCard N+1
- `getUserTeams` now embeds `open_role_names` (alongside the existing
  `open_role_count`), mirroring the search controller, so the frontend TeamCard
  can render open roles from the list payload instead of fetching each team's
  roles individually (companion frontend PR).

### Docs & chore
- README: clarify self-service registration and demo content; documentation update.
- Add `.claude/` to `.gitignore` (local editor/tool config).

## Testing
- `node --check` + `npm test` → 83/83 passing.
- Startup guard verified locally (production mode without the key → fatal log + exit).