### PR TITLE
feat(teams): scheduled cleanup of archived teams past a grace period

### DIFF
--- a/src/jobs/cleanupArchivedTeams.js
+++ b/src/jobs/cleanupArchivedTeams.js
@@ -1,0 +1,81 @@
+const cron = require("node-cron");
+const db = require("../config/database");
+const { permanentlyDeleteTeam } = require("../controllers/teamController");
+
+// When an owner deletes a team that still has other members it is only
+// soft-deleted (archived): the chat is kept so the remaining members can see the
+// "team deleted" notice and read the history one last time, and it is normally
+// purged once the last member leaves (see checkAndCleanupArchivedTeam). This job
+// is the safety net for the case where members never explicitly leave — it
+// permanently removes any team that has been archived for longer than the grace
+// period, together with its chat messages, members and avatar, so a deleted team
+// never lingers forever.
+const parsedGrace = Number(process.env.ARCHIVED_TEAM_GRACE_DAYS);
+const GRACE_PERIOD_DAYS =
+  Number.isFinite(parsedGrace) && parsedGrace >= 0 ? parsedGrace : 30;
+
+const debugLog = (...args) => {
+  if (process.env.NODE_ENV !== "production") {
+    console.log(...args);
+  }
+};
+
+// Core logic, separated from the schedule so it can be unit-tested and triggered
+// manually. Returns how many archived teams were found and successfully purged.
+const purgeExpiredArchivedTeams = async () => {
+  const { rows } = await db.query(
+    `
+    SELECT id
+    FROM teams
+    WHERE archived_at IS NOT NULL
+      AND archived_at < NOW() - INTERVAL '${GRACE_PERIOD_DAYS} days'
+    `,
+  );
+
+  let deleted = 0;
+  for (const { id } of rows) {
+    try {
+      await permanentlyDeleteTeam(id);
+      deleted += 1;
+    } catch (error) {
+      console.error(
+        `[Cleanup] Failed to permanently delete archived team ${id}:`,
+        error,
+      );
+    }
+  }
+
+  return { found: rows.length, deleted };
+};
+
+const cleanupArchivedTeams = () => {
+  // Daily at 03:30 — after the 02:00 file cleanup, before the 09:00 notifications.
+  cron.schedule(
+    "30 3 * * *",
+    async () => {
+      try {
+        const { found, deleted } = await purgeExpiredArchivedTeams();
+        if (found > 0) {
+          debugLog(
+            `[Cleanup] Permanently deleted ${deleted}/${found} archived team(s) older than ${GRACE_PERIOD_DAYS} day(s).`,
+          );
+        } else {
+          debugLog(
+            "[Cleanup] No archived teams past the grace period to delete.",
+          );
+        }
+      } catch (error) {
+        console.error("[Cleanup] Error cleaning up archived teams:", error);
+      }
+    },
+    { timezone: "Europe/Berlin" },
+  );
+
+  debugLog(
+    `[Cleanup] Archived-team cleanup job scheduled (daily 03:30 Europe/Berlin, grace ${GRACE_PERIOD_DAYS} day(s)).`,
+  );
+};
+
+module.exports = cleanupArchivedTeams;
+module.exports.purgeExpiredArchivedTeams = purgeExpiredArchivedTeams;
+module.exports.GRACE_PERIOD_DAYS = GRACE_PERIOD_DAYS;

--- a/src/server.js
+++ b/src/server.js
@@ -830,6 +830,9 @@ initScheduledJobs();
 const cleanupUnverifiedAccounts = require("./jobs/cleanupUnverifiedAccounts");
 cleanupUnverifiedAccounts();
 
+const cleanupArchivedTeams = require("./jobs/cleanupArchivedTeams");
+cleanupArchivedTeams();
+
 // Start server
 server.listen(PORT, () => {
   console.log(`Server running on port ${PORT} with Socket.IO enabled`);

--- a/test/cleanupArchivedTeams.test.js
+++ b/test/cleanupArchivedTeams.test.js
@@ -1,0 +1,109 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const db = require("../src/config/database");
+const cleanupArchivedTeams = require("../src/jobs/cleanupArchivedTeams");
+
+const { purgeExpiredArchivedTeams } = cleanupArchivedTeams;
+
+const originalQuery = db.query;
+const originalConnect = db.pool.connect;
+
+test.afterEach(() => {
+  db.query = originalQuery;
+  db.pool.connect = originalConnect;
+});
+
+test("purgeExpiredArchivedTeams permanently deletes archived teams past the grace period", async () => {
+  let selectSql = "";
+  db.query = async (sql) => {
+    selectSql = sql;
+    return { rows: [{ id: 10 }, { id: 20 }] };
+  };
+
+  // permanentlyDeleteTeam runs its own transaction through a dedicated client.
+  const clientCalls = [];
+  db.pool.connect = async () => ({
+    async query(sql) {
+      clientCalls.push(sql);
+      if (sql.includes("teamavatar_url")) {
+        return { rows: [{ teamavatar_url: null, teamavatar_file_id: null }] };
+      }
+      return { rows: [] };
+    },
+    release() {},
+  });
+
+  const result = await purgeExpiredArchivedTeams();
+
+  // Only archived teams older than the grace period are selected.
+  assert.match(selectSql, /archived_at IS NOT NULL/);
+  assert.match(selectSql, /archived_at < NOW\(\) - INTERVAL/);
+
+  assert.deepEqual(result, { found: 2, deleted: 2 });
+
+  // Each selected team was hard-deleted (team row removed once per team).
+  const teamDeletes = clientCalls.filter((sql) =>
+    sql.includes("DELETE FROM teams WHERE id"),
+  );
+  assert.equal(teamDeletes.length, 2);
+  // And the chat messages were purged too.
+  assert.equal(
+    clientCalls.filter((sql) => sql.includes("DELETE FROM messages WHERE team_id"))
+      .length,
+    2,
+  );
+});
+
+test("purgeExpiredArchivedTeams is a no-op when nothing is past the grace period", async () => {
+  db.query = async () => ({ rows: [] });
+
+  let connectCalled = false;
+  db.pool.connect = async () => {
+    connectCalled = true;
+    throw new Error("connect should not be called when there is nothing to purge");
+  };
+
+  const result = await purgeExpiredArchivedTeams();
+
+  assert.deepEqual(result, { found: 0, deleted: 0 });
+  assert.equal(connectCalled, false);
+});
+
+test("purgeExpiredArchivedTeams keeps going and counts only successful purges when one team fails", async () => {
+  db.query = async () => ({ rows: [{ id: 10 }, { id: 20 }] });
+
+  db.pool.connect = async () => ({
+    async query(sql) {
+      if (sql.includes("teamavatar_url")) {
+        // Team 10 blows up while reading its avatar; team 20 succeeds.
+        return { rows: [{ teamavatar_url: null, teamavatar_file_id: null }] };
+      }
+      return { rows: [] };
+    },
+    release() {},
+  });
+
+  // Make the first permanentlyDeleteTeam call fail by throwing on BEGIN once.
+  let beginCount = 0;
+  const originalConnectImpl = db.pool.connect;
+  db.pool.connect = async () => {
+    const client = await originalConnectImpl();
+    const innerQuery = client.query;
+    client.query = async (sql, params) => {
+      if (sql === "BEGIN") {
+        beginCount += 1;
+        if (beginCount === 1) {
+          throw new Error("simulated failure for the first team");
+        }
+      }
+      return innerQuery(sql, params);
+    };
+    return client;
+  };
+
+  const result = await purgeExpiredArchivedTeams();
+
+  assert.equal(result.found, 2);
+  assert.equal(result.deleted, 1);
+});


### PR DESCRIPTION
Add a daily cron job (03:30 Europe/Berlin) that permanently deletes teams which have been archived (soft-deleted) for longer than a grace period, removing the team along with its chat messages, members and avatar via permanentlyDeleteTeam.

The grace period defaults to 30 days and is configurable through the ARCHIVED_TEAM_GRACE_DAYS env var (validated as a non-negative number so it cannot break the interval query). The core purgeExpiredArchivedTeams logic is separated from the schedule so it can be unit-tested and triggered manually, and it is resilient: a failure on one team is logged and does not stop the others.

This complements checkAndCleanupArchivedTeam (which purges immediately once a team reaches zero members) as a safety net, so a deleted team never lingers forever when its members never explicitly leave the archived chat.