### PR TITLE
Run unverified account cleanup on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To test the live demo, anyone can just **register their own account** directly i
 
 ## Features
 
-- **Authentication** — JWT-based registration, login, email verification, password reset, and verified email change. The session JWT is delivered as an `httpOnly`, `sameSite` cookie (never in the response body or readable by frontend JavaScript); auth middleware and the Socket.IO handshake read it from the cookie, with the `Authorization: Bearer` header kept as a fallback for API clients. Transactional emails are sent through Brevo's transactional HTTPS API (Render blocks outbound SMTP). Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev). Registration requires explicit acceptance of Terms of Service, acknowledgement of the Privacy Policy, and confirmation of minimum age (16+); the version of each legal document is stamped on the user row at sign-up. Changing an account email is double-opt-in: the current-password-protected request stores the new address as `pending_email` with a 24-hour token and sends a verification link to it, and the account email only switches over once the new address confirms — the old address stays active until then. Expired email-change tokens are cleared by the same cleanup pass as password-reset tokens.
+- **Authentication** — JWT-based registration, login, email verification, password reset, and verified email change. The session JWT is delivered as an `httpOnly`, `sameSite` cookie (never in the response body or readable by frontend JavaScript); auth middleware and the Socket.IO handshake read it from the cookie, with the `Authorization: Bearer` header kept as a fallback for API clients. Transactional emails are sent through Brevo's transactional HTTPS API (Render blocks outbound SMTP). Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev). Registration requires explicit acceptance of Terms of Service, acknowledgement of the Privacy Policy, and confirmation of minimum age (16+); the version of each legal document is stamped on the user row at sign-up. Unverified accounts are deleted after their verification link expires plus a one-hour buffer, with cleanup running every six hours and once on server startup. Changing an account email is double-opt-in: the current-password-protected request stores the new address as `pending_email` with a 24-hour token and sends a verification link to it, and the account email only switches over once the new address confirms — the old address stays active until then. Expired email-change tokens are cleared by the same cleanup pass as password-reset tokens.
 - **User Profiles** — CRUD with avatar uploads (ImageKit), interest tags, badge portfolios, and user-controlled public/private visibility. Verified accounts remain private by default until the user opts in to public visibility.
 - **User Blocking** — Authenticated users can manage a private blocklist. Block relationships hide profiles and user-search results where requester context is available, suppress team application visibility, disable direct messaging, and exclude blocked users from team chat realtime events where needed.
 - **Teams** — Create, join, manage members, assign roles, and archive teams
@@ -247,8 +247,8 @@ Lomir-backend/
 │   │   └── geocodingUtil.js    # resolveLocationData (full enrichment) + geocodeAddress (coords only)
 │   ├── jobs/
 │   │   ├── fileCleanupScheduler.js # node-cron job that calls fileCleanup utilities on a schedule
-│   │   ├── cleanupUnverifiedAccounts.js # Runs every 6 hours; deletes expired unverified accounts
-│   │   └── cleanupArchivedTeams.js # Daily; permanently deletes teams archived longer than the grace period
+│   │   ├── cleanupUnverifiedAccounts.js # Every 6 hours + startup; deletes expired unverified accounts
+│   │   └── cleanupArchivedTeams.js # Daily + startup; permanently deletes teams archived longer than the grace period
 │   └── database/
 │       └── migrations/
 │           └── create_contact_reports.js # Stores report submissions with reference IDs and mail status
@@ -408,8 +408,13 @@ The public `GET /api/geocoding/postal-code/:code` endpoint is rate-limited (60 r
 | Job | Schedule | Description |
 |---|---|---|
 | File cleanup | Configurable (see `fileCleanupScheduler.js`) | Expires and deletes orphaned ImageKit files |
-| Unverified account cleanup | Every 6 hours | Deletes accounts where email verification expired more than 1 hour ago |
+| Unverified account cleanup | Every 6 hours and once on server startup | Deletes accounts where email verification expired more than 1 hour ago, including on hosts that may sleep through the cron time |
 | Archived team cleanup | Daily at 03:30 (Europe/Berlin) and once on server startup | Permanently deletes teams (with their chat, members, and avatar) archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30); safety net for deleted teams whose members never leave, including on hosts that may sleep through the cron time |
+
+The unverified-account cleanup first clears optional references that may point at
+expired registration rows (for example role, tag, team-owner, and badge-awarder
+references) so old unverified accounts can still be deleted safely even if they
+picked up related records during development or test activity.
 
 ---
 
@@ -431,7 +436,7 @@ When an owner deletes a team (`DELETE /api/teams/:id`), the behaviour depends on
 
 - **Solo team (owner is the only member)** — the team is **permanently deleted right away** via `permanentlyDeleteTeam`, removing the team row, its chat messages, invitations/applications, badges, notifications, members, and the ImageKit avatar. Nothing is left behind, so a deleted solo team never leaves an orphaned, unreachable conversation.
 - **Team with other members** — the team is **soft-deleted (archived)**: `archived_at`/`status` are set, a `TEAM_DELETED` system message is posted to the chat, and every member is notified. The archived chat stays visible so members can see the notice and read the history; it is permanently purged once the **last** member leaves (`checkAndCleanupArchivedTeam`).
-- **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the daily `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30). See [Scheduled Jobs](#scheduled-jobs).
+- **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30). It runs daily and once on server startup. See [Scheduled Jobs](#scheduled-jobs).
 
 Covered by `teamController.deleteTeam.test.js` and `cleanupArchivedTeams.test.js`.
 

--- a/src/jobs/cleanupUnverifiedAccounts.js
+++ b/src/jobs/cleanupUnverifiedAccounts.js
@@ -8,36 +8,93 @@ const debugLog = (...args) => {
   }
 };
 
+const purgeExpiredUnverifiedAccounts = async () => {
+  const client = await db.pool.connect();
+
+  try {
+    await client.query("BEGIN");
+
+    const expiredUsersResult = await client.query(
+      `
+      SELECT id
+      FROM users
+      WHERE email_verified = FALSE
+        AND verification_token_expires IS NOT NULL
+        AND verification_token_expires < NOW() - INTERVAL '${BUFFER_HOURS} hours'
+      `,
+    );
+
+    const expiredUserIds = expiredUsersResult.rows.map((row) => Number(row.id));
+
+    if (expiredUserIds.length === 0) {
+      await client.query("COMMIT");
+      return { deleted: 0, accounts: [] };
+    }
+
+    await client.query(
+      `UPDATE teams SET owner_id = NULL WHERE owner_id = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+    await client.query(
+      `UPDATE team_vacant_roles SET created_by = NULL WHERE created_by = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+    await client.query(
+      `UPDATE team_vacant_roles SET filled_by = NULL WHERE filled_by = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+    await client.query(
+      `UPDATE team_applications SET reviewed_by = NULL WHERE reviewed_by = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+    await client.query(
+      `UPDATE user_badges SET awarded_by = NULL WHERE awarded_by = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+    await client.query(
+      `UPDATE tags SET created_by = NULL WHERE created_by = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+
+    const result = await client.query(
+      `
+      DELETE FROM users
+      WHERE id = ANY($1::int[])
+      RETURNING id, created_at
+      `,
+      [expiredUserIds],
+    );
+
+    await client.query("COMMIT");
+
+    return {
+      deleted: result.rowCount || 0,
+      accounts: result.rows.map((row) => ({
+        id: row.id,
+        created: row.created_at,
+      })),
+    };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+const logCleanupResult = ({ deleted, accounts }) => {
+  if (deleted > 0) {
+    debugLog(`[Cleanup] Deleted ${deleted} unverified account(s):`, accounts);
+  } else {
+    debugLog("[Cleanup] No expired unverified accounts to delete.");
+  }
+};
+
 const cleanupUnverifiedAccounts = () => {
   cron.schedule("0 */6 * * *", async () => {
     try {
-      const result = await db.query(
-        `
-        WITH expired_users AS (
-          SELECT id FROM users
-          WHERE email_verified = FALSE
-            AND verification_token_expires IS NOT NULL
-            AND verification_token_expires < NOW() - INTERVAL '${BUFFER_HOURS} hours'
-        ),
-        deleted_tags AS (
-          DELETE FROM user_tags
-          WHERE user_id IN (SELECT id FROM expired_users)
-        )
-        DELETE FROM users
-        WHERE id IN (SELECT id FROM expired_users)
-        RETURNING id, email, created_at
-        `,
-      );
-
-      const count = result.rowCount || 0;
-      if (count > 0) {
-        debugLog(
-          `[Cleanup] Deleted ${count} unverified account(s):`,
-          result.rows.map((r) => ({ id: r.id, created: r.created_at })),
-        );
-      } else {
-        debugLog("[Cleanup] No expired unverified accounts to delete.");
-      }
+      const result = await purgeExpiredUnverifiedAccounts();
+      logCleanupResult(result);
     } catch (error) {
       console.error("[Cleanup] Error cleaning up unverified accounts:", error);
     }
@@ -47,3 +104,5 @@ const cleanupUnverifiedAccounts = () => {
 };
 
 module.exports = cleanupUnverifiedAccounts;
+module.exports.purgeExpiredUnverifiedAccounts = purgeExpiredUnverifiedAccounts;
+module.exports.BUFFER_HOURS = BUFFER_HOURS;

--- a/src/server.js
+++ b/src/server.js
@@ -829,6 +829,9 @@ initScheduledJobs();
 
 const cleanupUnverifiedAccounts = require("./jobs/cleanupUnverifiedAccounts");
 cleanupUnverifiedAccounts();
+cleanupUnverifiedAccounts.purgeExpiredUnverifiedAccounts().catch((error) => {
+  console.error("[Cleanup] Error cleaning up unverified accounts on startup:", error);
+});
 
 const cleanupArchivedTeams = require("./jobs/cleanupArchivedTeams");
 cleanupArchivedTeams();

--- a/test/cleanupUnverifiedAccounts.test.js
+++ b/test/cleanupUnverifiedAccounts.test.js
@@ -1,0 +1,132 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const db = require("../src/config/database");
+const cleanupUnverifiedAccounts = require("../src/jobs/cleanupUnverifiedAccounts");
+
+const { purgeExpiredUnverifiedAccounts } = cleanupUnverifiedAccounts;
+
+const originalConnect = db.pool.connect;
+
+test.afterEach(() => {
+  db.pool.connect = originalConnect;
+});
+
+test("purgeExpiredUnverifiedAccounts deletes expired unverified accounts", async () => {
+  const calls = [];
+
+  db.pool.connect = async () => ({
+    async query(sql, params) {
+      calls.push({ sql, params });
+
+      if (sql.includes("SELECT id") && sql.includes("FROM users")) {
+        return { rows: [{ id: 10 }, { id: 20 }] };
+      }
+
+      if (sql.includes("DELETE FROM users")) {
+        return {
+          rowCount: 2,
+          rows: [
+            { id: 10, created_at: "2026-06-28T08:00:00.000Z" },
+            { id: 20, created_at: "2026-06-28T09:00:00.000Z" },
+          ],
+        };
+      }
+
+      return { rows: [], rowCount: 0 };
+    },
+    release() {},
+  });
+
+  const result = await purgeExpiredUnverifiedAccounts();
+  const combinedSql = calls.map(({ sql }) => sql).join("\n");
+  const arrayParams = calls
+    .map(({ params }) => params)
+    .filter((params) => Array.isArray(params));
+
+  assert.equal(calls[0].sql, "BEGIN");
+  assert.equal(calls.at(-1).sql, "COMMIT");
+  assert.match(combinedSql, /email_verified = FALSE/);
+  assert.match(combinedSql, /verification_token_expires IS NOT NULL/);
+  assert.match(combinedSql, /verification_token_expires < NOW\(\) - INTERVAL/);
+  assert.match(combinedSql, /UPDATE teams SET owner_id = NULL/);
+  assert.match(combinedSql, /UPDATE team_vacant_roles SET created_by = NULL/);
+  assert.match(combinedSql, /UPDATE team_vacant_roles SET filled_by = NULL/);
+  assert.match(combinedSql, /UPDATE team_applications SET reviewed_by = NULL/);
+  assert.match(combinedSql, /UPDATE user_badges SET awarded_by = NULL/);
+  assert.match(combinedSql, /UPDATE tags SET created_by = NULL/);
+  assert.match(combinedSql, /DELETE FROM users/);
+  assert.doesNotMatch(combinedSql, /RETURNING id, email/);
+  assert.ok(
+    arrayParams.every((params) => params.length === 1 && params[0].length === 2),
+    "expected cleanup statements to target the expired user ids",
+  );
+  assert.deepEqual(result, {
+    deleted: 2,
+    accounts: [
+      { id: 10, created: "2026-06-28T08:00:00.000Z" },
+      { id: 20, created: "2026-06-28T09:00:00.000Z" },
+    ],
+  });
+});
+
+test("purgeExpiredUnverifiedAccounts is a no-op when no accounts expired", async () => {
+  const calls = [];
+
+  db.pool.connect = async () => ({
+    async query(sql) {
+      calls.push(sql);
+
+      if (sql.includes("SELECT id") && sql.includes("FROM users")) {
+        return { rows: [] };
+      }
+
+      return { rows: [], rowCount: 0 };
+    },
+    release() {},
+  });
+
+  const result = await purgeExpiredUnverifiedAccounts();
+
+  assert.deepEqual(result, { deleted: 0, accounts: [] });
+  assert.deepEqual(calls, [
+    "BEGIN",
+    `
+      SELECT id
+      FROM users
+      WHERE email_verified = FALSE
+        AND verification_token_expires IS NOT NULL
+        AND verification_token_expires < NOW() - INTERVAL '1 hours'
+      `,
+    "COMMIT",
+  ]);
+});
+
+test("purgeExpiredUnverifiedAccounts rolls back when cleanup fails", async () => {
+  const calls = [];
+
+  db.pool.connect = async () => ({
+    async query(sql) {
+      calls.push(sql);
+
+      if (sql.includes("SELECT id") && sql.includes("FROM users")) {
+        return { rows: [{ id: 10 }] };
+      }
+
+      if (sql.includes("UPDATE user_badges")) {
+        throw new Error("simulated foreign-key cleanup failure");
+      }
+
+      return { rows: [], rowCount: 0 };
+    },
+    release() {},
+  });
+
+  await assert.rejects(
+    () => purgeExpiredUnverifiedAccounts(),
+    /simulated foreign-key cleanup failure/,
+  );
+
+  assert.ok(calls.includes("ROLLBACK"));
+  assert.equal(calls.includes("COMMIT"), false);
+});


### PR DESCRIPTION
Extract the expired-unverified-account purge into a reusable function and invoke it once during server startup in addition to the existing six-hour cron schedule. Make the purge transactional and clear optional user references before deleting expired registration rows, so old unverified accounts with related test/development records can still be removed safely. Update the README and add focused tests for successful cleanup, no-op runs, and rollback on failure.