### PR TITLE
fix(user-deletion): honor snake_case ownership overrides on account d…

### DIFF
--- a/src/controllers/userDeletionController.js
+++ b/src/controllers/userDeletionController.js
@@ -120,7 +120,13 @@ const deleteUser = async (req, res) => {
 
   try {
     const userId = parseInt(req.params.id, 10);
-    const { password, ownershipOverrides = [] } = req.body || {};
+    const body = req.body || {};
+    const { password } = body;
+    // The frontend request interceptor serializes all request bodies to
+    // snake_case, so the wire payload is `ownership_overrides` with `team_id` /
+    // `successor_id`. Accept both casings so real requests AND direct/camelCase
+    // callers (e.g. tests) work.
+    const ownershipOverrides = body.ownershipOverrides ?? body.ownership_overrides ?? [];
 
     // Verify the user making the request is the same as the user being deleted
     if (Number(req.user.id) !== userId) {
@@ -147,8 +153,8 @@ const deleteUser = async (req, res) => {
     const ownershipOverrideMap = new Map();
 
     for (const override of ownershipOverrides) {
-      const teamId = Number(override?.teamId);
-      const successorId = Number(override?.successorId);
+      const teamId = Number(override?.teamId ?? override?.team_id);
+      const successorId = Number(override?.successorId ?? override?.successor_id);
 
       if (!Number.isInteger(teamId) || !Number.isInteger(successorId)) {
         return res.status(400).json({

--- a/test/userController.deleteUser.test.js
+++ b/test/userController.deleteUser.test.js
@@ -59,90 +59,12 @@ function createRequest({
   };
 }
 
-test.afterEach(() => {
-  db.pool.connect = originalConnect;
-  bcrypt.compare = originalCompare;
-  process.env.NODE_ENV = originalNodeEnv;
-});
-
-test("deleteUser rejects attempts to delete another user's account", async () => {
-  let connectCalled = false;
-
-  db.pool.connect = async () => {
-    connectCalled = true;
-    throw new Error("connect should not be called");
-  };
-
-  const req = createRequest({ userId: 7, paramId: "8" });
-  const res = createResponse();
-
-  await userDeletionController.deleteUser(req, res);
-
-  assert.equal(res.statusCode, 403);
-  assert.equal(res.body.success, false);
-  assert.match(res.body.message, /delete your own account/i);
-  assert.equal(connectCalled, false);
-});
-
-test("deleteUser rolls back and returns 401 when the password is incorrect", async () => {
-  process.env.NODE_ENV = "production";
-
-  const calls = [];
-  const client = {
-    async query(sql, params = []) {
-      calls.push({ sql, params });
-
-      if (sql === "BEGIN" || sql === "ROLLBACK") {
-        return { rows: [] };
-      }
-
-      if (sql.includes("SELECT id, first_name, last_name, username, avatar_url, avatar_file_id, password_hash")) {
-        return {
-          rows: [
-            {
-              id: 7,
-              first_name: "Jane",
-              last_name: "Doe",
-              username: "janed",
-              avatar_url: null,
-              avatar_file_id: null,
-              password_hash: "stored-hash",
-            },
-          ],
-        };
-      }
-
-      throw new Error(`Unexpected SQL in wrong-password delete test: ${sql}`);
-    },
-    release() {},
-  };
-
-  db.pool.connect = async () => client;
-  bcrypt.compare = async (password, hash) => {
-    assert.equal(password, "secret123");
-    assert.equal(hash, "stored-hash");
-    return false;
-  };
-
-  const req = createRequest();
-  const res = createResponse();
-
-  await userDeletionController.deleteUser(req, res);
-
-  assert.equal(res.statusCode, 401);
-  assert.equal(res.body.success, false);
-  assert.match(res.body.message, /password is incorrect/i);
-  assert.equal(calls.some(({ sql }) => sql === "ROLLBACK"), true);
-  assert.equal(calls.some(({ sql }) => sql === "COMMIT"), false);
-});
-
-test("deleteUser completes the transaction flow and emits the expected socket events", async () => {
-  process.env.NODE_ENV = "production";
-
-  const calls = [];
-  const { emits, io } = createIoRecorder();
-
-  const client = {
+// Shared pool client mock for the happy-path delete flow: one solo team (10,
+// deleted), one shared team (20, transferred) with two successor candidates —
+// user 11 (admin, earliest joined = the DEFAULT candidates[0]) and user 12
+// (member). Records every query into `calls`.
+function createSuccessfulDeleteClient(calls) {
+  return {
     async query(sql, params = []) {
       calls.push({ sql, params });
 
@@ -284,6 +206,92 @@ test("deleteUser completes the transaction flow and emits the expected socket ev
     },
     release() {},
   };
+}
+
+test.afterEach(() => {
+  db.pool.connect = originalConnect;
+  bcrypt.compare = originalCompare;
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
+test("deleteUser rejects attempts to delete another user's account", async () => {
+  let connectCalled = false;
+
+  db.pool.connect = async () => {
+    connectCalled = true;
+    throw new Error("connect should not be called");
+  };
+
+  const req = createRequest({ userId: 7, paramId: "8" });
+  const res = createResponse();
+
+  await userDeletionController.deleteUser(req, res);
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.body.success, false);
+  assert.match(res.body.message, /delete your own account/i);
+  assert.equal(connectCalled, false);
+});
+
+test("deleteUser rolls back and returns 401 when the password is incorrect", async () => {
+  process.env.NODE_ENV = "production";
+
+  const calls = [];
+  const client = {
+    async query(sql, params = []) {
+      calls.push({ sql, params });
+
+      if (sql === "BEGIN" || sql === "ROLLBACK") {
+        return { rows: [] };
+      }
+
+      if (sql.includes("SELECT id, first_name, last_name, username, avatar_url, avatar_file_id, password_hash")) {
+        return {
+          rows: [
+            {
+              id: 7,
+              first_name: "Jane",
+              last_name: "Doe",
+              username: "janed",
+              avatar_url: null,
+              avatar_file_id: null,
+              password_hash: "stored-hash",
+            },
+          ],
+        };
+      }
+
+      throw new Error(`Unexpected SQL in wrong-password delete test: ${sql}`);
+    },
+    release() {},
+  };
+
+  db.pool.connect = async () => client;
+  bcrypt.compare = async (password, hash) => {
+    assert.equal(password, "secret123");
+    assert.equal(hash, "stored-hash");
+    return false;
+  };
+
+  const req = createRequest();
+  const res = createResponse();
+
+  await userDeletionController.deleteUser(req, res);
+
+  assert.equal(res.statusCode, 401);
+  assert.equal(res.body.success, false);
+  assert.match(res.body.message, /password is incorrect/i);
+  assert.equal(calls.some(({ sql }) => sql === "ROLLBACK"), true);
+  assert.equal(calls.some(({ sql }) => sql === "COMMIT"), false);
+});
+
+test("deleteUser completes the transaction flow and emits the expected socket events", async () => {
+  process.env.NODE_ENV = "production";
+
+  const calls = [];
+  const { emits, io } = createIoRecorder();
+
+  const client = createSuccessfulDeleteClient(calls);
 
   db.pool.connect = async () => client;
   bcrypt.compare = async (password, hash) => {
@@ -373,6 +381,73 @@ test("deleteUser completes the transaction flow and emits the expected socket ev
     emits.some(
       ({ room, event, payload }) =>
         room === "user:11" &&
+        event === "notification:new" &&
+        payload.type === "ownership_transferred" &&
+        payload.teamId === 20,
+    ),
+    true,
+  );
+});
+
+// Regression test for the ownership-transfer casing bug: the frontend request
+// interceptor serializes the body to snake_case, so a real request arrives as
+// `ownership_overrides: [{ team_id, successor_id }]`. deleteUser must honor it.
+// The chosen successor here is user 12 (member) — NOT the default candidates[0]
+// (user 11, admin) — so a dropped/ignored override would transfer to 11 and
+// fail this test.
+test("deleteUser honors a snake_case ownership override for a non-default successor", async () => {
+  process.env.NODE_ENV = "production";
+
+  const calls = [];
+  const { emits, io } = createIoRecorder();
+  const client = createSuccessfulDeleteClient(calls);
+
+  db.pool.connect = async () => client;
+  bcrypt.compare = async () => true;
+
+  const req = createRequest({
+    body: {
+      password: "secret123",
+      ownership_overrides: [{ team_id: 20, successor_id: 12 }],
+    },
+    io,
+  });
+  const res = createResponse();
+
+  await userDeletionController.deleteUser(req, res);
+
+  assert.equal(res.statusCode, 200);
+
+  const transferRoleCall = calls.find(
+    ({ sql }) =>
+      sql.includes("UPDATE team_members") && sql.includes("SET role = 'owner'"),
+  );
+  const transferOwnerCall = calls.find(
+    ({ sql }) =>
+      sql.includes("UPDATE teams") && sql.includes("SET owner_id = $1"),
+  );
+
+  // team_members: WHERE team_id = $1 AND user_id = $2 -> [20, 12]
+  assert.deepEqual(transferRoleCall.params, [20, 12]);
+  // teams: SET owner_id = $1 WHERE id = $2 -> [12, 20]
+  assert.deepEqual(transferOwnerCall.params, [12, 20]);
+
+  // The in-chat ownership message names the chosen successor (Mia Ng), not the
+  // default (Sam Smith).
+  assert.equal(
+    calls.some(
+      ({ sql, params }) =>
+        sql.includes("INSERT INTO messages (sender_id, team_id, content, sent_at)") &&
+        params[2] === "👑 OWNERSHIP_TEAM: Former Lomir User | Mia Ng",
+    ),
+    true,
+  );
+
+  // The ownership-transferred notification goes to user 12, not user 11.
+  assert.equal(
+    emits.some(
+      ({ room, event, payload }) =>
+        room === "user:12" &&
         event === "notification:new" &&
         payload.type === "ownership_transferred" &&
         payload.teamId === 20,


### PR DESCRIPTION
…eletion

The account-deletion ownership transfer always used the default successor, ignoring the successor the user picked in the UI.

Root cause: the frontend request interceptor serializes every request body to snake_case, so a real delete request arrives as
. deleteUser read the
camelCase keys (, ,
), which are undefined on the real payload, so the override map was always empty and every team fell back to candidates[0] (the default successor). It failed silently:  is case-neutral, and an empty override array is valid, so the request still returned 200.

Fix: read both snake_case and camelCase for  and its / fields, so real requests and direct/camelCase callers (tests) both work.

Also add a regression test that sends a snake_case override for a NON-default successor (not candidates[0]) and asserts that successor becomes the owner. The pre-existing transfer test missed the bug because it passed camelCase directly (bypassing the interceptor) and happened to pick candidates[0], making override and default indistinguishable. Verified: the new test fails without the fix and passes with it. Suite 100/100. The happy-path client mock is factored into a shared helper used by both tests.

No frontend change: the client correctly follows the snake_case wire convention.