### PR TITLE
fix(chat): embed media fields in reply-preview snapshot

### DIFF
--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -5,6 +5,10 @@ const {
 } = require("../utils/imagekitUtils");
 const { validateChatFileUrl } = require("../utils/fileValidation");
 const userModel = require("../models/userModel");
+const {
+  replySnapshotJoinColumns,
+  buildReplyTo,
+} = require("../utils/replySnapshot");
 
 const CHAT_FILE_RETENTION_DAYS = 60;
 
@@ -703,11 +707,7 @@ const getMessages = async (req, res) => {
       u.first_name as sender_first_name,
       u.last_name as sender_last_name,
       u.avatar_url as sender_avatar_url,
-      rm.id as reply_to_message_id,
-      rm.content as reply_to_content,
-      rm.sender_id as reply_to_sender_id,
-      ru.username as reply_to_sender_username,
-      ru.first_name as reply_to_sender_first_name
+      ${replySnapshotJoinColumns}
     FROM messages m
     LEFT JOIN users u ON m.sender_id = u.id
     LEFT JOIN messages rm ON m.reply_to_id = rm.id
@@ -800,11 +800,7 @@ const getMessages = async (req, res) => {
       u.first_name as sender_first_name,
       u.last_name as sender_last_name,
       u.avatar_url as sender_avatar_url,
-      rm.id as reply_to_message_id,
-      rm.content as reply_to_content,
-      rm.sender_id as reply_to_sender_id,
-      ru.username as reply_to_sender_username,
-      ru.first_name as reply_to_sender_first_name
+      ${replySnapshotJoinColumns}
     FROM messages m
     LEFT JOIN users u ON m.sender_id = u.id
     LEFT JOIN messages rm ON m.reply_to_id = rm.id
@@ -832,17 +828,7 @@ const getMessages = async (req, res) => {
       teamId: row.team_id,
       content: row.content,
       replyToId: row.reply_to_id,
-      replyTo: row.reply_to_message_id
-        ? {
-            id: row.reply_to_message_id,
-            content: row.reply_to_content
-              ? row.reply_to_content.slice(0, 150)
-              : null,
-            senderId: row.reply_to_sender_id,
-            senderUsername: row.reply_to_sender_username,
-            senderFirstName: row.reply_to_sender_first_name,
-          }
-        : null,
+      replyTo: buildReplyTo(row),
       imageUrl: row.image_url,
       fileUrl: row.file_url,
       fileName: row.file_name,
@@ -1033,11 +1019,7 @@ const getMessageById = async (req, res) => {
         m.sent_at,
         m.read_at,
         u.username as sender_username,
-        rm.id as reply_to_message_id,
-        rm.content as reply_to_content,
-        rm.sender_id as reply_to_sender_id,
-        ru.username as reply_to_sender_username,
-        ru.first_name as reply_to_sender_first_name
+        ${replySnapshotJoinColumns}
       FROM messages m
       LEFT JOIN users u ON m.sender_id = u.id
       LEFT JOIN messages rm ON m.reply_to_id = rm.id
@@ -1082,17 +1064,7 @@ const getMessageById = async (req, res) => {
       success: true,
       data: {
         ...row,
-        replyTo: row.reply_to_message_id
-          ? {
-              id: row.reply_to_message_id,
-              content: row.reply_to_content
-                ? row.reply_to_content.slice(0, 150)
-                : null,
-              senderId: row.reply_to_sender_id,
-              senderUsername: row.reply_to_sender_username,
-              senderFirstName: row.reply_to_sender_first_name,
-            }
-          : null,
+        replyTo: buildReplyTo(row),
       },
     });
   } catch (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,9 @@
 const { initScheduledJobs } = require("./jobs/fileCleanupScheduler");
 const { validateChatFileUrl } = require("./utils/fileValidation");
+const {
+  replySnapshotSelfColumns,
+  buildReplyTo,
+} = require("./utils/replySnapshot");
 
 require("dotenv").config();
 
@@ -358,8 +362,7 @@ io.on("connection", (socket) => {
 
         if (replyToId) {
           const replyResult = await db.query(
-            `SELECT m.id, m.content, m.sender_id,
-                    u.username, u.first_name
+            `SELECT ${replySnapshotSelfColumns}
              FROM messages m
              LEFT JOIN users u ON m.sender_id = u.id
              WHERE m.id = $1`,
@@ -367,14 +370,7 @@ io.on("connection", (socket) => {
           );
 
           if (replyResult.rows.length > 0) {
-            const r = replyResult.rows[0];
-            replyTo = {
-              id: r.id,
-              content: r.content ? r.content.slice(0, 150) : null,
-              senderId: r.sender_id,
-              senderUsername: r.username,
-              senderFirstName: r.first_name,
-            };
+            replyTo = buildReplyTo(replyResult.rows[0]);
           }
         }
 
@@ -460,8 +456,7 @@ io.on("connection", (socket) => {
 
         if (replyToId) {
           const replyResult = await db.query(
-            `SELECT m.id, m.content, m.sender_id,
-                    u.username, u.first_name
+            `SELECT ${replySnapshotSelfColumns}
              FROM messages m
              LEFT JOIN users u ON m.sender_id = u.id
              WHERE m.id = $1`,
@@ -469,14 +464,7 @@ io.on("connection", (socket) => {
           );
 
           if (replyResult.rows.length > 0) {
-            const r = replyResult.rows[0];
-            replyTo = {
-              id: r.id,
-              content: r.content ? r.content.slice(0, 150) : null,
-              senderId: r.sender_id,
-              senderUsername: r.username,
-              senderFirstName: r.first_name,
-            };
+            replyTo = buildReplyTo(replyResult.rows[0]);
           }
         }
 

--- a/src/utils/replySnapshot.js
+++ b/src/utils/replySnapshot.js
@@ -1,0 +1,72 @@
+// Shared reply-preview ("quoted message") snapshot helpers.
+//
+// The reply snapshot embedded in each delivered message must be self-contained
+// so the frontend can render the quoted message (text, image, file, expiry)
+// without needing the original message to still be in the loaded window. This
+// used to be hand-built in 5 places with only id/content/sender columns, which
+// drifted from what the frontend renders and dropped image/file/expiry fields
+// for everyone except the message author's optimistic copy. Centralize the
+// column list + the row->object mapping here so all call sites stay in sync.
+//
+// Two SELECT-column fragments because the reply row is queried two ways:
+//   - JOINED into the main message query (aliases rm = reply message, ru = its sender)
+//   - as a STANDALONE lookup by id (aliases m = reply message, u = its sender)
+// Both alias to the same `reply_to_*` output columns so `buildReplyTo` works for either.
+
+const replySnapshotJoinColumns = `
+  rm.id AS reply_to_message_id,
+  rm.content AS reply_to_content,
+  rm.sender_id AS reply_to_sender_id,
+  ru.username AS reply_to_sender_username,
+  ru.first_name AS reply_to_sender_first_name,
+  rm.image_url AS reply_to_image_url,
+  rm.file_url AS reply_to_file_url,
+  rm.file_name AS reply_to_file_name,
+  rm.file_size AS reply_to_file_size,
+  rm.file_expires_at AS reply_to_file_expires_at,
+  rm.file_deleted_at AS reply_to_file_deleted_at,
+  rm.deleted_at AS reply_to_deleted_at
+`;
+
+const replySnapshotSelfColumns = `
+  m.id AS reply_to_message_id,
+  m.content AS reply_to_content,
+  m.sender_id AS reply_to_sender_id,
+  u.username AS reply_to_sender_username,
+  u.first_name AS reply_to_sender_first_name,
+  m.image_url AS reply_to_image_url,
+  m.file_url AS reply_to_file_url,
+  m.file_name AS reply_to_file_name,
+  m.file_size AS reply_to_file_size,
+  m.file_expires_at AS reply_to_file_expires_at,
+  m.file_deleted_at AS reply_to_file_deleted_at,
+  m.deleted_at AS reply_to_deleted_at
+`;
+
+// Map a row carrying the `reply_to_*` columns above to the frontend reply-preview
+// shape, or null if the message has no reply. Content is trimmed to 150 chars to
+// match the previous inline behavior.
+const buildReplyTo = (row) => {
+  if (!row || !row.reply_to_message_id) return null;
+
+  return {
+    id: row.reply_to_message_id,
+    content: row.reply_to_content ? row.reply_to_content.slice(0, 150) : null,
+    senderId: row.reply_to_sender_id,
+    senderUsername: row.reply_to_sender_username,
+    senderFirstName: row.reply_to_sender_first_name,
+    imageUrl: row.reply_to_image_url,
+    fileUrl: row.reply_to_file_url,
+    fileName: row.reply_to_file_name,
+    fileSize: row.reply_to_file_size,
+    fileExpiresAt: row.reply_to_file_expires_at,
+    fileDeletedAt: row.reply_to_file_deleted_at,
+    deletedAt: row.reply_to_deleted_at,
+  };
+};
+
+module.exports = {
+  replySnapshotJoinColumns,
+  replySnapshotSelfColumns,
+  buildReplyTo,
+};

--- a/test/replySnapshot.test.js
+++ b/test/replySnapshot.test.js
@@ -1,0 +1,67 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { buildReplyTo } = require("../src/utils/replySnapshot");
+
+test("buildReplyTo returns null when there is no reply", () => {
+  assert.equal(buildReplyTo(null), null);
+  assert.equal(buildReplyTo(undefined), null);
+  assert.equal(buildReplyTo({ reply_to_message_id: null }), null);
+});
+
+test("buildReplyTo maps the media fields so quoted image/file previews render for every viewer", () => {
+  // Regression guard: the snapshot must carry image/file/expiry, not just
+  // id/content/sender — otherwise a reply to an image-only message shows as
+  // "Original message was deleted" for non-author viewers.
+  const row = {
+    reply_to_message_id: 42,
+    reply_to_content: "hello",
+    reply_to_sender_id: 7,
+    reply_to_sender_username: "anna",
+    reply_to_sender_first_name: "Anna",
+    reply_to_image_url: "https://ik.imagekit.io/lomir/chat-images/x.jpg",
+    reply_to_file_url: "https://ik.imagekit.io/lomir/chat-files/y.pdf",
+    reply_to_file_name: "y.pdf",
+    reply_to_file_size: 1234,
+    reply_to_file_expires_at: "2026-07-11T00:00:00.000Z",
+    reply_to_file_deleted_at: null,
+    reply_to_deleted_at: null,
+  };
+
+  assert.deepEqual(buildReplyTo(row), {
+    id: 42,
+    content: "hello",
+    senderId: 7,
+    senderUsername: "anna",
+    senderFirstName: "Anna",
+    imageUrl: "https://ik.imagekit.io/lomir/chat-images/x.jpg",
+    fileUrl: "https://ik.imagekit.io/lomir/chat-files/y.pdf",
+    fileName: "y.pdf",
+    fileSize: 1234,
+    fileExpiresAt: "2026-07-11T00:00:00.000Z",
+    fileDeletedAt: null,
+    deletedAt: null,
+  });
+});
+
+test("buildReplyTo trims content to 150 chars and preserves deletedAt", () => {
+  const longContent = "a".repeat(300);
+  const result = buildReplyTo({
+    reply_to_message_id: 1,
+    reply_to_content: longContent,
+    reply_to_deleted_at: "2026-07-04T10:00:00.000Z",
+  });
+
+  assert.equal(result.content.length, 150);
+  assert.equal(result.deletedAt, "2026-07-04T10:00:00.000Z");
+});
+
+test("buildReplyTo keeps null content as null (deleted original)", () => {
+  const result = buildReplyTo({
+    reply_to_message_id: 1,
+    reply_to_content: null,
+    reply_to_deleted_at: "2026-07-04T10:00:00.000Z",
+  });
+
+  assert.equal(result.content, null);
+});


### PR DESCRIPTION
Problem
Replying to a message that contains an image or file rendered a broken quoted preview for everyone except the message author. The author saw the thumbnail and expiry (from their optimistic reply object), but every other viewer saw no thumbnail, no expiry, and for an image-only original a misleading placeholder saying the original message was deleted.

Root cause
The reply (quoted message) snapshot embedded in each delivered message was hand-built in 5 separate places, each selecting only the original's id, content and sender columns. The media columns (image_url, file_url, file_name, file_size, file_expires_at, deleted_at) were never included, so the delivered replyTo object carried no media. An image-only original also has empty content, which then fell through to the deleted-message fallback on the client.

Changes
Add src/utils/replySnapshot.js with shared building blocks so the snapshot cannot drift again:
replySnapshotJoinColumns for the queries that JOIN the reply row (aliases rm/ru)
replySnapshotSelfColumns for the standalone reply lookups (aliases m/u)
buildReplyTo(row) mapper returning a self-contained snapshot incl. image/file/expiry and deletedAt (content trimmed to 150 chars)
Use the helper at all 5 sites, removing the duplicated inline SQL and object-building:
server.js socket send (team and direct branches)
messageController.js getMessages (team and direct SELECTs) and getMessageById
Add test/replySnapshot.test.js covering the media-field mapping, the null case, content trimming and deletedAt.
Note: soft delete already nulls content and media and sets deleted_at, so a deleted original now surfaces correctly in the snapshot as well.

Testing
node --check on the changed files
npm test green (99/99, incl. the 4 new snapshot tests)
Manually smoke-verified: a reply to an older image message now shows the thumbnail and expiry for the other participant, not a deleted-message placeholder.