### PR TITLE
Release: team deletion lifecycle, retention cleanup & archived-team farewell chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,10 +436,11 @@ Full transactional account deletion. Key highlights:
 When an owner deletes a team (`DELETE /api/teams/:id`), the behaviour depends on whether anyone else is still a member:
 
 - **Solo team (owner is the only member)** — the team is **permanently deleted right away** via `permanentlyDeleteTeam`, removing the team row, its chat messages, invitations/applications, badges, notifications, members, and the ImageKit avatar. Nothing is left behind, so a deleted solo team never leaves an orphaned, unreachable conversation.
-- **Team with other members** — the team is **soft-deleted (archived)**: `archived_at`/`status` are set, a `TEAM_DELETED` system message is posted to the chat, and every member is notified. The archived chat stays visible so members can see the notice and read the history; it is permanently purged once the **last** member leaves (`checkAndCleanupArchivedTeam`).
+- **Team with other members** — the team is **soft-deleted (archived)**: `archived_at`/`status` are set, a `TEAM_DELETED` system message is posted to the chat, and every member is notified. The archived chat stays available to the remaining members as a **"farewell" window**: they can still read **and post** messages until they leave or the grace period ends. Socket and REST team access are gated on current membership (not on `archived_at`), so live messages keep flowing to remaining members. It is permanently purged once the **last** member leaves (`checkAndCleanupArchivedTeam`).
+- **Member visibility of archived teams** — archived teams are still served to their current members (never to outsiders — 404 otherwise, regardless of `is_public`): `getTeamById` and the team badge endpoints return them so members can open the full Team Details modal (info, focus areas, badges, roles, members) for an archived team's chat, and `getConversations`/`getConversationById` expose `archived_at`/`status`. Archived teams where the viewer is the only remaining member are hidden from the conversation list and chat search.
 - **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 14). It runs daily and once on server startup. See [Scheduled Jobs](#scheduled-jobs).
 
-Covered by `teamController.deleteTeam.test.js` and `cleanupArchivedTeams.test.js`.
+Covered by `teamController.deleteTeam.test.js`, `cleanupArchivedTeams.test.js`, and `messageController.sendMessage.test.js`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ FRONTEND_URL=http://localhost:5173
 # TURNSTILE_SECRET_KEY=<turnstile-secret-key>
 
 # Scheduled jobs (optional)
-# ARCHIVED_TEAM_GRACE_DAYS=30          # days an archived (deleted) team is kept before the cleanup job purges it; defaults to 30
+# ARCHIVED_TEAM_GRACE_DAYS=14          # days an archived (deleted) team is kept before the cleanup job purges it; defaults to 14
 ```
 
 > Get the ImageKit and database values from the project owner.
@@ -264,6 +264,7 @@ Lomir-backend/
 │   ├── errorResponse.test.js
 │   ├── invitationController.test.js
 │   ├── contactController.test.js
+│   ├── messageController.sendMessage.test.js
 │   ├── locationDerivation.test.js
 │   ├── searchController.test.js
 │   ├── teamController.applyToJoinTeam.test.js
@@ -409,7 +410,7 @@ The public `GET /api/geocoding/postal-code/:code` endpoint is rate-limited (60 r
 |---|---|---|
 | File cleanup | Configurable (see `fileCleanupScheduler.js`) | Expires and deletes orphaned ImageKit files |
 | Unverified account cleanup | Every 6 hours and once on server startup | Deletes accounts where email verification expired more than 1 hour ago, including on hosts that may sleep through the cron time |
-| Archived team cleanup | Daily at 03:30 (Europe/Berlin) and once on server startup | Permanently deletes teams (with their chat, members, and avatar) archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30); safety net for deleted teams whose members never leave, including on hosts that may sleep through the cron time |
+| Archived team cleanup | Daily at 03:30 (Europe/Berlin) and once on server startup | Permanently deletes teams (with their chat, members, and avatar) archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 14); safety net for deleted teams whose members never leave, including on hosts that may sleep through the cron time |
 
 The unverified-account cleanup first clears optional references that may point at
 expired registration rows (for example role, tag, team-owner, and badge-awarder
@@ -436,7 +437,7 @@ When an owner deletes a team (`DELETE /api/teams/:id`), the behaviour depends on
 
 - **Solo team (owner is the only member)** — the team is **permanently deleted right away** via `permanentlyDeleteTeam`, removing the team row, its chat messages, invitations/applications, badges, notifications, members, and the ImageKit avatar. Nothing is left behind, so a deleted solo team never leaves an orphaned, unreachable conversation.
 - **Team with other members** — the team is **soft-deleted (archived)**: `archived_at`/`status` are set, a `TEAM_DELETED` system message is posted to the chat, and every member is notified. The archived chat stays visible so members can see the notice and read the history; it is permanently purged once the **last** member leaves (`checkAndCleanupArchivedTeam`).
-- **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30). It runs daily and once on server startup. See [Scheduled Jobs](#scheduled-jobs).
+- **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 14). It runs daily and once on server startup. See [Scheduled Jobs](#scheduled-jobs).
 
 Covered by `teamController.deleteTeam.test.js` and `cleanupArchivedTeams.test.js`.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To test the live demo, anyone can just **register their own account** directly i
 
 ## Features
 
-- **Authentication** — JWT-based registration, login, email verification, password reset, and verified email change. The session JWT is delivered as an `httpOnly`, `sameSite` cookie (never in the response body or readable by frontend JavaScript); auth middleware and the Socket.IO handshake read it from the cookie, with the `Authorization: Bearer` header kept as a fallback for API clients. Transactional emails are sent through Brevo's transactional HTTPS API (Render blocks outbound SMTP). Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev). Registration requires explicit acceptance of Terms of Service, acknowledgement of the Privacy Policy, and confirmation of minimum age (16+); the version of each legal document is stamped on the user row at sign-up. Changing an account email is double-opt-in: the current-password-protected request stores the new address as `pending_email` with a 24-hour token and sends a verification link to it, and the account email only switches over once the new address confirms — the old address stays active until then. Expired email-change tokens are cleared by the same cleanup pass as password-reset tokens.
+- **Authentication** — JWT-based registration, login, email verification, password reset, and verified email change. The session JWT is delivered as an `httpOnly`, `sameSite` cookie (never in the response body or readable by frontend JavaScript); auth middleware and the Socket.IO handshake read it from the cookie, with the `Authorization: Bearer` header kept as a fallback for API clients. Transactional emails are sent through Brevo's transactional HTTPS API (Render blocks outbound SMTP). Registration protected by Cloudflare Turnstile CAPTCHA (feature-flagged for local dev). Registration requires explicit acceptance of Terms of Service, acknowledgement of the Privacy Policy, and confirmation of minimum age (16+); the version of each legal document is stamped on the user row at sign-up. Unverified accounts are deleted after their verification link expires plus a one-hour buffer, with cleanup running every six hours and once on server startup. Changing an account email is double-opt-in: the current-password-protected request stores the new address as `pending_email` with a 24-hour token and sends a verification link to it, and the account email only switches over once the new address confirms — the old address stays active until then. Expired email-change tokens are cleared by the same cleanup pass as password-reset tokens.
 - **User Profiles** — CRUD with avatar uploads (ImageKit), interest tags, badge portfolios, and user-controlled public/private visibility. Verified accounts remain private by default until the user opts in to public visibility.
 - **User Blocking** — Authenticated users can manage a private blocklist. Block relationships hide profiles and user-search results where requester context is available, suppress team application visibility, disable direct messaging, and exclude blocked users from team chat realtime events where needed.
 - **Teams** — Create, join, manage members, assign roles, and archive teams
@@ -247,8 +247,8 @@ Lomir-backend/
 │   │   └── geocodingUtil.js    # resolveLocationData (full enrichment) + geocodeAddress (coords only)
 │   ├── jobs/
 │   │   ├── fileCleanupScheduler.js # node-cron job that calls fileCleanup utilities on a schedule
-│   │   ├── cleanupUnverifiedAccounts.js # Runs every 6 hours; deletes expired unverified accounts
-│   │   └── cleanupArchivedTeams.js # Daily; permanently deletes teams archived longer than the grace period
+│   │   ├── cleanupUnverifiedAccounts.js # Every 6 hours + startup; deletes expired unverified accounts
+│   │   └── cleanupArchivedTeams.js # Daily + startup; permanently deletes teams archived longer than the grace period
 │   └── database/
 │       └── migrations/
 │           └── create_contact_reports.js # Stores report submissions with reference IDs and mail status
@@ -408,8 +408,13 @@ The public `GET /api/geocoding/postal-code/:code` endpoint is rate-limited (60 r
 | Job | Schedule | Description |
 |---|---|---|
 | File cleanup | Configurable (see `fileCleanupScheduler.js`) | Expires and deletes orphaned ImageKit files |
-| Unverified account cleanup | Every 6 hours | Deletes accounts where email verification expired more than 1 hour ago |
+| Unverified account cleanup | Every 6 hours and once on server startup | Deletes accounts where email verification expired more than 1 hour ago, including on hosts that may sleep through the cron time |
 | Archived team cleanup | Daily at 03:30 (Europe/Berlin) and once on server startup | Permanently deletes teams (with their chat, members, and avatar) archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30); safety net for deleted teams whose members never leave, including on hosts that may sleep through the cron time |
+
+The unverified-account cleanup first clears optional references that may point at
+expired registration rows (for example role, tag, team-owner, and badge-awarder
+references) so old unverified accounts can still be deleted safely even if they
+picked up related records during development or test activity.
 
 ---
 
@@ -431,7 +436,7 @@ When an owner deletes a team (`DELETE /api/teams/:id`), the behaviour depends on
 
 - **Solo team (owner is the only member)** — the team is **permanently deleted right away** via `permanentlyDeleteTeam`, removing the team row, its chat messages, invitations/applications, badges, notifications, members, and the ImageKit avatar. Nothing is left behind, so a deleted solo team never leaves an orphaned, unreachable conversation.
 - **Team with other members** — the team is **soft-deleted (archived)**: `archived_at`/`status` are set, a `TEAM_DELETED` system message is posted to the chat, and every member is notified. The archived chat stays visible so members can see the notice and read the history; it is permanently purged once the **last** member leaves (`checkAndCleanupArchivedTeam`).
-- **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the daily `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30). See [Scheduled Jobs](#scheduled-jobs).
+- **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30). It runs daily and once on server startup. See [Scheduled Jobs](#scheduled-jobs).
 
 Covered by `teamController.deleteTeam.test.js` and `cleanupArchivedTeams.test.js`.
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ FRONTEND_URL=http://localhost:5173
 
 # Cloudflare Turnstile (configured in the deployed environment; the CAPTCHA widget stays inactive locally until a key is set)
 # TURNSTILE_SECRET_KEY=<turnstile-secret-key>
+
+# Scheduled jobs (optional)
+# ARCHIVED_TEAM_GRACE_DAYS=30          # days an archived (deleted) team is kept before the cleanup job purges it; defaults to 30
 ```
 
 > Get the ImageKit and database values from the project owner.
@@ -244,7 +247,8 @@ Lomir-backend/
 │   │   └── geocodingUtil.js    # resolveLocationData (full enrichment) + geocodeAddress (coords only)
 │   ├── jobs/
 │   │   ├── fileCleanupScheduler.js # node-cron job that calls fileCleanup utilities on a schedule
-│   │   └── cleanupUnverifiedAccounts.js # Runs every 6 hours; deletes expired unverified accounts
+│   │   ├── cleanupUnverifiedAccounts.js # Runs every 6 hours; deletes expired unverified accounts
+│   │   └── cleanupArchivedTeams.js # Daily; permanently deletes teams archived longer than the grace period
 │   └── database/
 │       └── migrations/
 │           └── create_contact_reports.js # Stores report submissions with reference IDs and mail status
@@ -264,6 +268,8 @@ Lomir-backend/
 │   ├── searchController.test.js
 │   ├── teamController.applyToJoinTeam.test.js
 │   ├── teamController.applications.test.js
+│   ├── teamController.deleteTeam.test.js
+│   ├── cleanupArchivedTeams.test.js
 │   ├── userController.deleteUser.test.js
 │   ├── userController.deletionPreview.test.js
 │   ├── userController.emailUpdate.test.js
@@ -403,6 +409,7 @@ The public `GET /api/geocoding/postal-code/:code` endpoint is rate-limited (60 r
 |---|---|---|
 | File cleanup | Configurable (see `fileCleanupScheduler.js`) | Expires and deletes orphaned ImageKit files |
 | Unverified account cleanup | Every 6 hours | Deletes accounts where email verification expired more than 1 hour ago |
+| Archived team cleanup | Daily at 03:30 (Europe/Berlin) | Permanently deletes teams (with their chat, members, and avatar) archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30); safety net for deleted teams whose members never leave |
 
 ---
 
@@ -415,6 +422,18 @@ Full transactional account deletion. Key highlights:
 - **Badge preservation** — Team names copied to `badge_awards.custom_team_name` before sole-owner teams are deleted
 - **"Former Lomir User"** — Deleted user references display a grey silhouette avatar with no personal info
 - **41+ automated tests** covering deletion scenarios and preview logic
+
+---
+
+## Team Deletion
+
+When an owner deletes a team (`DELETE /api/teams/:id`), the behaviour depends on whether anyone else is still a member:
+
+- **Solo team (owner is the only member)** — the team is **permanently deleted right away** via `permanentlyDeleteTeam`, removing the team row, its chat messages, invitations/applications, badges, notifications, members, and the ImageKit avatar. Nothing is left behind, so a deleted solo team never leaves an orphaned, unreachable conversation.
+- **Team with other members** — the team is **soft-deleted (archived)**: `archived_at`/`status` are set, a `TEAM_DELETED` system message is posted to the chat, and every member is notified. The archived chat stays visible so members can see the notice and read the history; it is permanently purged once the **last** member leaves (`checkAndCleanupArchivedTeam`).
+- **Grace-period safety net** — to guarantee a deleted team never lingers forever when members never explicitly leave, the daily `cleanupArchivedTeams` job permanently deletes any team archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30). See [Scheduled Jobs](#scheduled-jobs).
+
+Covered by `teamController.deleteTeam.test.js` and `cleanupArchivedTeams.test.js`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ The public `GET /api/geocoding/postal-code/:code` endpoint is rate-limited (60 r
 |---|---|---|
 | File cleanup | Configurable (see `fileCleanupScheduler.js`) | Expires and deletes orphaned ImageKit files |
 | Unverified account cleanup | Every 6 hours | Deletes accounts where email verification expired more than 1 hour ago |
-| Archived team cleanup | Daily at 03:30 (Europe/Berlin) | Permanently deletes teams (with their chat, members, and avatar) archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30); safety net for deleted teams whose members never leave |
+| Archived team cleanup | Daily at 03:30 (Europe/Berlin) and once on server startup | Permanently deletes teams (with their chat, members, and avatar) archived longer than `ARCHIVED_TEAM_GRACE_DAYS` (default 30); safety net for deleted teams whose members never leave, including on hosts that may sleep through the cron time |
 
 ---
 

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -421,6 +421,14 @@ const getConversations = async (req, res) => {
       FROM latest_team_messages ltm
       JOIN teams t ON ltm.team_id = t.id
       LEFT JOIN team_unread_counts tuc ON ltm.team_id = tuc.team_id
+      -- Hide archived (deleted) teams where the viewer is the only remaining
+      -- member: there is no one left who needs to see the deletion notice, so the
+      -- chat should disappear. Archived teams with other members stay visible so
+      -- those members still see the "team deleted" message until they leave.
+      WHERE NOT (
+        t.archived_at IS NOT NULL
+        AND (SELECT COUNT(*) FROM team_members tm2 WHERE tm2.team_id = t.id) <= 1
+      )
       ORDER BY ltm.last_message_time DESC
     `;
 

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -40,10 +40,8 @@ const ensureTeamMessageAccess = async (teamId, userId) => {
   const result = await db.query(
     `SELECT 1
      FROM team_members tm
-     JOIN teams t ON t.id = tm.team_id
      WHERE tm.team_id = $1
        AND tm.user_id = $2
-       AND t.archived_at IS NULL
      LIMIT 1`,
     [teamId, userId],
   );
@@ -415,6 +413,8 @@ const getConversations = async (req, res) => {
         NULL as first_name,
         NULL as last_name,
         t.teamavatar_url as avatar_url,
+        t.archived_at,
+        t.status,
         ltm.last_message,
         ltm.last_message_time as updated_at,
         COALESCE(tuc.unread_count, 0) as unread_count
@@ -462,6 +462,9 @@ const getConversations = async (req, res) => {
         id: row.id,
         name: row.name,
         avatarUrl: row.avatar_url,
+        archived_at: row.archived_at,
+        archivedAt: row.archived_at,
+        status: row.status,
       },
       lastMessage: row.last_message,
       updatedAt: row.updated_at,
@@ -501,10 +504,31 @@ const getConversationById = async (req, res) => {
         SELECT 
           t.id,
           t.name,
-          t.teamavatar_url as avatar_url
+          t.teamavatar_url as avatar_url,
+          t.archived_at,
+          t.status,
+          COALESCE(
+            jsonb_agg(
+              jsonb_build_object(
+                'id', u.id,
+                'userId', u.id,
+                'user_id', u.id,
+                'username', u.username,
+                'firstName', u.first_name,
+                'lastName', u.last_name,
+                'avatarUrl', u.avatar_url,
+                'role', tm_all.role
+              )
+              ORDER BY u.first_name, u.last_name, u.username
+            ) FILTER (WHERE u.id IS NOT NULL),
+            '[]'::jsonb
+          ) as members
         FROM teams t
         JOIN team_members tm ON t.id = tm.team_id
+        LEFT JOIN team_members tm_all ON t.id = tm_all.team_id
+        LEFT JOIN users u ON tm_all.user_id = u.id
         WHERE t.id = $1 AND tm.user_id = $2
+        GROUP BY t.id
       `;
 
       const teamResult = await db.query(teamQuery, [conversationId, userId]);
@@ -527,6 +551,10 @@ const getConversationById = async (req, res) => {
             id: team.id,
             name: team.name,
             avatarUrl: team.avatar_url,
+            archived_at: team.archived_at,
+            archivedAt: team.archived_at,
+            status: team.status,
+            members: team.members || [],
           },
         },
       });

--- a/src/controllers/teamBadgeController.js
+++ b/src/controllers/teamBadgeController.js
@@ -2,21 +2,30 @@ const db = require("../config/database");
 
 const isTeamVisibleToViewer = async (teamId, viewerId) => {
   const teamResult = await db.pool.query(
-    'SELECT is_public FROM teams WHERE id = $1 AND archived_at IS NULL',
+    'SELECT is_public, archived_at FROM teams WHERE id = $1',
     [teamId],
   );
   if (teamResult.rows.length === 0) return false;
 
   const team = teamResult.rows[0];
+
+  const isMember = async () => {
+    if (!viewerId) return false;
+    const memberCheck = await db.pool.query(
+      'SELECT 1 FROM team_members WHERE team_id = $1 AND user_id = $2',
+      [teamId, viewerId],
+    );
+    return memberCheck.rows.length > 0;
+  };
+
+  // Archived (deleted, scheduled-for-deletion) teams are only visible to their
+  // remaining members, regardless of is_public — so the archived-team chat can
+  // still show team badges to those members.
+  if (team.archived_at) return isMember();
+
   if (team.is_public === true || team.is_public === 'true') return true;
 
-  if (!viewerId) return false;
-
-  const memberCheck = await db.pool.query(
-    'SELECT 1 FROM team_members WHERE team_id = $1 AND user_id = $2',
-    [teamId, viewerId],
-  );
-  return memberCheck.rows.length > 0;
+  return isMember();
 };
 
 const getTeamBadgeAwards = async (req, res) => {

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -752,6 +752,27 @@ const deleteTeam = async (req, res) => {
       });
     }
 
+    // If the owner is the only remaining member, there is no one left to be
+    // notified or to read a "team deleted" message — skip the soft-delete/archive
+    // path and permanently remove the team right away. This also purges the team
+    // chat (messages) and avatar, so a solo team never leaves an orphaned,
+    // unreachable conversation behind.
+    const otherMembersResult = await db.pool.query(
+      `SELECT COUNT(*)::int AS count
+       FROM team_members
+       WHERE team_id = $1 AND user_id != $2`,
+      [teamId, userId],
+    );
+
+    if (otherMembersResult.rows[0].count === 0) {
+      await permanentlyDeleteTeam(teamId);
+      return res.status(200).json({
+        success: true,
+        message: "Team deleted successfully",
+        permanentlyDeleted: true,
+      });
+    }
+
     // Begin transaction
     const client = await db.pool.connect();
 

--- a/src/controllers/teamReadController.js
+++ b/src/controllers/teamReadController.js
@@ -67,12 +67,13 @@ const getTeamById = async (req, res) => {
       SELECT t.id, t.name, t.description, t.is_public, t.max_members,
              t.owner_id, t.teamavatar_url, t.is_remote, t.is_synthetic,
              t.created_at, t.updated_at, t.postal_code, t.city, t.country, t.state, t.district,
+             t.archived_at, t.status,
              COALESCE(COUNT(DISTINCT tm.user_id), 0) as current_members_count,
              (SELECT COUNT(*) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_count,
              (SELECT COALESCE(json_agg(vr.role_name ORDER BY vr.role_name ASC), '[]'::json) FROM team_vacant_roles vr WHERE vr.team_id = t.id AND vr.status = 'open') AS open_role_names
       FROM teams t
       LEFT JOIN team_members tm ON t.id = tm.team_id
-      WHERE t.id = $1 AND t.archived_at IS NULL
+      WHERE t.id = $1
       GROUP BY t.id
       `,
       [teamId],
@@ -121,6 +122,16 @@ const getTeamById = async (req, res) => {
         [teamId, req.user.id],
       );
       viewerIsMember = memberCheck.rows.length > 0;
+    }
+
+    // Archived (deleted, scheduled-for-deletion) teams are only visible to their
+    // remaining members — never to outsiders — regardless of is_public, so the
+    // archived-team chat can still show full team details to those members.
+    if (team.archived_at && !viewerIsMember) {
+      return res.status(404).json({
+        success: false,
+        message: "Team not found",
+      });
     }
 
     // Get team members — public profile location is visible to visitors and

--- a/src/jobs/cleanupArchivedTeams.js
+++ b/src/jobs/cleanupArchivedTeams.js
@@ -1,0 +1,81 @@
+const cron = require("node-cron");
+const db = require("../config/database");
+const { permanentlyDeleteTeam } = require("../controllers/teamController");
+
+// When an owner deletes a team that still has other members it is only
+// soft-deleted (archived): the chat is kept so the remaining members can see the
+// "team deleted" notice and read the history one last time, and it is normally
+// purged once the last member leaves (see checkAndCleanupArchivedTeam). This job
+// is the safety net for the case where members never explicitly leave — it
+// permanently removes any team that has been archived for longer than the grace
+// period, together with its chat messages, members and avatar, so a deleted team
+// never lingers forever.
+const parsedGrace = Number(process.env.ARCHIVED_TEAM_GRACE_DAYS);
+const GRACE_PERIOD_DAYS =
+  Number.isFinite(parsedGrace) && parsedGrace >= 0 ? parsedGrace : 30;
+
+const debugLog = (...args) => {
+  if (process.env.NODE_ENV !== "production") {
+    console.log(...args);
+  }
+};
+
+// Core logic, separated from the schedule so it can be unit-tested and triggered
+// manually. Returns how many archived teams were found and successfully purged.
+const purgeExpiredArchivedTeams = async () => {
+  const { rows } = await db.query(
+    `
+    SELECT id
+    FROM teams
+    WHERE archived_at IS NOT NULL
+      AND archived_at < NOW() - INTERVAL '${GRACE_PERIOD_DAYS} days'
+    `,
+  );
+
+  let deleted = 0;
+  for (const { id } of rows) {
+    try {
+      await permanentlyDeleteTeam(id);
+      deleted += 1;
+    } catch (error) {
+      console.error(
+        `[Cleanup] Failed to permanently delete archived team ${id}:`,
+        error,
+      );
+    }
+  }
+
+  return { found: rows.length, deleted };
+};
+
+const cleanupArchivedTeams = () => {
+  // Daily at 03:30 — after the 02:00 file cleanup, before the 09:00 notifications.
+  cron.schedule(
+    "30 3 * * *",
+    async () => {
+      try {
+        const { found, deleted } = await purgeExpiredArchivedTeams();
+        if (found > 0) {
+          debugLog(
+            `[Cleanup] Permanently deleted ${deleted}/${found} archived team(s) older than ${GRACE_PERIOD_DAYS} day(s).`,
+          );
+        } else {
+          debugLog(
+            "[Cleanup] No archived teams past the grace period to delete.",
+          );
+        }
+      } catch (error) {
+        console.error("[Cleanup] Error cleaning up archived teams:", error);
+      }
+    },
+    { timezone: "Europe/Berlin" },
+  );
+
+  debugLog(
+    `[Cleanup] Archived-team cleanup job scheduled (daily 03:30 Europe/Berlin, grace ${GRACE_PERIOD_DAYS} day(s)).`,
+  );
+};
+
+module.exports = cleanupArchivedTeams;
+module.exports.purgeExpiredArchivedTeams = purgeExpiredArchivedTeams;
+module.exports.GRACE_PERIOD_DAYS = GRACE_PERIOD_DAYS;

--- a/src/jobs/cleanupArchivedTeams.js
+++ b/src/jobs/cleanupArchivedTeams.js
@@ -12,7 +12,7 @@ const { permanentlyDeleteTeam } = require("../controllers/teamController");
 // never lingers forever.
 const parsedGrace = Number(process.env.ARCHIVED_TEAM_GRACE_DAYS);
 const GRACE_PERIOD_DAYS =
-  Number.isFinite(parsedGrace) && parsedGrace >= 0 ? parsedGrace : 30;
+  Number.isFinite(parsedGrace) && parsedGrace >= 0 ? parsedGrace : 14;
 
 const debugLog = (...args) => {
   if (process.env.NODE_ENV !== "production") {

--- a/src/jobs/cleanupUnverifiedAccounts.js
+++ b/src/jobs/cleanupUnverifiedAccounts.js
@@ -8,36 +8,93 @@ const debugLog = (...args) => {
   }
 };
 
+const purgeExpiredUnverifiedAccounts = async () => {
+  const client = await db.pool.connect();
+
+  try {
+    await client.query("BEGIN");
+
+    const expiredUsersResult = await client.query(
+      `
+      SELECT id
+      FROM users
+      WHERE email_verified = FALSE
+        AND verification_token_expires IS NOT NULL
+        AND verification_token_expires < NOW() - INTERVAL '${BUFFER_HOURS} hours'
+      `,
+    );
+
+    const expiredUserIds = expiredUsersResult.rows.map((row) => Number(row.id));
+
+    if (expiredUserIds.length === 0) {
+      await client.query("COMMIT");
+      return { deleted: 0, accounts: [] };
+    }
+
+    await client.query(
+      `UPDATE teams SET owner_id = NULL WHERE owner_id = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+    await client.query(
+      `UPDATE team_vacant_roles SET created_by = NULL WHERE created_by = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+    await client.query(
+      `UPDATE team_vacant_roles SET filled_by = NULL WHERE filled_by = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+    await client.query(
+      `UPDATE team_applications SET reviewed_by = NULL WHERE reviewed_by = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+    await client.query(
+      `UPDATE user_badges SET awarded_by = NULL WHERE awarded_by = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+    await client.query(
+      `UPDATE tags SET created_by = NULL WHERE created_by = ANY($1::int[])`,
+      [expiredUserIds],
+    );
+
+    const result = await client.query(
+      `
+      DELETE FROM users
+      WHERE id = ANY($1::int[])
+      RETURNING id, created_at
+      `,
+      [expiredUserIds],
+    );
+
+    await client.query("COMMIT");
+
+    return {
+      deleted: result.rowCount || 0,
+      accounts: result.rows.map((row) => ({
+        id: row.id,
+        created: row.created_at,
+      })),
+    };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+};
+
+const logCleanupResult = ({ deleted, accounts }) => {
+  if (deleted > 0) {
+    debugLog(`[Cleanup] Deleted ${deleted} unverified account(s):`, accounts);
+  } else {
+    debugLog("[Cleanup] No expired unverified accounts to delete.");
+  }
+};
+
 const cleanupUnverifiedAccounts = () => {
   cron.schedule("0 */6 * * *", async () => {
     try {
-      const result = await db.query(
-        `
-        WITH expired_users AS (
-          SELECT id FROM users
-          WHERE email_verified = FALSE
-            AND verification_token_expires IS NOT NULL
-            AND verification_token_expires < NOW() - INTERVAL '${BUFFER_HOURS} hours'
-        ),
-        deleted_tags AS (
-          DELETE FROM user_tags
-          WHERE user_id IN (SELECT id FROM expired_users)
-        )
-        DELETE FROM users
-        WHERE id IN (SELECT id FROM expired_users)
-        RETURNING id, email, created_at
-        `,
-      );
-
-      const count = result.rowCount || 0;
-      if (count > 0) {
-        debugLog(
-          `[Cleanup] Deleted ${count} unverified account(s):`,
-          result.rows.map((r) => ({ id: r.id, created: r.created_at })),
-        );
-      } else {
-        debugLog("[Cleanup] No expired unverified accounts to delete.");
-      }
+      const result = await purgeExpiredUnverifiedAccounts();
+      logCleanupResult(result);
     } catch (error) {
       console.error("[Cleanup] Error cleaning up unverified accounts:", error);
     }
@@ -47,3 +104,5 @@ const cleanupUnverifiedAccounts = () => {
 };
 
 module.exports = cleanupUnverifiedAccounts;
+module.exports.purgeExpiredUnverifiedAccounts = purgeExpiredUnverifiedAccounts;
+module.exports.BUFFER_HOURS = BUFFER_HOURS;

--- a/src/server.js
+++ b/src/server.js
@@ -829,6 +829,9 @@ initScheduledJobs();
 
 const cleanupUnverifiedAccounts = require("./jobs/cleanupUnverifiedAccounts");
 cleanupUnverifiedAccounts();
+cleanupUnverifiedAccounts.purgeExpiredUnverifiedAccounts().catch((error) => {
+  console.error("[Cleanup] Error cleaning up unverified accounts on startup:", error);
+});
 
 const cleanupArchivedTeams = require("./jobs/cleanupArchivedTeams");
 cleanupArchivedTeams();

--- a/src/server.js
+++ b/src/server.js
@@ -830,6 +830,9 @@ initScheduledJobs();
 const cleanupUnverifiedAccounts = require("./jobs/cleanupUnverifiedAccounts");
 cleanupUnverifiedAccounts();
 
+const cleanupArchivedTeams = require("./jobs/cleanupArchivedTeams");
+cleanupArchivedTeams();
+
 // Start server
 server.listen(PORT, () => {
   console.log(`Server running on port ${PORT} with Socket.IO enabled`);

--- a/src/server.js
+++ b/src/server.js
@@ -42,14 +42,12 @@ const CHAT_FILE_RETENTION_DAYS = 60;
 const getChatFileExpiresAt = () =>
   new Date(Date.now() + CHAT_FILE_RETENTION_DAYS * 24 * 60 * 60 * 1000);
 
-const isActiveTeamMember = async (teamId, userId) => {
+const isCurrentTeamMember = async (teamId, userId) => {
   const result = await db.query(
     `SELECT 1
      FROM team_members tm
-     JOIN teams t ON t.id = tm.team_id
      WHERE tm.team_id = $1
        AND tm.user_id = $2
-       AND t.archived_at IS NULL
      LIMIT 1`,
     [teamId, userId],
   );
@@ -216,8 +214,7 @@ io.on("connection", (socket) => {
          FROM team_members tm
          JOIN teams t ON t.id = tm.team_id
          WHERE tm.team_id = $1
-           AND tm.user_id = $2
-           AND t.archived_at IS NULL`,
+           AND tm.user_id = $2`,
         [conversationId, userId],
       );
 
@@ -324,7 +321,7 @@ io.on("connection", (socket) => {
       let replyTo = null;
 
       if (type === "team") {
-        const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+        const canAccessTeam = await isCurrentTeamMember(conversationId, userId);
         if (!canAccessTeam) {
           socket.emit("error", { message: "Not authorized to send messages to this team" });
           return;
@@ -542,7 +539,7 @@ io.on("connection", (socket) => {
         for (const mentionedUserId of notified) {
           try {
             if (type === "team") {
-              const mentionedMember = await isActiveTeamMember(
+              const mentionedMember = await isCurrentTeamMember(
                 conversationId,
                 mentionedUserId,
               );
@@ -591,7 +588,7 @@ io.on("connection", (socket) => {
     }
 
     if (type === "team") {
-      const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+      const canAccessTeam = await isCurrentTeamMember(conversationId, userId);
       if (!canAccessTeam) {
         socket.emit("error", { message: "Not authorized for this team conversation" });
         return;
@@ -639,7 +636,7 @@ io.on("connection", (socket) => {
     }
 
     if (type === "team") {
-      const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+      const canAccessTeam = await isCurrentTeamMember(conversationId, userId);
       if (!canAccessTeam) {
         socket.emit("error", { message: "Not authorized for this team conversation" });
         return;
@@ -689,7 +686,7 @@ io.on("connection", (socket) => {
       }
 
       if (type === "team") {
-        const canAccessTeam = await isActiveTeamMember(conversationId, userId);
+        const canAccessTeam = await isCurrentTeamMember(conversationId, userId);
         if (!canAccessTeam) {
           socket.emit("error", { message: "Not authorized for this team conversation" });
           return;

--- a/src/server.js
+++ b/src/server.js
@@ -832,6 +832,9 @@ cleanupUnverifiedAccounts();
 
 const cleanupArchivedTeams = require("./jobs/cleanupArchivedTeams");
 cleanupArchivedTeams();
+cleanupArchivedTeams.purgeExpiredArchivedTeams().catch((error) => {
+  console.error("[Cleanup] Error cleaning up archived teams on startup:", error);
+});
 
 // Start server
 server.listen(PORT, () => {

--- a/test/cleanupArchivedTeams.test.js
+++ b/test/cleanupArchivedTeams.test.js
@@ -1,0 +1,109 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const db = require("../src/config/database");
+const cleanupArchivedTeams = require("../src/jobs/cleanupArchivedTeams");
+
+const { purgeExpiredArchivedTeams } = cleanupArchivedTeams;
+
+const originalQuery = db.query;
+const originalConnect = db.pool.connect;
+
+test.afterEach(() => {
+  db.query = originalQuery;
+  db.pool.connect = originalConnect;
+});
+
+test("purgeExpiredArchivedTeams permanently deletes archived teams past the grace period", async () => {
+  let selectSql = "";
+  db.query = async (sql) => {
+    selectSql = sql;
+    return { rows: [{ id: 10 }, { id: 20 }] };
+  };
+
+  // permanentlyDeleteTeam runs its own transaction through a dedicated client.
+  const clientCalls = [];
+  db.pool.connect = async () => ({
+    async query(sql) {
+      clientCalls.push(sql);
+      if (sql.includes("teamavatar_url")) {
+        return { rows: [{ teamavatar_url: null, teamavatar_file_id: null }] };
+      }
+      return { rows: [] };
+    },
+    release() {},
+  });
+
+  const result = await purgeExpiredArchivedTeams();
+
+  // Only archived teams older than the grace period are selected.
+  assert.match(selectSql, /archived_at IS NOT NULL/);
+  assert.match(selectSql, /archived_at < NOW\(\) - INTERVAL/);
+
+  assert.deepEqual(result, { found: 2, deleted: 2 });
+
+  // Each selected team was hard-deleted (team row removed once per team).
+  const teamDeletes = clientCalls.filter((sql) =>
+    sql.includes("DELETE FROM teams WHERE id"),
+  );
+  assert.equal(teamDeletes.length, 2);
+  // And the chat messages were purged too.
+  assert.equal(
+    clientCalls.filter((sql) => sql.includes("DELETE FROM messages WHERE team_id"))
+      .length,
+    2,
+  );
+});
+
+test("purgeExpiredArchivedTeams is a no-op when nothing is past the grace period", async () => {
+  db.query = async () => ({ rows: [] });
+
+  let connectCalled = false;
+  db.pool.connect = async () => {
+    connectCalled = true;
+    throw new Error("connect should not be called when there is nothing to purge");
+  };
+
+  const result = await purgeExpiredArchivedTeams();
+
+  assert.deepEqual(result, { found: 0, deleted: 0 });
+  assert.equal(connectCalled, false);
+});
+
+test("purgeExpiredArchivedTeams keeps going and counts only successful purges when one team fails", async () => {
+  db.query = async () => ({ rows: [{ id: 10 }, { id: 20 }] });
+
+  db.pool.connect = async () => ({
+    async query(sql) {
+      if (sql.includes("teamavatar_url")) {
+        // Team 10 blows up while reading its avatar; team 20 succeeds.
+        return { rows: [{ teamavatar_url: null, teamavatar_file_id: null }] };
+      }
+      return { rows: [] };
+    },
+    release() {},
+  });
+
+  // Make the first permanentlyDeleteTeam call fail by throwing on BEGIN once.
+  let beginCount = 0;
+  const originalConnectImpl = db.pool.connect;
+  db.pool.connect = async () => {
+    const client = await originalConnectImpl();
+    const innerQuery = client.query;
+    client.query = async (sql, params) => {
+      if (sql === "BEGIN") {
+        beginCount += 1;
+        if (beginCount === 1) {
+          throw new Error("simulated failure for the first team");
+        }
+      }
+      return innerQuery(sql, params);
+    };
+    return client;
+  };
+
+  const result = await purgeExpiredArchivedTeams();
+
+  assert.equal(result.found, 2);
+  assert.equal(result.deleted, 1);
+});

--- a/test/cleanupUnverifiedAccounts.test.js
+++ b/test/cleanupUnverifiedAccounts.test.js
@@ -1,0 +1,132 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const db = require("../src/config/database");
+const cleanupUnverifiedAccounts = require("../src/jobs/cleanupUnverifiedAccounts");
+
+const { purgeExpiredUnverifiedAccounts } = cleanupUnverifiedAccounts;
+
+const originalConnect = db.pool.connect;
+
+test.afterEach(() => {
+  db.pool.connect = originalConnect;
+});
+
+test("purgeExpiredUnverifiedAccounts deletes expired unverified accounts", async () => {
+  const calls = [];
+
+  db.pool.connect = async () => ({
+    async query(sql, params) {
+      calls.push({ sql, params });
+
+      if (sql.includes("SELECT id") && sql.includes("FROM users")) {
+        return { rows: [{ id: 10 }, { id: 20 }] };
+      }
+
+      if (sql.includes("DELETE FROM users")) {
+        return {
+          rowCount: 2,
+          rows: [
+            { id: 10, created_at: "2026-06-28T08:00:00.000Z" },
+            { id: 20, created_at: "2026-06-28T09:00:00.000Z" },
+          ],
+        };
+      }
+
+      return { rows: [], rowCount: 0 };
+    },
+    release() {},
+  });
+
+  const result = await purgeExpiredUnverifiedAccounts();
+  const combinedSql = calls.map(({ sql }) => sql).join("\n");
+  const arrayParams = calls
+    .map(({ params }) => params)
+    .filter((params) => Array.isArray(params));
+
+  assert.equal(calls[0].sql, "BEGIN");
+  assert.equal(calls.at(-1).sql, "COMMIT");
+  assert.match(combinedSql, /email_verified = FALSE/);
+  assert.match(combinedSql, /verification_token_expires IS NOT NULL/);
+  assert.match(combinedSql, /verification_token_expires < NOW\(\) - INTERVAL/);
+  assert.match(combinedSql, /UPDATE teams SET owner_id = NULL/);
+  assert.match(combinedSql, /UPDATE team_vacant_roles SET created_by = NULL/);
+  assert.match(combinedSql, /UPDATE team_vacant_roles SET filled_by = NULL/);
+  assert.match(combinedSql, /UPDATE team_applications SET reviewed_by = NULL/);
+  assert.match(combinedSql, /UPDATE user_badges SET awarded_by = NULL/);
+  assert.match(combinedSql, /UPDATE tags SET created_by = NULL/);
+  assert.match(combinedSql, /DELETE FROM users/);
+  assert.doesNotMatch(combinedSql, /RETURNING id, email/);
+  assert.ok(
+    arrayParams.every((params) => params.length === 1 && params[0].length === 2),
+    "expected cleanup statements to target the expired user ids",
+  );
+  assert.deepEqual(result, {
+    deleted: 2,
+    accounts: [
+      { id: 10, created: "2026-06-28T08:00:00.000Z" },
+      { id: 20, created: "2026-06-28T09:00:00.000Z" },
+    ],
+  });
+});
+
+test("purgeExpiredUnverifiedAccounts is a no-op when no accounts expired", async () => {
+  const calls = [];
+
+  db.pool.connect = async () => ({
+    async query(sql) {
+      calls.push(sql);
+
+      if (sql.includes("SELECT id") && sql.includes("FROM users")) {
+        return { rows: [] };
+      }
+
+      return { rows: [], rowCount: 0 };
+    },
+    release() {},
+  });
+
+  const result = await purgeExpiredUnverifiedAccounts();
+
+  assert.deepEqual(result, { deleted: 0, accounts: [] });
+  assert.deepEqual(calls, [
+    "BEGIN",
+    `
+      SELECT id
+      FROM users
+      WHERE email_verified = FALSE
+        AND verification_token_expires IS NOT NULL
+        AND verification_token_expires < NOW() - INTERVAL '1 hours'
+      `,
+    "COMMIT",
+  ]);
+});
+
+test("purgeExpiredUnverifiedAccounts rolls back when cleanup fails", async () => {
+  const calls = [];
+
+  db.pool.connect = async () => ({
+    async query(sql) {
+      calls.push(sql);
+
+      if (sql.includes("SELECT id") && sql.includes("FROM users")) {
+        return { rows: [{ id: 10 }] };
+      }
+
+      if (sql.includes("UPDATE user_badges")) {
+        throw new Error("simulated foreign-key cleanup failure");
+      }
+
+      return { rows: [], rowCount: 0 };
+    },
+    release() {},
+  });
+
+  await assert.rejects(
+    () => purgeExpiredUnverifiedAccounts(),
+    /simulated foreign-key cleanup failure/,
+  );
+
+  assert.ok(calls.includes("ROLLBACK"));
+  assert.equal(calls.includes("COMMIT"), false);
+});

--- a/test/messageController.sendMessage.test.js
+++ b/test/messageController.sendMessage.test.js
@@ -1,0 +1,184 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const db = require("../src/config/database");
+const messageController = require("../src/controllers/messageController");
+
+const originalQuery = db.query;
+
+test.afterEach(() => {
+  db.query = originalQuery;
+});
+
+const createResponse = () => {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res;
+};
+
+test("sendMessage allows current members to post in an archived team chat", async () => {
+  const queries = [];
+
+  db.query = async (sql, params) => {
+    queries.push({ sql, params });
+
+    if (sql.includes("FROM team_members tm")) {
+      return { rows: [{ "?column?": 1 }] };
+    }
+
+    if (sql.includes("INSERT INTO messages")) {
+      return {
+        rows: [
+          {
+            id: 123,
+            sender_id: 10,
+            team_id: 20,
+            content: "Still here for the farewell.",
+            reply_to_id: null,
+            image_url: null,
+            file_url: null,
+            file_name: null,
+            file_size: null,
+            file_expires_at: null,
+            sent_at: new Date("2026-06-30T10:00:00.000Z"),
+          },
+        ],
+      };
+    }
+
+    if (sql.includes("SELECT username, first_name, last_name FROM users")) {
+      return {
+        rows: [
+          { username: "jane", first_name: "Jane", last_name: "Doe" },
+        ],
+      };
+    }
+
+    if (sql.includes("SELECT COUNT(*)::int AS recipient_count")) {
+      return { rows: [{ recipient_count: 1 }] };
+    }
+
+    return { rows: [] };
+  };
+
+  const emitted = [];
+  const req = {
+    user: { id: 10 },
+    params: { id: "20" },
+    body: {
+      type: "team",
+      content: "Still here for the farewell.",
+    },
+    app: {
+      get() {
+        return {
+          to(room) {
+            return {
+              emit(event, payload) {
+                emitted.push({ room, event, payload });
+              },
+            };
+          },
+        };
+      },
+    },
+  };
+  const res = createResponse();
+
+  await messageController.sendMessage(req, res);
+
+  const accessQuery = queries.find(({ sql }) =>
+    sql.includes("FROM team_members tm"),
+  );
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.success, true);
+  assert.doesNotMatch(accessQuery.sql, /archived_at IS NULL/);
+  assert.equal(emitted[0].room, "team:20");
+  assert.equal(emitted[0].event, "message:received");
+});
+
+test("sendMessage still rejects users who are no longer team members", async () => {
+  db.query = async (sql) => {
+    if (sql.includes("FROM team_members tm")) {
+      return { rows: [] };
+    }
+
+    throw new Error(`Unexpected query for unauthorized team message: ${sql}`);
+  };
+
+  const req = {
+    user: { id: 10 },
+    params: { id: "20" },
+    body: {
+      type: "team",
+      content: "I should not be able to send this.",
+    },
+  };
+  const res = createResponse();
+
+  await messageController.sendMessage(req, res);
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.success, false);
+});
+
+test("getConversationById includes archived team metadata", async () => {
+  db.query = async (sql) => {
+    if (sql.includes("FROM teams t") && sql.includes("JOIN team_members tm")) {
+      return {
+        rows: [
+          {
+            id: 20,
+            name: "Deleted Farewell Team",
+            avatar_url: null,
+            archived_at: "2026-06-30T12:00:00.000Z",
+            status: "inactive",
+            members: [
+              {
+                id: 10,
+                userId: 10,
+                user_id: 10,
+                username: "current_member",
+                firstName: "Current",
+                lastName: "Member",
+                avatarUrl: null,
+                role: "member",
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    throw new Error(`Unexpected query for team conversation details: ${sql}`);
+  };
+
+  const req = {
+    user: { id: 10 },
+    params: { id: "20" },
+    query: { type: "team" },
+  };
+  const res = createResponse();
+
+  await messageController.getConversationById(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.team.archived_at, "2026-06-30T12:00:00.000Z");
+  assert.equal(res.body.data.team.archivedAt, "2026-06-30T12:00:00.000Z");
+  assert.equal(res.body.data.team.status, "inactive");
+  assert.equal(res.body.data.team.members.length, 1);
+  assert.equal(res.body.data.team.members[0].userId, 10);
+});

--- a/test/teamController.deleteTeam.test.js
+++ b/test/teamController.deleteTeam.test.js
@@ -1,0 +1,190 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const db = require("../src/config/database");
+const teamController = require("../src/controllers/teamController");
+
+const originalQuery = db.pool.query;
+const originalConnect = db.pool.connect;
+const originalNodeEnv = process.env.NODE_ENV;
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+function createRequest({ userId = 7, paramId = "10", io = null } = {}) {
+  return {
+    params: { id: paramId },
+    user: { id: userId },
+    app: {
+      get() {
+        return io;
+      },
+    },
+  };
+}
+
+test.afterEach(() => {
+  db.pool.query = originalQuery;
+  db.pool.connect = originalConnect;
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
+test("deleteTeam permanently deletes a solo team (owner is the only member) instead of archiving", async () => {
+  process.env.NODE_ENV = "production";
+
+  const poolCalls = [];
+  const clientCalls = [];
+
+  db.pool.query = async (sql, params = []) => {
+    poolCalls.push({ sql, params });
+
+    if (sql.includes("tm.role = 'owner'") && sql.includes("FROM teams t")) {
+      // Owner authorization check
+      return { rows: [{ id: 10, name: "Solo Team", role: "owner" }] };
+    }
+
+    if (sql.includes("COUNT(*)::int AS count") && sql.includes("user_id != $2")) {
+      // No other members besides the owner
+      return { rows: [{ count: 0 }] };
+    }
+
+    throw new Error(`Unexpected pool SQL in solo delete test: ${sql}`);
+  };
+
+  // permanentlyDeleteTeam runs its own transaction through a dedicated client.
+  const client = {
+    async query(sql, params = []) {
+      clientCalls.push({ sql, params });
+      if (sql.includes("teamavatar_url")) {
+        return { rows: [{ teamavatar_url: null, teamavatar_file_id: null }] };
+      }
+      return { rows: [] };
+    },
+    release() {},
+  };
+  db.pool.connect = async () => client;
+
+  const req = createRequest({ userId: 7, paramId: "10" });
+  const res = createResponse();
+
+  await teamController.deleteTeam(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.permanentlyDeleted, true);
+
+  // The hard-delete path ran: messages and the team row were removed...
+  assert.equal(
+    clientCalls.some(({ sql }) => sql.includes("DELETE FROM messages WHERE team_id")),
+    true,
+    "expected the team chat messages to be deleted",
+  );
+  assert.equal(
+    clientCalls.some(({ sql }) => sql.includes("DELETE FROM teams WHERE id")),
+    true,
+    "expected the team row to be deleted",
+  );
+  assert.equal(clientCalls.some(({ sql }) => sql === "COMMIT"), true);
+
+  // ...and the soft-delete/archive path was NOT taken.
+  assert.equal(
+    clientCalls.some(({ sql }) => sql.includes("archived_at = NOW()")),
+    false,
+    "a solo team must not be archived",
+  );
+  assert.equal(
+    poolCalls.some(({ sql }) => sql.includes("INSERT INTO messages")),
+    false,
+    "no TEAM_DELETED system message should be posted for a solo team",
+  );
+});
+
+test("deleteTeam archives (soft-deletes) a team that still has other members", async () => {
+  process.env.NODE_ENV = "production";
+
+  const poolCalls = [];
+  const clientCalls = [];
+
+  db.pool.query = async (sql, params = []) => {
+    poolCalls.push({ sql, params });
+
+    if (sql.includes("tm.role = 'owner'") && sql.includes("FROM teams t")) {
+      return { rows: [{ id: 10, name: "Shared Team", role: "owner" }] };
+    }
+
+    if (sql.includes("COUNT(*)::int AS count") && sql.includes("user_id != $2")) {
+      // Two other members remain
+      return { rows: [{ count: 2 }] };
+    }
+
+    if (sql.includes("SELECT first_name, last_name, username FROM users")) {
+      return { rows: [{ first_name: "Julia", last_name: "Baur", username: "juliab" }] };
+    }
+
+    if (sql.includes("SELECT user_id FROM team_members")) {
+      return { rows: [{ user_id: 11 }, { user_id: 12 }] };
+    }
+
+    if (sql.includes("INSERT INTO messages")) {
+      return { rows: [{ id: 555, sender_id: 7, team_id: 10, content: "x", sent_at: new Date() }] };
+    }
+
+    // Notification cleanup / createNotification inserts / anything else: no-op.
+    return { rows: [] };
+  };
+
+  const client = {
+    async query(sql) {
+      clientCalls.push({ sql });
+      return { rows: [] };
+    },
+    release() {},
+  };
+  db.pool.connect = async () => client;
+
+  const emits = [];
+  const io = {
+    to(room) {
+      return {
+        emit(event, payload) {
+          emits.push({ room, event, payload });
+        },
+      };
+    },
+  };
+
+  const req = createRequest({ userId: 7, paramId: "10", io });
+  const res = createResponse();
+
+  await teamController.deleteTeam(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.match(res.body.message, /archived/i);
+  assert.notEqual(res.body.permanentlyDeleted, true);
+
+  // Archive path ran...
+  assert.equal(
+    clientCalls.some(({ sql }) => sql.includes("archived_at = NOW()")),
+    true,
+    "expected the team to be archived",
+  );
+  // ...and the team/chat were NOT permanently deleted.
+  assert.equal(
+    clientCalls.some(({ sql }) => sql.includes("DELETE FROM teams WHERE id")),
+    false,
+    "a team with other members must not be hard-deleted",
+  );
+});


### PR DESCRIPTION
Ships the full team-deletion / retention work to production (backend PRs #285–#290). Pairs with the frontend dev → main release — deploy backend first / together, since the frontend consumes the new archived-team fields and member-gated endpoints.

**Team deletion**

- Solo team → immediate hard delete (#285): when the owner is the only member, deleteTeam permanently removes the team, its chat, members, invitations/applications, badges, notifications, and ImageKit avatar right away — no orphaned, unreachable conversation. Teams with other members are still archived.
- Archived-team "farewell" chat (#290): a deleted team that still has other members is archived, and its chat stays usable by the remaining members until they leave or the grace period ends. Socket + REST team access are gated on current membership (not archived_at), so they can still read and post live.

**Retention cleanup**

- Grace-period cleanup job (#286): new cleanupArchivedTeams job permanently deletes teams archived longer than ARCHIVED_TEAM_GRACE_DAYS (default 14), including chat, members and avatar — a safety net so a deleted team never lingers forever.
- Runs on a schedule and on startup (#289): both the archived-team cleanup and the unverified-account cleanup now also run once on server boot (not only via node-cron), so retention still runs on hosts that sleep through the cron time (Render free tier). cleanupUnverifiedAccounts was refactored to be startup-runnable and unit-tested.

**Visibility**

- Hide archived solo-member teams (#288): archived teams where the viewer is the only/last member are excluded from the conversation list (and therefore chat search).
- Member visibility of archived teams (#290): getTeamById and the team-badge endpoints serve archived teams to their current members (still 404 for outsiders, regardless of is_public) and expose archived_at/status, so members can open the full Team Details modal (info, focus areas, badges, roles, members) for an archived team.

**Tests & docs**

- New suites: teamController.deleteTeam.test.js, cleanupArchivedTeams.test.js, cleanupUnverifiedAccounts.test.js, messageController.sendMessage.test.js. Full suite 94/94 green.
- README updated: Team Deletion section, Scheduled Jobs (schedule + startup), .env (ARCHIVED_TEAM_GRACE_DAYS), project structure (#287, #290).

**Deploy notes**

- No DB migration — uses the existing teams.archived_at / status columns.
- Optional env ARCHIVED_TEAM_GRACE_DAYS on Render (defaults to 14).
- Expected on first boot after deploy: the startup cleanup permanently deletes teams already archived longer than 14 days (the legacy/test archived teams), clearing the current backlog.
- Verify after deploy: HSTS/security headers still present; Server running … in logs (Turnstile startup guard passes).