### PR TITLE
Fix backend email delivery with Brevo HTTPS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To test the live demo, anyone can just **register their own account** directly i
 
 ## Features
 
-- **Authentication** — JWT-based registration, login, email verification, password reset, and verified email change. The session JWT is delivered as an `httpOnly`, `sameSite` cookie (never in the response body or readable by frontend JavaScript); auth middleware and the Socket.IO handshake read it from the cookie, with the `Authorization: Bearer` header kept as a fallback for API clients. Transactional auth emails are sent through Nodemailer SMTP. Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev). Registration requires explicit acceptance of Terms of Service, acknowledgement of the Privacy Policy, and confirmation of minimum age (16+); the version of each legal document is stamped on the user row at sign-up. Changing an account email is double-opt-in: the current-password-protected request stores the new address as `pending_email` with a 24-hour token and sends a verification link to it, and the account email only switches over once the new address confirms — the old address stays active until then. Expired email-change tokens are cleared by the same cleanup pass as password-reset tokens.
+- **Authentication** — JWT-based registration, login, email verification, password reset, and verified email change. The session JWT is delivered as an `httpOnly`, `sameSite` cookie (never in the response body or readable by frontend JavaScript); auth middleware and the Socket.IO handshake read it from the cookie, with the `Authorization: Bearer` header kept as a fallback for API clients. Transactional emails are sent through Brevo's transactional HTTPS API (Render blocks outbound SMTP). Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev). Registration requires explicit acceptance of Terms of Service, acknowledgement of the Privacy Policy, and confirmation of minimum age (16+); the version of each legal document is stamped on the user row at sign-up. Changing an account email is double-opt-in: the current-password-protected request stores the new address as `pending_email` with a 24-hour token and sends a verification link to it, and the account email only switches over once the new address confirms — the old address stays active until then. Expired email-change tokens are cleared by the same cleanup pass as password-reset tokens.
 - **User Profiles** — CRUD with avatar uploads (ImageKit), interest tags, badge portfolios, and user-controlled public/private visibility. Verified accounts remain private by default until the user opts in to public visibility.
 - **User Blocking** — Authenticated users can manage a private blocklist. Block relationships hide profiles and user-search results where requester context is available, suppress team application visibility, disable direct messaging, and exclude blocked users from team chat realtime events where needed.
 - **Teams** — Create, join, manage members, assign roles, and archive teams
@@ -39,7 +39,7 @@ To test the live demo, anyone can just **register their own account** directly i
 - **Badge System** — 30 badges across 5 categories; award badges to teammates with reasons and context
 - **Notifications** — In-app notifications for invitations, applications, badge awards, messages, @mentions, and role lifecycle events; each notification deep-links to the exact message that triggered it; stale notifications are cleaned up automatically on member removal, role deletion, and team deletion
 - **Account Deletion** — Full transactional account deletion with impact preview, automatic team ownership transfer, role reopening, and "Former Lomir User" handling for preserved references
-- **Contact Form & Reports** — Public `/api/contact` endpoint with Joi validation, Turnstile CAPTCHA, in-memory file attachments (up to 3 files, 5 MB each, 10 MB total), and SMTP forwarding. Abuse/content reports are persisted in `contact_reports` with a reference ID before email forwarding, so reports are not lost if SMTP delivery fails; reporters also receive an automated acknowledgement-of-receipt email with their reference ID (sent only for `Report content or abuse` submissions, best-effort so a failed receipt never fails the request); unexpected body fields are stripped defensively so multipart attachment fields cannot break validation; rate-limited to 5 submissions/hr
+- **Contact Form & Reports** — Public `/api/contact` endpoint with Joi validation, Turnstile CAPTCHA, in-memory file attachments (up to 3 files, 5 MB each, 10 MB total), and email delivery via Brevo. Abuse/content reports are persisted in `contact_reports` with a reference ID before the email is forwarded, so reports are not lost if email delivery fails; reporters also receive an automated acknowledgement-of-receipt email with their reference ID (sent only for `Report content or abuse` submissions, best-effort so a failed receipt never fails the request); unexpected body fields are stripped defensively so multipart attachment fields cannot break validation; rate-limited to 5 submissions/hr
 - **Geocoding** — Location enrichment via Nominatim: resolves a full location object (postal code, city, district, state, country, coordinates) from partial input. Built-in postal-code-to-district lookup for Berlin and Frankfurt (200+ mappings) used as a fast offline fallback before the API call. Works with country alone — does not require both postal code and city.
 - **Security** — `httpOnly` cookie sessions (JWT not exposed to JavaScript), CSRF origin/referer validation on all state-changing requests, Helmet security headers, request body size cap (1 MB), rate limiting on auth, contact, and geocoding endpoints, credentialed CORS allowlist (applied before body parsing), password policy enforcement, Socket.IO conversation/message authorization, production error message scrubbing
 
@@ -56,7 +56,7 @@ To test the live demo, anyone can just **register their own account** directly i
 | Auth | JSON Web Tokens (jsonwebtoken, bcrypt) |
 | Validation | Joi |
 | File Uploads | ImageKit + Multer |
-| Email | Nodemailer SMTP |
+| Email | Brevo (transactional HTTPS API) |
 | Scheduling | node-cron |
 | CAPTCHA | Cloudflare Turnstile |
 | Rate Limiting | express-rate-limit |
@@ -109,11 +109,11 @@ IMAGEKIT_PUBLIC_KEY=<your-public-key>
 IMAGEKIT_PRIVATE_KEY=<your-private-key>
 IMAGEKIT_URL_ENDPOINT=https://ik.imagekit.io/<your-id>
 
-# SMTP email (Gmail SMTP in the current deployment)
-SMTP_HOST=smtp.gmail.com
-SMTP_PORT=587
-SMTP_USER=<smtp-email-address>
-SMTP_PASS=<smtp-app-password>
+# Email (Brevo transactional HTTPS API — Render blocks outbound SMTP)
+BREVO_API_KEY=<brevo-api-key>
+BREVO_SENDER_EMAIL=<verified-brevo-sender-address>
+# BREVO_SENDER_NAME=Lomir              # optional, defaults to "Lomir"
+# CONTACT_INBOX_EMAIL=<inbox-address>  # where contact-form/report mail is sent
 
 # Frontend URL (for CORS and email links)
 CLIENT_URL=http://localhost:5173
@@ -191,7 +191,7 @@ Lomir-backend/
 │   │   ├── searchController.js
 │   │   ├── badgeController.js
 │   │   ├── contactController.js       # Contact form: Joi validation with unknown-field stripping,
-│   │   │                              #   Turnstile CAPTCHA, report persistence, SMTP forwarding
+│   │   │                              #   Turnstile CAPTCHA, report persistence, email forwarding
 │   │   ├── messageController.js
 │   │   ├── notificationController.js
 │   │   └── matchingController.js
@@ -221,7 +221,8 @@ Lomir-backend/
 │   │   ├── tagModel.js
 │   │   └── contactReportModel.js # Persistent abuse/content report records and email status updates
 │   ├── services/
-│   │   └── emailService.js     # Nodemailer SMTP transactional email (verification, password reset/changed, email-change, contact forwarding, report receipt)
+│   │   ├── emailService.js     # Transactional email methods + templates (verification, password reset/changed, email-change, contact forwarding, report receipt)
+│   │   └── mailProvider.js     # Brevo HTTPS transport (single seam; swap provider here)
 │   ├── utils/
 │   │   ├── booleanSearchParser.js
 │   │   ├── imagekitUtils.js
@@ -296,7 +297,7 @@ All routes are prefixed with `/api`.
 | `/api/imagekit` | Auth params for client-side ImageKit uploads |
 | `/api/tags` | Tag catalog (structured by category) |
 | `/api/geocoding` | Postal code → city/district/country/coordinates lookup |
-| `/api/contact` | Public contact form submission with optional file attachments forwarded by SMTP; `Report content or abuse` submissions are persisted first, return a `referenceId`, and trigger an automated acknowledgement-of-receipt email to the reporter |
+| `/api/contact` | Public contact form submission with optional file attachments forwarded by email (Brevo); `Report content or abuse` submissions are persisted first, return a `referenceId`, and trigger an automated acknowledgement-of-receipt email to the reporter |
 
 ---
 
@@ -443,7 +444,7 @@ Full transactional account deletion. Key highlights:
 - **`npm install` fails on bcrypt** — Install native build tools (see Prerequisites), then `rm -rf node_modules package-lock.json && npm install`
 - **CORS errors** — Make sure `CLIENT_URL` in `.env` matches your frontend origin (`http://localhost:5173`)
 - **Database connection issues** — Verify `DATABASE_URL` is correct and you have internet access
-- **SMTP transport is not configured** — Set `SMTP_HOST`, `SMTP_USER`, and `SMTP_PASS`; `SMTP_PORT` defaults to `587`
+- **Email provider is not configured** — Set `BREVO_API_KEY` and `BREVO_SENDER_EMAIL` (the sender must be verified in Brevo)
 - **Port already in use** — `lsof -i :5001` to find the process, `kill -9 <PID>` to free the port
 - **CAPTCHA not loading locally** — Expected when no Turnstile key is configured; the CAPTCHA check runs in the deployed environment.
 

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -1,45 +1,17 @@
-const nodemailer = require("nodemailer");
+const mailProvider = require("./mailProvider");
 
-const useSmtp = Boolean(
-  process.env.SMTP_HOST && process.env.SMTP_USER && process.env.SMTP_PASS,
-);
-const smtpPort = parseInt(process.env.SMTP_PORT || "587", 10);
-// Port 465 uses implicit TLS; 587 uses STARTTLS. Some hosts (incl. cloud
-// platforms) throttle or block outbound 587, surfacing as an ETIMEDOUT on
-// connect — switching to 465 via SMTP_PORT (or forcing SMTP_SECURE=true) is the
-// usual fix. Explicit timeouts so an unreachable SMTP host fails fast instead of
-// hanging the request for the nodemailer default (~2 min).
-const smtpSecure = process.env.SMTP_SECURE === "true" || smtpPort === 465;
-const smtpTransporter = useSmtp
-  ? nodemailer.createTransport({
-      host: process.env.SMTP_HOST,
-      port: smtpPort,
-      secure: smtpSecure,
-      auth: {
-        user: process.env.SMTP_USER,
-        pass: process.env.SMTP_PASS,
-      },
-      connectionTimeout: 15000,
-      greetingTimeout: 10000,
-      socketTimeout: 30000,
-    })
-  : null;
-
-const SMTP_FROM = `Lomir <${process.env.SMTP_USER}>`;
-
-const sendEmail = async ({ to, subject, html, replyTo }) => {
-  if (!smtpTransporter) {
-    throw new Error(
-      "SMTP transport is not configured. Set SMTP_HOST, SMTP_USER, and SMTP_PASS environment variables.",
-    );
-  }
-
-  const info = await smtpTransporter.sendMail({
-    from: SMTP_FROM,
+// All transactional email goes out through the provider module (Brevo over the
+// HTTPS API, port 443). Render blocks outbound SMTP, so nodemailer/SMTP is no
+// longer used. sendEmail is the single transport seam — swap the provider and
+// every mail method follows. `attachments` are passed through for the contact
+// form (multer files); the provider base64-encodes them.
+const sendEmail = async ({ to, subject, html, replyTo, attachments }) => {
+  const info = await mailProvider.send({
     to,
     subject,
     html,
     replyTo,
+    attachments,
   });
 
   // Log success in all environments (subject + messageId are not PII; the
@@ -389,13 +361,11 @@ const emailService = {
     const subjectTopic = cleanHeaderValue(topic || "General inquiry");
 
     try {
-      if (!smtpTransporter) {
-        throw new Error("SMTP transport is not configured");
-      }
-
       const mailOptions = {
-        from: SMTP_FROM,
-        to: process.env.SMTP_USER,
+        to:
+          process.env.CONTACT_INBOX_EMAIL ||
+          process.env.BREVO_SENDER_EMAIL ||
+          process.env.SMTP_USER,
         replyTo: {
           name: cleanHeaderValue(name),
           address: email,
@@ -438,20 +408,10 @@ const emailService = {
       };
 
       if (attachments?.length) {
-        mailOptions.attachments = attachments.map((file) => ({
-          filename: file.originalname,
-          content: file.buffer,
-          contentType: file.mimetype,
-        }));
+        mailOptions.attachments = attachments;
       }
 
-      const info = await smtpTransporter.sendMail(mailOptions);
-
-      if (process.env.NODE_ENV !== "production") {
-        console.log("Contact form email sent:", info?.messageId);
-      }
-
-      return { success: true, messageId: info?.messageId };
+      return await sendEmail(mailOptions);
     } catch (error) {
       console.error("Contact form email send error:", error);
       return { success: false };

--- a/src/services/mailProvider.js
+++ b/src/services/mailProvider.js
@@ -1,0 +1,88 @@
+// Mail transport provider — Brevo transactional email over the HTTPS API
+// (port 443). Render blocks outbound SMTP (ETIMEDOUT on connect for 587 and
+// 465), so we send over HTTPS instead of nodemailer/SMTP. emailService.sendEmail
+// is the single seam that calls this module; to swap providers later, only this
+// file changes (the controllers, templates, and email methods stay untouched).
+
+const BREVO_API_URL = "https://api.brevo.com/v3/smtp/email";
+
+const isConfigured = () =>
+  Boolean(process.env.BREVO_API_KEY && process.env.BREVO_SENDER_EMAIL);
+
+// Accept a reply-to as a plain email string or an object ({ email|address, name }).
+const normalizeReplyTo = (replyTo) => {
+  if (!replyTo) return undefined;
+  if (typeof replyTo === "string") return { email: replyTo };
+  const email = replyTo.email || replyTo.address;
+  if (!email) return undefined;
+  return replyTo.name ? { email, name: replyTo.name } : { email };
+};
+
+// Accept multer files ({ originalname, buffer, mimetype }) or pre-mapped
+// attachments ({ filename|name, content }); Brevo wants { name, content(base64) }.
+const normalizeAttachments = (attachments) => {
+  if (!attachments?.length) return undefined;
+  return attachments.map((file) => {
+    const buf = file.content ?? file.buffer;
+    return {
+      name: file.filename || file.originalname || file.name,
+      content: Buffer.isBuffer(buf)
+        ? buf.toString("base64")
+        : Buffer.from(buf || "").toString("base64"),
+    };
+  });
+};
+
+/**
+ * Send one transactional email via Brevo. Resolves to { messageId } on success
+ * and throws on failure, mirroring the previous nodemailer contract so callers
+ * (which check `emailResult.success`) stay unchanged.
+ */
+const send = async ({ to, subject, html, replyTo, attachments }) => {
+  if (!isConfigured()) {
+    throw new Error(
+      "Email provider is not configured. Set BREVO_API_KEY and BREVO_SENDER_EMAIL.",
+    );
+  }
+
+  const payload = {
+    sender: {
+      email: process.env.BREVO_SENDER_EMAIL,
+      name: process.env.BREVO_SENDER_NAME || "Lomir",
+    },
+    to: [{ email: to }],
+    subject,
+    htmlContent: html,
+  };
+
+  const normalizedReplyTo = normalizeReplyTo(replyTo);
+  if (normalizedReplyTo) payload.replyTo = normalizedReplyTo;
+
+  const normalizedAttachments = normalizeAttachments(attachments);
+  if (normalizedAttachments) payload.attachment = normalizedAttachments;
+
+  const response = await fetch(BREVO_API_URL, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "api-key": process.env.BREVO_API_KEY,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let detail = "";
+    try {
+      detail = JSON.stringify(await response.json());
+    } catch {
+      detail = await response.text().catch(() => "");
+    }
+    throw new Error(`Brevo API responded ${response.status}: ${detail}`);
+  }
+
+  const data = await response.json().catch(() => ({}));
+  return { messageId: data?.messageId };
+};
+
+module.exports = { send, isConfigured };


### PR DESCRIPTION
## Summary

This PR switches Lomir backend transactional email delivery from SMTP/Nodemailer to Brevo's transactional HTTPS API.

Render blocks outbound SMTP connections, which caused email delivery failures/timeouts for auth and contact/report emails. The new provider sends mail over HTTPS instead, while keeping the existing email service methods and caller behavior intact.

## Changes

- Add `src/services/mailProvider.js` as the single transport layer for Brevo email delivery
- Replace the Nodemailer/SMTP transport in `emailService.js` with the new provider
- Preserve support for:
  - verification emails
  - password reset and password-change emails
  - email-change verification
  - contact form forwarding
  - abuse/content report acknowledgement emails
- Pass contact form attachments through to Brevo as base64-encoded attachments
- Normalize `replyTo` values for contact/report submissions
- Add `CONTACT_INBOX_EMAIL` fallback behavior for contact/report delivery
- Update README documentation and environment variable examples from SMTP settings to Brevo settings

## Environment Variables

New required variables:

- `BREVO_API_KEY`
- `BREVO_SENDER_EMAIL`

Optional variables:

- `BREVO_SENDER_NAME`
- `CONTACT_INBOX_EMAIL`

## Testing

Not run locally for this comparison.

Expected manual checks after deployment:

- Register a new user and receive verification email
- Request password reset and receive reset email
- Submit contact form with and without attachments
- Submit abuse/content report and confirm report acknowledgement email