### PR TITLE
fix(search): include userLocation in roles-only response so Nearest sort shows

### DIFF
--- a/src/controllers/searchController.js
+++ b/src/controllers/searchController.js
@@ -168,6 +168,9 @@ const searchController = {
             sortBy: roleSort,
             sortDir: getRolesSortDir(roleSort, direction),
           },
+          userLocation: userLocation
+            ? { hasLocation: true, hasCoordinates: !!userLocation.hasCoordinates }
+            : { hasLocation: false, hasCoordinates: false },
         });
       }
 
@@ -550,6 +553,9 @@ const searchController = {
             sortBy: roleSort,
             sortDir: getRolesSortDir(roleSort, direction),
           },
+          userLocation: userLocation
+            ? { hasLocation: true, hasCoordinates: !!userLocation.hasCoordinates }
+            : { hasLocation: false, hasCoordinates: false },
         });
       }
 

--- a/test/searchController.test.js
+++ b/test/searchController.test.js
@@ -683,6 +683,70 @@ test("globalSearch proximity sort applies distance ordering to open roles in all
   assert.match(roleSql, /ORDER BY .*distance_km ASC/s);
 });
 
+test("globalSearch roles-only response reports userLocation so the frontend can offer the Nearest sort", async () => {
+  const { query } = buildQueryStub({
+    userLocation: {
+      latitude: "52.52",
+      longitude: "13.405",
+      postal_code: "10115",
+      city: "Berlin",
+    },
+  });
+  db.pool.query = query;
+
+  const req = {
+    query: {
+      query: "de",
+      page: "1",
+      limit: "15",
+      searchType: "roles",
+    },
+    user: { id: 99 },
+  };
+  const res = createResponse();
+
+  await searchController.globalSearch(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.data.teams, []);
+  assert.deepEqual(res.body.data.users, []);
+  assert.deepEqual(res.body.userLocation, {
+    hasLocation: true,
+    hasCoordinates: true,
+  });
+});
+
+test("globalSearch roles-only response reports no coordinates when the user has none", async () => {
+  const { query } = buildQueryStub({
+    userLocation: {
+      latitude: null,
+      longitude: null,
+      postal_code: null,
+      city: null,
+    },
+  });
+  db.pool.query = query;
+
+  const req = {
+    query: {
+      query: "de",
+      page: "1",
+      limit: "15",
+      searchType: "roles",
+    },
+    user: { id: 99 },
+  };
+  const res = createResponse();
+
+  await searchController.globalSearch(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.userLocation, {
+    hasLocation: false,
+    hasCoordinates: false,
+  });
+});
+
 test("globalSearch excludes own teams for authenticated users and keeps user results unchanged", async () => {
   const { query, calls } = buildQueryStub();
   db.pool.query = query;


### PR DESCRIPTION
The Open Roles search type was missing the Nearest sort option that All, Teams and People offer. The frontend gates that option on userHasCoordinates, which it reads from userLocation.hasCoordinates in the search response (SearchPage.jsx). The normal globalSearch response returns that field, but the includeRoles branch omitted it, so a roles-only search reported no coordinates and the frontend hid Nearest.

Add the same userLocation payload to the includeRoles branch of both globalSearch and getAllUsersAndTeams, mirroring the normal response shape. The backend already supports proximity ordering for roles (buildRoleNearestPrioritySQL); only the capability signal to the frontend was missing. Frontend needs no change.

Add regression tests asserting the roles-only response reports hasCoordinates true when the user has coordinates and false otherwise. Suite 102/102. 