### PR TITLE
Archived-team "farewell" chat + member visibility (+ 14-day grace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,10 +436,11 @@ Full transactional account deletion. Key highlights:
 When an owner deletes a team (`DELETE /api/teams/:id`), the behaviour depends on whether anyone else is still a member:
 
 - **Solo team (owner is the only member)** — the team is **permanently deleted right away** via `permanentlyDeleteTeam`, removing the team row, its chat messages, invitations/applications, badges, notifications, members, and the ImageKit avatar. Nothing is left behind, so a deleted solo team never leaves an orphaned, unreachable conversation.
-- **Team with other members** — the team is **soft-deleted (archived)**: `archived_at`/`status` are set, a `TEAM_DELETED` system message is posted to the chat, and every member is notified. The archived chat stays visible so members can see the notice and read the history; it is permanently purged once the **last** member leaves (`checkAndCleanupArchivedTeam`).
+- **Team with other members** — the team is **soft-deleted (archived)**: `archived_at`/`status` are set, a `TEAM_DELETED` system message is posted to the chat, and every member is notified. The archived chat stays available to the remaining members as a **"farewell" window**: they can still read **and post** messages until they leave or the grace period ends. Socket and REST team access are gated on current membership (not on `archived_at`), so live messages keep flowing to remaining members. It is permanently purged once the **last** member leaves (`checkAndCleanupArchivedTeam`).
+- **Member visibility of archived teams** — archived teams are still served to their current members (never to outsiders — 404 otherwise, regardless of `is_public`): `getTeamById` and the team badge endpoints return them so members can open the full Team Details modal (info, focus areas, badges, roles, members) for an archived team's chat, and `getConversations`/`getConversationById` expose `archived_at`/`status`. Archived teams where the viewer is the only remaining member are hidden from the conversation list and chat search.
 - **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 14). It runs daily and once on server startup. See [Scheduled Jobs](#scheduled-jobs).
 
-Covered by `teamController.deleteTeam.test.js` and `cleanupArchivedTeams.test.js`.
+Covered by `teamController.deleteTeam.test.js`, `cleanupArchivedTeams.test.js`, and `messageController.sendMessage.test.js`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ FRONTEND_URL=http://localhost:5173
 # TURNSTILE_SECRET_KEY=<turnstile-secret-key>
 
 # Scheduled jobs (optional)
-# ARCHIVED_TEAM_GRACE_DAYS=30          # days an archived (deleted) team is kept before the cleanup job purges it; defaults to 30
+# ARCHIVED_TEAM_GRACE_DAYS=14          # days an archived (deleted) team is kept before the cleanup job purges it; defaults to 14
 ```
 
 > Get the ImageKit and database values from the project owner.
@@ -264,6 +264,7 @@ Lomir-backend/
 │   ├── errorResponse.test.js
 │   ├── invitationController.test.js
 │   ├── contactController.test.js
+│   ├── messageController.sendMessage.test.js
 │   ├── locationDerivation.test.js
 │   ├── searchController.test.js
 │   ├── teamController.applyToJoinTeam.test.js
@@ -409,7 +410,7 @@ The public `GET /api/geocoding/postal-code/:code` endpoint is rate-limited (60 r
 |---|---|---|
 | File cleanup | Configurable (see `fileCleanupScheduler.js`) | Expires and deletes orphaned ImageKit files |
 | Unverified account cleanup | Every 6 hours and once on server startup | Deletes accounts where email verification expired more than 1 hour ago, including on hosts that may sleep through the cron time |
-| Archived team cleanup | Daily at 03:30 (Europe/Berlin) and once on server startup | Permanently deletes teams (with their chat, members, and avatar) archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30); safety net for deleted teams whose members never leave, including on hosts that may sleep through the cron time |
+| Archived team cleanup | Daily at 03:30 (Europe/Berlin) and once on server startup | Permanently deletes teams (with their chat, members, and avatar) archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 14); safety net for deleted teams whose members never leave, including on hosts that may sleep through the cron time |
 
 The unverified-account cleanup first clears optional references that may point at
 expired registration rows (for example role, tag, team-owner, and badge-awarder
@@ -436,7 +437,7 @@ When an owner deletes a team (`DELETE /api/teams/:id`), the behaviour depends on
 
 - **Solo team (owner is the only member)** — the team is **permanently deleted right away** via `permanentlyDeleteTeam`, removing the team row, its chat messages, invitations/applications, badges, notifications, members, and the ImageKit avatar. Nothing is left behind, so a deleted solo team never leaves an orphaned, unreachable conversation.
 - **Team with other members** — the team is **soft-deleted (archived)**: `archived_at`/`status` are set, a `TEAM_DELETED` system message is posted to the chat, and every member is notified. The archived chat stays visible so members can see the notice and read the history; it is permanently purged once the **last** member leaves (`checkAndCleanupArchivedTeam`).
-- **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30). It runs daily and once on server startup. See [Scheduled Jobs](#scheduled-jobs).
+- **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 14). It runs daily and once on server startup. See [Scheduled Jobs](#scheduled-jobs).
 
 Covered by `teamController.deleteTeam.test.js` and `cleanupArchivedTeams.test.js`.
 

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -40,10 +40,8 @@ const ensureTeamMessageAccess = async (teamId, userId) => {
   const result = await db.query(
     `SELECT 1
      FROM team_members tm
-     JOIN teams t ON t.id = tm.team_id
      WHERE tm.team_id = $1
        AND tm.user_id = $2
-       AND t.archived_at IS NULL
      LIMIT 1`,
     [teamId, userId],
   );
@@ -415,6 +413,8 @@ const getConversations = async (req, res) => {
         NULL as first_name,
         NULL as last_name,
         t.teamavatar_url as avatar_url,
+        t.archived_at,
+        t.status,
         ltm.last_message,
         ltm.last_message_time as updated_at,
         COALESCE(tuc.unread_count, 0) as unread_count
@@ -462,6 +462,9 @@ const getConversations = async (req, res) => {
         id: row.id,
         name: row.name,
         avatarUrl: row.avatar_url,
+        archived_at: row.archived_at,
+        archivedAt: row.archived_at,
+        status: row.status,
       },
       lastMessage: row.last_message,
       updatedAt: row.updated_at,
@@ -501,10 +504,31 @@ const getConversationById = async (req, res) => {
         SELECT 
           t.id,
           t.name,
-          t.teamavatar_url as avatar_url
+          t.teamavatar_url as avatar_url,
+          t.archived_at,
+          t.status,
+          COALESCE(
+            jsonb_agg(
+              jsonb_build_object(
+                'id', u.id,
+                'userId', u.id,
+                'user_id', u.id,
+                'username', u.username,
+                'firstName', u.first_name,
+                'lastName', u.last_name,
+                'avatarUrl', u.avatar_url,
+                'role', tm_all.role
+              )
+              ORDER BY u.first_name, u.last_name, u.username
+            ) FILTER (WHERE u.id IS NOT NULL),
+            '[]'::jsonb
+          ) as members
         FROM teams t
         JOIN team_members tm ON t.id = tm.team_id
+        LEFT JOIN team_members tm_all ON t.id = tm_all.team_id
+        LEFT JOIN users u ON tm_all.user_id = u.id
         WHERE t.id = $1 AND tm.user_id = $2
+        GROUP BY t.id
       `;
 
       const teamResult = await db.query(teamQuery, [conversationId, userId]);
@@ -527,6 +551,10 @@ const getConversationById = async (req, res) => {
             id: team.id,
             name: team.name,
             avatarUrl: team.avatar_url,
+            archived_at: team.archived_at,
+            archivedAt: team.archived_at,
+            status: team.status,
+            members: team.members || [],
           },
         },
       });

--- a/src/controllers/teamBadgeController.js
+++ b/src/controllers/teamBadgeController.js
@@ -2,21 +2,30 @@ const db = require("../config/database");
 
 const isTeamVisibleToViewer = async (teamId, viewerId) => {
   const teamResult = await db.pool.query(
-    'SELECT is_public FROM teams WHERE id = $1 AND archived_at IS NULL',
+    'SELECT is_public, archived_at FROM teams WHERE id = $1',
     [teamId],
   );
   if (teamResult.rows.length === 0) return false;
 
   const team = teamResult.rows[0];
+
+  const isMember = async () => {
+    if (!viewerId) return false;
+    const memberCheck = await db.pool.query(
+      'SELECT 1 FROM team_members WHERE team_id = $1 AND user_id = $2',
+      [teamId, viewerId],
+    );
+    return memberCheck.rows.length > 0;
+  };
+
+  // Archived (deleted, scheduled-for-deletion) teams are only visible to their
+  // remaining members, regardless of is_public — so the archived-team chat can
+  // still show team badges to those members.
+  if (team.archived_at) return isMember();
+
   if (team.is_public === true || team.is_public === 'true') return true;
 
-  if (!viewerId) return false;
-
-  const memberCheck = await db.pool.query(
-    'SELECT 1 FROM team_members WHERE team_id = $1 AND user_id = $2',
-    [teamId, viewerId],
-  );
-  return memberCheck.rows.length > 0;
+  return isMember();
 };
 
 const getTeamBadgeAwards = async (req, res) => {

--- a/src/controllers/teamReadController.js
+++ b/src/controllers/teamReadController.js
@@ -67,12 +67,13 @@ const getTeamById = async (req, res) => {
       SELECT t.id, t.name, t.description, t.is_public, t.max_members,
              t.owner_id, t.teamavatar_url, t.is_remote, t.is_synthetic,
              t.created_at, t.updated_at, t.postal_code, t.city, t.country, t.state, t.district,
+             t.archived_at, t.status,
              COALESCE(COUNT(DISTINCT tm.user_id), 0) as current_members_count,
              (SELECT COUNT(*) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_count,
              (SELECT COALESCE(json_agg(vr.role_name ORDER BY vr.role_name ASC), '[]'::json) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_names
       FROM teams t
       LEFT JOIN team_members tm ON t.id = tm.team_id
-      WHERE t.id = $1 AND t.archived_at IS NULL
+      WHERE t.id = $1
       GROUP BY t.id
       `,
       [teamId],
@@ -121,6 +122,16 @@ const getTeamById = async (req, res) => {
         [teamId, req.user.id],
       );
       viewerIsMember = memberCheck.rows.length > 0;
+    }
+
+    // Archived (deleted, scheduled-for-deletion) teams are only visible to their
+    // remaining members — never to outsiders — regardless of is_public, so the
+    // archived-team chat can still show full team details to those members.
+    if (team.archived_at && !viewerIsMember) {
+      return res.status(404).json({
+        success: false,
+        message: "Team not found",
+      });
     }
 
     // Get team members — public profile location is visible to visitors and

--- a/src/jobs/cleanupArchivedTeams.js
+++ b/src/jobs/cleanupArchivedTeams.js
@@ -12,7 +12,7 @@ const { permanentlyDeleteTeam } = require("../controllers/teamController");
 // never lingers forever.
 const parsedGrace = Number(process.env.ARCHIVED_TEAM_GRACE_DAYS);
 const GRACE_PERIOD_DAYS =
-  Number.isFinite(parsedGrace) && parsedGrace >= 0 ? parsedGrace : 30;
+  Number.isFinite(parsedGrace) && parsedGrace >= 0 ? parsedGrace : 14;
 
 const debugLog = (...args) => {
   if (process.env.NODE_ENV !== "production") {

--- a/src/server.js
+++ b/src/server.js
@@ -42,14 +42,12 @@ const CHAT_FILE_RETENTION_DAYS = 60;
 const getChatFileExpiresAt = () =>
   new Date(Date.now() + CHAT_FILE_RETENTION_DAYS * 24 * 60 * 60 * 1000);
 
-const isActiveTeamMember = async (teamId, userId) => {
+const isCurrentTeamMember = async (teamId, userId) => {
   const result = await db.query(
     `SELECT 1
      FROM team_members tm
-     JOIN teams t ON t.id = tm.team_id
      WHERE tm.team_id = $1
        AND tm.user_id = $2
-       AND t.archived_at IS NULL
      LIMIT 1`,
     [teamId, userId],
   );
@@ -216,8 +214,7 @@ io.on("connection", (socket) => {
          FROM team_members tm
          JOIN teams t ON t.id = tm.team_id
          WHERE tm.team_id = $1
-           AND tm.user_id = $2
-           AND t.archived_at IS NULL`,
+           AND tm.user_id = $2`,
         [conversationId, userId],
       );
 
@@ -324,7 +321,7 @@ io.on("connection", (socket) => {
       let replyTo = null;
 
       if (type === "team") {
-        const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+        const canAccessTeam = await isCurrentTeamMember(conversationId, userId);
         if (!canAccessTeam) {
           socket.emit("error", { message: "Not authorized to send messages to this team" });
           return;
@@ -542,7 +539,7 @@ io.on("connection", (socket) => {
         for (const mentionedUserId of notified) {
           try {
             if (type === "team") {
-              const mentionedMember = await isActiveTeamMember(
+              const mentionedMember = await isCurrentTeamMember(
                 conversationId,
                 mentionedUserId,
               );
@@ -591,7 +588,7 @@ io.on("connection", (socket) => {
     }
 
     if (type === "team") {
-      const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+      const canAccessTeam = await isCurrentTeamMember(conversationId, userId);
       if (!canAccessTeam) {
         socket.emit("error", { message: "Not authorized for this team conversation" });
         return;
@@ -639,7 +636,7 @@ io.on("connection", (socket) => {
     }
 
     if (type === "team") {
-      const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+      const canAccessTeam = await isCurrentTeamMember(conversationId, userId);
       if (!canAccessTeam) {
         socket.emit("error", { message: "Not authorized for this team conversation" });
         return;
@@ -689,7 +686,7 @@ io.on("connection", (socket) => {
       }
 
       if (type === "team") {
-        const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+        const canAccessTeam = await isCurrentTeamMember(conversationId, userId);
         if (!canAccessTeam) {
           socket.emit("error", { message: "Not authorized for this team conversation" });
           return;

--- a/test/messageController.sendMessage.test.js
+++ b/test/messageController.sendMessage.test.js
@@ -1,0 +1,184 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const db = require("../src/config/database");
+const messageController = require("../src/controllers/messageController");
+
+const originalQuery = db.query;
+
+test.afterEach(() => {
+  db.query = originalQuery;
+});
+
+const createResponse = () => {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res;
+};
+
+test("sendMessage allows current members to post in an archived team chat", async () => {
+  const queries = [];
+
+  db.query = async (sql, params) => {
+    queries.push({ sql, params });
+
+    if (sql.includes("FROM team_members tm")) {
+      return { rows: [{ "?column?": 1 }] };
+    }
+
+    if (sql.includes("INSERT INTO messages")) {
+      return {
+        rows: [
+          {
+            id: 123,
+            sender_id: 10,
+            team_id: 20,
+            content: "Still here for the farewell.",
+            reply_to_id: null,
+            image_url: null,
+            file_url: null,
+            file_name: null,
+            file_size: null,
+            file_expires_at: null,
+            sent_at: new Date("2026-06-30T10:00:00.000Z"),
+          },
+        ],
+      };
+    }
+
+    if (sql.includes("SELECT username, first_name, last_name FROM users")) {
+      return {
+        rows: [
+          { username: "jane", first_name: "Jane", last_name: "Doe" },
+        ],
+      };
+    }
+
+    if (sql.includes("SELECT COUNT(*)::int AS recipient_count")) {
+      return { rows: [{ recipient_count: 1 }] };
+    }
+
+    return { rows: [] };
+  };
+
+  const emitted = [];
+  const req = {
+    user: { id: 10 },
+    params: { id: "20" },
+    body: {
+      type: "team",
+      content: "Still here for the farewell.",
+    },
+    app: {
+      get() {
+        return {
+          to(room) {
+            return {
+              emit(event, payload) {
+                emitted.push({ room, event, payload });
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+  const res = createResponse();
+
+  await messageController.sendMessage(req, res);
+
+  const accessQuery = queries.find(({ sql }) =>
+    sql.includes("FROM team_members tm"),
+  );
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.success, true);
+  assert.doesNotMatch(accessQuery.sql, /archived_at IS NULL/);
+  assert.equal(emitted[0].room, "team:20");
+  assert.equal(emitted[0].event, "message:received");
+});
+
+test("sendMessage still rejects users who are no longer team members", async () => {
+  db.query = async (sql) => {
+    if (sql.includes("FROM team_members tm")) {
+      return { rows: [] };
+    }
+
+    throw new Error(`Unexpected query for unauthorized team message: ${sql}`);
+  };
+
+  const req = {
+    user: { id: 10 },
+    params: { id: "20" },
+    body: {
+      type: "team",
+      content: "I should not be able to send this.",
+    },
+  };
+  const res = createResponse();
+
+  await messageController.sendMessage(req, res);
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.success, false);
+});
+
+test("getConversationById includes archived team metadata", async () => {
+  db.query = async (sql) => {
+    if (sql.includes("FROM teams t") && sql.includes("JOIN team_members tm")) {
+      return {
+        rows: [
+          {
+            id: 20,
+            name: "Deleted Farewell Team",
+            avatar_url: null,
+            archived_at: "2026-06-30T12:00:00.000Z",
+            status: "inactive",
+            members: [
+              {
+                id: 10,
+                userId: 10,
+                user_id: 10,
+                username: "current_member",
+                firstName: "Current",
+                lastName: "Member",
+                avatarUrl: null,
+                role: "member",
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    throw new Error(`Unexpected query for team conversation details: ${sql}`);
+  };
+
+  const req = {
+    user: { id: 10 },
+    params: { id: "20" },
+    query: { type: "team" },
+  };
+  const res = createResponse();
+
+  await messageController.getConversationById(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.team.archived_at, "2026-06-30T12:00:00.000Z");
+  assert.equal(res.body.data.team.archivedAt, "2026-06-30T12:00:00.000Z");
+  assert.equal(res.body.data.team.status, "inactive");
+  assert.equal(res.body.data.team.members.length, 1);
+  assert.equal(res.body.data.team.members[0].userId, 10);
+});


### PR DESCRIPTION
Backend half of the archived-team UX work (frontend is a companion PR on retention-deletion-notices). When an owner deletes a team that still has other members, the team is archived (scheduled for deletion) and its chat becomes a "farewell" window — this PR makes that window actually usable for the remaining members and lets them see the full archived team.

**What changed**
_1. Remaining members can keep using an archived team's chat_
Socket and REST team access are now gated on current membership rather than archived_at: server.js (isActiveTeamMember → isCurrentTeamMember, used for conversation:join, message:new, typing, read receipts, mention notifications) and messageController.ensureTeamMessageAccess. Remaining members keep receiving/sending live messages in an archived chat; former members stay excluded.
getConversations and getConversationById now expose archived_at/status (and getConversationById the member list) so the client can render the farewell banner and verify membership without hitting /api/teams/:id.

_2. Member visibility of archived teams (so the full Team Details modal works)_
teamReadController.getTeamById and the team-badge visibility helper teamBadgeController.isTeamVisibleToViewer now serve archived teams to their current members (still 404 for everyone else, regardless of is_public), and expose archived_at/status. This lets remaining members open the complete Team Details modal (info, focus areas, badges, roles, members) for an archived team's chat.

_3. Grace period default 30 → 14 days_
cleanupArchivedTeams.js default changed to 14 (ARCHIVED_TEAM_GRACE_DAYS still overrides).

**Security / access**
Archived teams remain invisible to non-members (404, independent of public/private). Only current members gain read/post + detail/badge access, matching the existing private-team gating pattern.

**Tests**
New test/messageController.sendMessage.test.js.
Full suite: 94/94 green; node --check clean.

**Docs**
README "Team Deletion" section updated (farewell window, member visibility, hidden solo-archived teams) and grace period reflected as 14 days.

**Release note**
Ship coupled with / before the frontend PR — the frontend consumes the new archived_at/status/members fields and the member-gated archived endpoints.