### PR TITLE
Release: navbar notifications, mark-all-as-read, and roles search fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To test the live demo, anyone can just **register their own account** directly i
 - **Search** — Global search across teams, users, and roles with boolean queries, tag/badge/location filtering, proximity sorting, and "Best Match" scoring
 - **Chat** — Real-time direct and team group messaging via Socket.IO, including typing indicators, read receipts, message replies (reply-to with sender preview), @mention notifications, and structured system messages for team events (member join/leave/removal, role changes, invitation responses, application decisions, role lifecycle, team deletion)
 - **Badge System** — 30 badges across 5 categories; award badges to teammates with reasons and context
-- **Notifications** — In-app notifications for invitations, applications, badge awards, messages, @mentions, and role lifecycle events; each notification deep-links to the exact message that triggered it; stale notifications are cleaned up automatically on member removal, role deletion, and team deletion
+- **Notifications** — In-app notifications for invitations, applications, badge awards, messages, @mentions, and role lifecycle events; each notification deep-links to the exact message that triggered it. The unread-count response also returns the oldest unread notification per type, so a client can walk a type-group from oldest to newest, and both notifications and messages can be cleared in one call via mark-all-as-read endpoints. Stale notifications are cleaned up automatically on member removal, role deletion, team deletion, once a team application is handled, and once an invitation is resolved (accepted, declined, or withdrawn)
 - **Account Deletion** — Full transactional account deletion with impact preview, automatic team ownership transfer, role reopening, and "Former Lomir User" handling for preserved references
 - **Contact Form & Reports** — Public `/api/contact` endpoint with Joi validation, Turnstile CAPTCHA, in-memory file attachments (up to 3 files, 5 MB each, 10 MB total), and email delivery via Brevo. Abuse/content reports are persisted in `contact_reports` with a reference ID before the email is forwarded, so reports are not lost if email delivery fails; reporters also receive an automated acknowledgement-of-receipt email with their reference ID (sent only for `Report content or abuse` submissions, best-effort so a failed receipt never fails the request); unexpected body fields are stripped defensively so multipart attachment fields cannot break validation; rate-limited to 5 submissions/hr
 - **Geocoding** — Location enrichment via Nominatim: resolves a full location object (postal code, city, district, state, country, coordinates) from partial input. Built-in postal-code-to-district lookup for Berlin and Frankfurt (200+ mappings) used as a fast offline fallback before the API call. Works with country alone — does not require both postal code and city.
@@ -266,8 +266,11 @@ Lomir-backend/
 │   ├── csrfProtection.test.js
 │   ├── errorResponse.test.js
 │   ├── invitationController.test.js
+│   ├── invitationController.staleNotifications.test.js
 │   ├── contactController.test.js
 │   ├── messageController.sendMessage.test.js
+│   ├── messageController.markAllAsRead.test.js
+│   ├── notificationController.getUnreadCount.test.js
 │   ├── locationDerivation.test.js
 │   ├── searchController.test.js
 │   ├── teamController.applyToJoinTeam.test.js
@@ -300,8 +303,8 @@ All routes are prefixed with `/api`.
 | `/api/search/all` | Initial search-page data without a required keyword, using the same filtering/sorting core |
 | `/api/matching` | Role ↔ user matching scores and candidate lists |
 | `/api/badges` | Badge catalog and awarding |
-| `/api/messages` | Direct and team message history |
-| `/api/notifications` | User notifications (includes `referenceType`, `typeTeamCounts` in unread count response) |
+| `/api/messages` | Direct and team message history; `PUT /messages/read-all` marks every conversation (direct and team) as read and clears the user's pending @mention notifications |
+| `/api/notifications` | User notifications. The unread-count response includes `referenceType`, `typeTeamCounts`, and `typeFirstUnread` (the oldest unread notification per type with its navigation target); `PUT /notifications/read-all` marks all of them as read |
 | `/api/imagekit` | Auth params for client-side ImageKit uploads |
 | `/api/tags` | Tag catalog (structured by category) |
 | `/api/geocoding` | Postal code → city/district/country/coordinates lookup |
@@ -356,6 +359,7 @@ The server uses Socket.IO for real-time features. Clients authenticate from the 
 | `message:received` | Server → Client | New message broadcast; includes `replyTo` object (id, content preview, sender) when replying; also emitted for server-inserted system messages (role events, member changes, etc.) |
 | `message:read` | Client → Server | Mark messages as read |
 | `message:status` | Server → Client | Read receipt notification |
+| `messages:read-all` | Server → Client | Emitted to the user's own room after `PUT /messages/read-all` so the navbar badge and the chat page conversation list drop to zero in real time |
 | `typing:start` / `typing:stop` | Bidirectional | Typing indicators |
 | `blocks:updated` | Server → Client | Tells both affected users to re-sync block state after a block or unblock |
 | `users:online` | Server → Client | Updated list of online user IDs |
@@ -363,7 +367,7 @@ The server uses Socket.IO for real-time features. Clients authenticate from the 
 | `team:member_kicked` | Server → Client | Emitted to the removed member to kick them from the team chat |
 | `conversation:deleted` | Server → Client | DM conversation removed |
 | `notification:new` | Server → Client | New notification for the user — covers invitations, applications, member changes, role lifecycle events (`role_created`, `role_updated`, `role_deleted`, `role_closed`, `role_filled`, `role_reopened`), badge awards, `message_mention`, team deletion, and ownership transfers |
-| `notification:updated` | Server → Client | Tells the client to re-fetch notifications — emitted on invitation cancellation, role invitation cancellation, stale notification cleanup (e.g. after member removal or role deletion), and admin action acknowledgements |
+| `notification:updated` | Server → Client | Tells the client to re-fetch notifications — emitted on invitation cancellation, role invitation cancellation, an invitee accepting or declining an invitation (so their own resolved invite notification disappears), stale notification cleanup (e.g. after member removal or role deletion), and admin action acknowledgements |
 
 ---
 

--- a/docs/RESTORE_EMAIL_VERIFICATION_GUIDE.md
+++ b/docs/RESTORE_EMAIL_VERIFICATION_GUIDE.md
@@ -1,0 +1,195 @@
+# Email Registration — Interim Solution & Restoration Guide
+
+Documentation of the interim registration strategy and step-by-step instructions for restoring full email verification.
+
+---
+
+## Background
+
+Lomir uses [Resend](https://resend.com) for transactional emails (account verification, password reset). Resend's free tier provides 100 emails/day and 3,000/month, which is sufficient for testing. However, without a verified custom domain, Resend only delivers emails from the sandbox sender (`onboarding@resend.dev`) to the **account holder's email address**. This means new users cannot receive verification emails during the current testing phase.
+
+To unblock user registration while the app is deployed on free-tier infrastructure (Render + Vercel) without a custom domain, we introduced a **feature-flag bypass** that skips email verification entirely.
+
+---
+
+## How the Interim Solution Works
+
+A single environment variable controls whether email verification is enforced:
+
+```env
+SKIP_EMAIL_VERIFICATION=true
+```
+
+When this flag is set to `true`:
+
+1. **Registration** — the user is created, tags are saved, and the account is immediately set to `email_verified = TRUE`. A JWT token is returned in the response, logging the user in directly. No verification token is generated and no email is sent.
+2. **Login** — the `email_verified` check is relaxed. Users who registered before the flag was set (and never verified) can still log in.
+3. **Frontend** — no changes were needed. `AuthContext.jsx` already handled both paths: when the backend returns `requiresVerification: true` it shows the "check your email" screen, and when it returns a `token` + `user` directly it logs the user in.
+
+All existing verification code remains in place and untouched — it is simply bypassed by an early `return` in the `register` method.
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/controllers/authController.js` → `register` | Added conditional block (marked with `INTERIM` comments) that auto-verifies the user and returns a JWT when the flag is set |
+| `src/controllers/authController.js` → `login` | Added `&& process.env.SKIP_EMAIL_VERIFICATION !== "true"` to the `email_verified` check |
+
+No frontend files were modified.
+
+---
+
+## Where the Flag Is Set
+
+| Environment | Location | Value |
+|-------------|----------|-------|
+| **Local development** | `Lomir-backend/.env` | `SKIP_EMAIL_VERIFICATION=true` |
+| **Production (Render)** | Render dashboard → Backend service → Environment Variables | `SKIP_EMAIL_VERIFICATION=true` |
+
+---
+
+## Restoring Full Email Verification
+
+Follow these steps when you are ready to enforce email verification for all new users.
+
+### Prerequisites
+
+Before you begin, make sure both of these are in place:
+
+1. **A custom domain** (e.g. `lomir.app`) is configured and pointing at your deployment
+2. **The domain is verified in Resend** — this requires adding DNS records (SPF, DKIM, and optionally DMARC) in your domain registrar. Resend's dashboard will show green checkmarks once the records propagate.
+
+### Step 1 — Update the sender address
+
+**File:** `src/services/emailService.js`
+
+```js
+// Before (sandbox — only delivers to account holder)
+const FROM_EMAIL = "onboarding@resend.dev";
+
+// After (verified domain — delivers to all recipients)
+const FROM_EMAIL = "noreply@lomir.app";  // replace with your actual domain
+```
+
+### Step 2 — Verify the frontend URL
+
+Make sure `FRONTEND_URL` points to your production frontend in **both** your local `.env` and Render environment variables. This URL is used to build the verification link in emails:
+
+```env
+FRONTEND_URL=https://lomir.app
+```
+
+The link template in `emailService.js` uses it like this:
+
+```
+${process.env.FRONTEND_URL}/verify-email?token=${token}
+```
+
+### Step 3 — Remove the feature flag
+
+**On Render:** Dashboard → Backend service → Environment Variables → delete `SKIP_EMAIL_VERIFICATION` (or set it to `false`).
+
+**In local `.env`:** Remove the line or set it to `false`:
+
+```env
+# SKIP_EMAIL_VERIFICATION=true
+```
+
+Render will redeploy automatically after the env var change. Restart your local backend (`npm run dev`) to pick up the change.
+
+### Step 4 — Test the full flow
+
+1. Register a new account with a real email address
+2. Confirm you receive the verification email from your custom domain sender
+3. Click the verification link — you should land on `/verify-email` and see the success screen
+4. Log in with the new credentials
+
+Also test the edge cases:
+
+- Trying to log in before verifying (should be blocked with "Please verify your email")
+- Resending the verification email
+- Expired verification tokens (24-hour window)
+- Password reset emails (these also use Resend)
+
+---
+
+## What Happens to Existing Users
+
+Users who registered **during the interim period** are already marked `email_verified = TRUE` in the database. They are unaffected and can continue logging in normally after the flag is removed.
+
+Users who register **after the flag is removed** will go through the full verification flow.
+
+---
+
+## Optional: Remove the Interim Code
+
+Once full verification is confirmed working, you can optionally clean up the interim code. This is not required — the code is harmless when the flag is absent — but keeps the codebase tidy.
+
+### In `src/controllers/authController.js` — `register` method
+
+Delete the block between the `INTERIM` comments:
+
+```js
+      // ── INTERIM: skip email verification when flag is set ──
+      if (process.env.SKIP_EMAIL_VERIFICATION === "true") {
+        await db.query(
+          `UPDATE users SET email_verified = TRUE WHERE id = $1`,
+          [user.id],
+        );
+
+        const token = generateToken(user);
+
+        return res.status(201).json({
+          success: true,
+          message: "Registration successful!",
+          data: {
+            token,
+            user: {
+              id: user.id,
+              username: user.username,
+              email: user.email,
+              first_name: user.first_name,
+              last_name: user.last_name,
+              bio: user.bio,
+              postal_code: user.postal_code,
+              city: user.city,
+              country: user.country,
+              avatar_url: user.avatar_url,
+              is_public: user.is_public,
+              created_at: user.created_at,
+            },
+          },
+        });
+      }
+      // ── END INTERIM ──
+```
+
+### In `src/controllers/authController.js` — `login` method
+
+Revert:
+
+```js
+      // Current (interim)
+      if (!user.email_verified && process.env.SKIP_EMAIL_VERIFICATION !== "true") {
+```
+
+Back to:
+
+```js
+      // Original
+      if (!user.email_verified) {
+```
+
+### Environment variables
+
+Delete `SKIP_EMAIL_VERIFICATION` from Render and local `.env` if you haven't already.
+
+---
+
+## Related Documentation
+
+- [Deployment Guide](../../LOMIR_DEPLOYMENT_GUIDE.md) — environment variables and deploy workflow
+- [Local Setup Guide](../../LOMIR_LOCAL_SETUP_GUIDE.md) — local `.env` configuration
+- Resend documentation: [https://resend.com/docs](https://resend.com/docs)

--- a/docs/USER_DELETION_SPEC.md
+++ b/docs/USER_DELETION_SPEC.md
@@ -1,0 +1,363 @@
+# Lomir — User Account Deletion: Complete Specification
+
+## Overview
+
+This document captures every decision made for implementing account deletion in Lomir. It serves as the single reference for backend and frontend implementation.
+
+---
+
+## Pre-Deletion Flow
+
+### Step 1: Password Confirmation
+- User clicks "Delete Account" in Settings
+- Modal requires **password entry** before proceeding
+- Backend verifies password against `password_hash` before returning the impact summary
+
+### Step 2: Impact Summary (new endpoint)
+- Backend calculates and returns a JSON summary of what will happen:
+  - Teams where ownership will be transferred (with auto-selected successors)
+  - Teams that will be deleted (sole-owner teams)
+  - Roles that will be reopened
+  - Counts: badge awards given, messages, team memberships
+- User sees the summary in the modal with the option to **override ownership transfer targets**
+
+### Step 3: Confirm & Execute
+- User confirms → backend executes full deletion in a single transaction
+- On success: logout, redirect to home
+- No grace period — deletion is instant and irreversible
+- No confirmation email sent
+
+---
+
+## Scenario-by-Scenario Specification
+
+### 1. Badges the User RECEIVED
+| Item | Action |
+|------|--------|
+| `badge_awards` where `awarded_to_user_id = userId` | **DELETE** |
+| `user_badges` where `user_id = userId` | **DELETE** |
+
+User's own badge collection is removed entirely.
+
+### 2. Badges the User AWARDED to Others
+| Item | Action |
+|------|--------|
+| `badge_awards.awarded_by_user_id` | **SET NULL** |
+| `user_badges.awarded_by` | **SET NULL** |
+
+Recipients keep their badges and credits intact. Frontend displays **"Former Lomir User"** with a **grey silhouette avatar** wherever the awarder's name/avatar would appear. No credit recalculation needed.
+
+### 3. Teams — Sole Owner (Only Member)
+| Item | Action |
+|------|--------|
+| The team itself | **HARD DELETE** |
+| `team_tags` for the team | **DELETE** (cascades) |
+| `team_members` for the team | **DELETE** (cascades) |
+| `team_vacant_roles` for the team | **DELETE** (cascades) |
+| `team_vacant_role_tags` for those roles | **DELETE** (cascades) |
+| `team_vacant_role_badges` for those roles | **DELETE** (cascades) |
+| `team_applications` for the team | **DELETE** |
+| `team_invitations` for the team | **DELETE** |
+| `messages` with `team_id` for the team | **DELETE** |
+
+**Before deleting:** Copy team name into `badge_awards.custom_team_name` (and SET NULL on `badge_awards.team_id`) for any badge awards that reference this team. This preserves the team name on badges without a clickable link.
+
+**Notifications to send before deletion:**
+- Notify **pending applicants** that the team has been dissolved
+- Notify **pending invitees** (team and role invitations) that the team has been dissolved
+
+**Pre-deletion summary** shows these teams with a clear message: *"This team will be permanently deleted."*
+
+### 4. Teams — Owner with Other Members (Ownership Transfer)
+| Item | Action |
+|------|--------|
+| `teams.owner_id` | **UPDATE** to successor |
+| `team_members` role of successor | **UPDATE** to `'owner'` |
+| `team_members` row of deleted user | **DELETE** |
+
+**Successor selection cascade:**
+1. User's explicit choice (from pre-deletion summary override)
+2. Longest-serving **admin** (by `joined_at`)
+3. Longest-serving **member** (by `joined_at`)
+
+**Notifications:**
+- Successor receives ownership transfer notification
+- Team chat receives system message (see §12)
+
+### 5. Teams — Regular Member (Not Owner)
+| Item | Action |
+|------|--------|
+| `team_members` row | **DELETE** |
+
+Team chat receives system message: `"🚪 [Name] has left Lomir."` (uses the user's real name one final time).
+
+### 6. Roles the User FILLED
+| Item | Action |
+|------|--------|
+| `team_vacant_roles.status` | **UPDATE** to `'open'` |
+| `team_vacant_roles.filled_by` | **SET NULL** |
+
+**Timing:** Execute after removing user from `team_members` but before deleting the user row (so the user's name is still available for notifications).
+
+**Notifications:**
+- Team **owner and admins** receive a dedicated notification: *"The role [Role Name] is now open again."*
+- Team chat receives a system message: `"🔓 The role [Role Name] is now open again."`
+
+### 7. Roles the User CREATED
+| Item | Action |
+|------|--------|
+| `team_vacant_roles.created_by` | **SET NULL** |
+
+Role definitions persist. Only the "created by" attribution is lost.
+
+### 8. User's Team Applications
+| Item | Action |
+|------|--------|
+| `team_applications` where `applicant_id = userId` | **DELETE** (all statuses) |
+
+### 9. Applications the User Reviewed
+| Item | Action |
+|------|--------|
+| `team_applications.reviewed_by` | **SET NULL** |
+
+The approval/rejection decision stands; reviewer attribution is cleared.
+
+### 10. All Invitations Involving the User
+| Item | Action |
+|------|--------|
+| `team_invitations` where `invitee_id = userId` | **DELETE** (all statuses) |
+| `team_invitations` where `inviter_id = userId` | **DELETE** (all statuses) |
+
+Both pending and resolved invitations are removed.
+
+### 11. Direct Messages
+| Item | Action |
+|------|--------|
+| `messages` where `sender_id = userId AND team_id IS NULL` | **DELETE** |
+| `messages` where `receiver_id = userId AND team_id IS NULL` | **DELETE** |
+
+All DMs involving the user are removed. The other party loses the conversation. ImageKit file attachments in these messages are left alone — existing 60-day expiration handles cleanup.
+
+### 12. Team Chat Messages
+| Item | Action |
+|------|--------|
+| `messages.sender_id` where `sender_id = userId AND team_id IS NOT NULL` | **SET NULL** |
+| System messages containing user's name | **REPLACE** name with `"Former Lomir User"` in `content` |
+
+**New departure message** posted to each team: `"🚪 [Real Name] has left Lomir."` — this is the last record of their name.
+
+**Backend query fix required:** `getMessages` must change `JOIN users u ON m.sender_id = u.id` → `LEFT JOIN users u ON m.sender_id = u.id`.
+
+**Frontend display:** Messages with `sender_id = NULL` show **"Former Lomir User"** with a **generic grey silhouette** avatar.
+
+### 13. Notifications FOR the User
+| Item | Action |
+|------|--------|
+| `notifications` where `user_id = userId` | **DELETE** |
+
+### 14. Notifications ABOUT the User
+| Item | Action |
+|------|--------|
+| `notifications.actor_id` where `actor_id = userId` | **SET NULL** |
+| `notifications.reference_id` where it points to a now-deleted resource | **SET NULL** |
+
+Notification text (`title`, `message`) already contains the name as a baked-in string, so notifications remain readable. Frontend shows "Former Lomir User" for the actor avatar/link.
+
+### 15. User Tags
+| Item | Action |
+|------|--------|
+| `user_tags` where `user_id = userId` | **DELETE** (CASCADE handles this) |
+
+### 16. Tags Created by the User
+| Item | Action |
+|------|--------|
+| `tags.created_by` where `created_by = userId` | **SET NULL** |
+
+Currently 0 user-created tags exist (all 780 are system tags), but this FK is `NO ACTION` and will block deletion if a user ever creates custom tags. Must be handled in code.
+
+### 17. Messages — deleted_by Column
+| Item | Action |
+|------|--------|
+| `messages.deleted_by` where `deleted_by = userId` | **SET NULL** |
+
+No FK constraint exists on this column, so it won't block deletion, but cleanup prevents orphaned references.
+
+---
+
+## Profile Placeholder
+
+When someone visits a deleted user's profile URL:
+- **Show a "This user profile does not exist on Lomir" placeholder page** with subtitle **"This profile is not available"**
+- Grey silhouette avatar, no personal information displayed
+- This placeholder appears for ANY profile 404 — the backend does not distinguish between "never existed" and "was deleted". This is by design (Option A).
+
+---
+
+## Real-Time Updates (Socket.IO)
+
+On successful deletion, emit events so connected clients update:
+- `team:member_left` → to each team the user was in (refreshes member list)
+- `notification:new` → to team owners/admins for reopened roles
+- `notification:new` → to pending applicants/invitees of dissolved teams
+- `conversation:deleted` → to DM partners (removes the conversation from their list)
+
+---
+
+## New API Endpoints
+
+### `POST /api/users/:id/deletion-preview`
+- **Auth:** Requires valid token + password verification
+- **Returns:** Impact summary JSON (teams to transfer, teams to delete, roles to reopen, counts)
+
+### `DELETE /api/users/:id` (updated)
+- **Auth:** Requires valid token + password in request body
+- **Body:** `{ password: string, ownershipOverrides?: { teamId: number, successorId: number }[] }`
+- **Executes:** Full deletion transaction as specified above
+- Service calls use `skipAuthRedirect` on the frontend to prevent a 401 (wrong password) from triggering a global logout.
+
+---
+
+## Frontend Changes Required
+
+1. **Settings.jsx** — Updated delete modal: password input → impact summary → confirm
+2. **Message display components** — Handle `sender_id = NULL` → show "Former Lomir User" + grey avatar
+3. **AwardCard.jsx / badge components** — Handle `awarded_by = NULL` → show "Former Lomir User"
+4. **Profile routes** — New `/profile/:id` public route with `PublicProfile.jsx` component for deleted user placeholder. `UserDetailsModal` also handles 404 inline with 'Former Lomir User' display.
+5. **Notification click handlers** — Handle `reference_id = NULL` gracefully (no navigation)
+6. **Chat/conversation list** — Handle `conversation:deleted` socket event
+7. **Shared utility** — `deletedUser.js` (or similar) with `DELETED_USER_DISPLAY_NAME` constant, `isDeletedUser()` helper, `getDisplayName()` fallback, and `FormerUserAvatar` grey silhouette component.
+
+---
+
+## Database FK Constraint Analysis
+
+Based on the actual constraints in the Neon database:
+
+### Already handled automatically by CASCADE / SET NULL on `DELETE FROM users`:
+| Table.Column | Rule | Notes |
+|---|---|---|
+| `badge_awards.awarded_to_user_id` | CASCADE | Deletes received awards |
+| `badge_awards.awarded_by_user_id` | SET NULL | Preserves others' badges |
+| `messages.sender_id` | SET NULL | Keeps team messages |
+| `messages.receiver_id` | SET NULL | Keeps DMs — but we delete DMs first |
+| `notifications.user_id` | CASCADE | Removes user's notifications |
+| `notifications.actor_id` | SET NULL | Preserves others' notifications |
+| `team_applications.applicant_id` | CASCADE | Removes user's applications |
+| `team_invitations.invitee_id` | CASCADE | Removes invitations to user |
+| `team_invitations.inviter_id` | CASCADE | Removes invitations from user |
+| `team_members.user_id` | CASCADE | Removes memberships — but we transfer ownership first |
+| `user_badges.user_id` | CASCADE | Removes user's badge summary |
+| `user_tags.user_id` | CASCADE | Removes user's tags |
+
+### 6 blockers — must be resolved BEFORE deleting user row:
+| Table.Column | Rule | Action in code |
+|---|---|---|
+| `teams.owner_id` | NO ACTION | Transfer ownership or delete team first |
+| `team_vacant_roles.filled_by` | NO ACTION | SET NULL + reopen role |
+| `team_vacant_roles.created_by` | NO ACTION | SET NULL. **Schema change applied:** `ALTER TABLE team_vacant_roles ALTER COLUMN created_by DROP NOT NULL` — the column originally had a NOT NULL constraint that prevented SET NULL. This was dropped in the Neon database. |
+| `team_applications.reviewed_by` | NO ACTION | SET NULL |
+| `user_badges.awarded_by` | NO ACTION | SET NULL |
+| `tags.created_by` | NO ACTION | SET NULL (0 rows currently, future-proofing) |
+
+### No FK but needs cleanup:
+| Table.Column | Action |
+|---|---|
+| `messages.deleted_by` | SET NULL (18 rows, no FK constraint) |
+
+### Critical ordering note:
+Since `messages.sender_id/receiver_id` auto-SET-NULL and `team_members.user_id` auto-CASCADEs when the user row is deleted, all custom cleanup (DM deletion, system message rewriting, ownership transfers, role reopening) **must happen before** `DELETE FROM users`.
+
+---
+
+## Transaction Order
+
+The `deleteUser` controller executes all operations in a **single database transaction** in this order:
+
+**Phase A — Gather context (before any mutations):**
+1. **Verify password** against stored hash
+2. **Fetch user data**: name, avatar URL, team memberships (with roles), owned teams, filled roles
+
+**Phase B — Messages & chat cleanup (while sender_id still identifies the user):**
+3. **Delete all DMs** involving the user (`sender_id = userId OR receiver_id = userId` where `team_id IS NULL`)
+4. **Post departure messages** to all team chats: `"🚪 [Name] has left Lomir."`
+5. **Replace user's name** in existing system messages in team chats with `"Former Lomir User"`
+
+**Phase C — Team ownership (while team_members still exist):**
+6. **Handle sole-owner teams:**
+   a. Copy team name into `badge_awards.custom_team_name` where `badge_awards.team_id` references the team
+   b. Create notifications for pending applicants/invitees about dissolution
+   c. Hard delete: team_invitations, team_applications, messages, team_vacant_role_tags, team_vacant_role_badges, team_vacant_roles, team_tags, team_members, then the team itself
+7. **Transfer ownership** of multi-member teams (update `teams.owner_id` + `team_members.role`)
+
+**Phase D — Role & reference cleanup (resolve all 6 NO ACTION blockers):**
+8. **Reopen filled roles**: `UPDATE team_vacant_roles SET status='open', filled_by=NULL WHERE filled_by=userId`
+9. **Create notifications** for all team members about reopened roles
+10. **SET NULL on remaining blockers:**
+    - `team_vacant_roles.created_by`
+    - `team_applications.reviewed_by`
+    - `user_badges.awarded_by`
+    - `tags.created_by`
+11. **SET NULL** on `messages.deleted_by` (no FK, but clean up orphaned refs)
+12. **SET NULL** on `notifications.reference_id` for notifications pointing to resources that were deleted in Phase C
+
+**Phase E — Delete user row (CASCADE handles the rest):**
+13. **DELETE the user row** — triggers automatic CASCADE/SET NULL for all remaining FKs
+
+**Phase F — Post-transaction cleanup (outside transaction):**
+14. **Delete ImageKit avatar** (non-blocking, best-effort)
+15. **Emit Socket.IO events**: `team:member_left`, `notification:new`, `conversation:deleted`
+
+---
+
+## Query Fixes Applied
+
+All `JOIN users u ON m.sender_id = u.id` in `messageController.js` changed to `LEFT JOIN` — affects `getMessages` (both legacy and paginated versions) and `getMessageById`. Without this, team messages from deleted users (`sender_id = NULL`) are silently excluded from results.
+
+---
+
+## Data Impact Summary (Current Database)
+
+| Resource | Count | Action | FK handles it? |
+|----------|-------|--------|----------------|
+| Badge awards (received by user) | Varies | Deleted | ✅ CASCADE |
+| Badge awards (given by user) | Up to 188 users affected | SET NULL | ✅ SET NULL |
+| User badges (awarded_by) | Up to 186 users affected | SET NULL | ❌ NO ACTION — code required |
+| Team memberships | Up to 158 users | Removed | ✅ CASCADE (after ownership transfer) |
+| Teams (sole owner) | 3 currently | Hard deleted | ❌ NO ACTION — code required |
+| Teams (owner with members) | 74 currently | Ownership transferred | ❌ NO ACTION — code required |
+| Filled roles | 13 currently | Reopened | ❌ NO ACTION — code required |
+| Roles created_by | 21 users affected | SET NULL | ❌ NO ACTION — code required |
+| Tags created_by | 0 currently | SET NULL | ❌ NO ACTION — code required |
+| Applications reviewed_by | 41 users affected | SET NULL | ❌ NO ACTION — code required |
+| DMs | 1,292 total | Deleted before cascade | ⚠️ SET NULL would fire — must pre-delete |
+| Team messages | 1,681 total | Sender nullified | ✅ SET NULL (rewrite names before cascade) |
+| Notifications (user's) | Varies | Deleted | ✅ CASCADE |
+| Notifications (actor) | 191 users affected | SET NULL | ✅ SET NULL |
+| Invitations | 585 total | All involving user deleted | ✅ CASCADE |
+| Applications (user's) | Varies | Deleted | ✅ CASCADE |
+| Messages deleted_by | 18 rows | SET NULL | ⚠️ No FK — code required |
+
+---
+
+## Implementation Notes
+
+**Status:** Fully implemented and tested (April 2026).
+
+**Schema change applied:** `team_vacant_roles.created_by` changed from NOT NULL to nullable.
+
+**Key files (backend):**
+- `src/controllers/userController.js` — `deletionPreview` and `deleteUser` functions
+- `src/controllers/messageController.js` — LEFT JOIN fixes
+- `src/routes/userRoutes.js` — POST /:id/deletion-preview route
+- `test/userController.deleteUser.test.js` — deletion test coverage (41 tests)
+
+**Key files (frontend):**
+- `src/pages/Settings.jsx` — multi-step deletion modal
+- `src/pages/PublicProfile.jsx` — deleted user profile placeholder
+- `src/App.jsx` — /profile/:id route
+- `src/services/userService.js` — deletionPreview and updated deleteUser methods
+- `src/components/badges/AwardCard.jsx` — Former Lomir User fallback
+- Shared deleted user utility and FormerUserAvatar component
+- Chat message components — null sender handling
+- Notification components — null actor/reference handling
+- `UserDetailsModal.jsx` — inline deleted user handling on 404

--- a/docs/postman/Lomir App.postman_collection.json
+++ b/docs/postman/Lomir App.postman_collection.json
@@ -1,0 +1,105 @@
+{
+	"info": {
+		"_postman_id": "224353ff-1d74-4586-bc46-56b62abbb5d3",
+		"name": "Lomir App",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "41847943"
+	},
+	"item": [
+		{
+			"name": "Register a user",
+			"request": {
+				"auth": {
+					"type": "inherit"
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"username\": \"testuser\",\n  \"email\": \"testuser@example.com\",\n  \"password\": \"password123\",\n  \"first_name\": \"Test\",\n  \"last_name\": \"User\",\n  \"bio\": \"This is a test user\",\n  \"postal_code\": \"10115\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://lomir-backend.onrender.com/api/auth/register",
+					"protocol": "https",
+					"host": ["lomir-backend", "onrender", "com"],
+					"path": ["api", "auth", "register"]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Login with the user",
+			"request": {
+				"auth": {
+					"type": "inherit"
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"email\": \"testuser@example.com\",\n  \"password\": \"password123\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://lomir-backend.onrender.com/api/auth/login",
+					"protocol": "https",
+					"host": ["lomir-backend", "onrender", "com"],
+					"path": [
+						"api",
+						"auth",
+						"login"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get current user",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "inherit"
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTUxLCJ1c2VybmFtZSI6InRlc3R1c2VyIiwiZW1haWwiOiJ0ZXN0dXNlckBleGFtcGxlLmNvbSIsImlhdCI6MTc0MzQxMDI1MCwiZXhwIjoxNzQ0MDE1MDUwfQ._temMQzXPlHgyes4lJ79KFvUWYI_Jnndrfr2mIQkabo",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"email\": \"testuser@example.com\",\n  \"password\": \"password123\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://lomir-backend.onrender.com/api/auth/me",
+					"protocol": "https",
+					"host": ["lomir-backend", "onrender", "com"],
+					"path": [
+						"api",
+						"auth",
+						"me"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/docs/postman/RESTORE_EMAIL_VERIFICATION_GUIDE.md
+++ b/docs/postman/RESTORE_EMAIL_VERIFICATION_GUIDE.md
@@ -1,0 +1,195 @@
+# Email Registration — Interim Solution & Restoration Guide
+
+Documentation of the interim registration strategy and step-by-step instructions for restoring full email verification.
+
+---
+
+## Background
+
+Lomir uses [Resend](https://resend.com) for transactional emails (account verification, password reset). Resend's free tier provides 100 emails/day and 3,000/month, which is sufficient for testing. However, without a verified custom domain, Resend only delivers emails from the sandbox sender (`onboarding@resend.dev`) to the **account holder's email address**. This means new users cannot receive verification emails during the current testing phase.
+
+To unblock user registration while the app is deployed on free-tier infrastructure (Render + Vercel) without a custom domain, we introduced a **feature-flag bypass** that skips email verification entirely.
+
+---
+
+## How the Interim Solution Works
+
+A single environment variable controls whether email verification is enforced:
+
+```env
+SKIP_EMAIL_VERIFICATION=true
+```
+
+When this flag is set to `true`:
+
+1. **Registration** — the user is created, tags are saved, and the account is immediately set to `email_verified = TRUE`. A JWT token is returned in the response, logging the user in directly. No verification token is generated and no email is sent.
+2. **Login** — the `email_verified` check is relaxed. Users who registered before the flag was set (and never verified) can still log in.
+3. **Frontend** — no changes were needed. `AuthContext.jsx` already handled both paths: when the backend returns `requiresVerification: true` it shows the "check your email" screen, and when it returns a `token` + `user` directly it logs the user in.
+
+All existing verification code remains in place and untouched — it is simply bypassed by an early `return` in the `register` method.
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/controllers/authController.js` → `register` | Added conditional block (marked with `INTERIM` comments) that auto-verifies the user and returns a JWT when the flag is set |
+| `src/controllers/authController.js` → `login` | Added `&& process.env.SKIP_EMAIL_VERIFICATION !== "true"` to the `email_verified` check |
+
+No frontend files were modified.
+
+---
+
+## Where the Flag Is Set
+
+| Environment | Location | Value |
+|-------------|----------|-------|
+| **Local development** | `Lomir-backend/.env` | `SKIP_EMAIL_VERIFICATION=true` |
+| **Production (Render)** | Render dashboard → Backend service → Environment Variables | `SKIP_EMAIL_VERIFICATION=true` |
+
+---
+
+## Restoring Full Email Verification
+
+Follow these steps when you are ready to enforce email verification for all new users.
+
+### Prerequisites
+
+Before you begin, make sure both of these are in place:
+
+1. **A custom domain** (e.g. `lomir.app`) is configured and pointing at your deployment
+2. **The domain is verified in Resend** — this requires adding DNS records (SPF, DKIM, and optionally DMARC) in your domain registrar. Resend's dashboard will show green checkmarks once the records propagate.
+
+### Step 1 — Update the sender address
+
+**File:** `src/services/emailService.js`
+
+```js
+// Before (sandbox — only delivers to account holder)
+const FROM_EMAIL = "onboarding@resend.dev";
+
+// After (verified domain — delivers to all recipients)
+const FROM_EMAIL = "noreply@lomir.app";  // replace with your actual domain
+```
+
+### Step 2 — Verify the frontend URL
+
+Make sure `FRONTEND_URL` points to your production frontend in **both** your local `.env` and Render environment variables. This URL is used to build the verification link in emails:
+
+```env
+FRONTEND_URL=https://lomir.app
+```
+
+The link template in `emailService.js` uses it like this:
+
+```
+${process.env.FRONTEND_URL}/verify-email?token=${token}
+```
+
+### Step 3 — Remove the feature flag
+
+**On Render:** Dashboard → Backend service → Environment Variables → delete `SKIP_EMAIL_VERIFICATION` (or set it to `false`).
+
+**In local `.env`:** Remove the line or set it to `false`:
+
+```env
+# SKIP_EMAIL_VERIFICATION=true
+```
+
+Render will redeploy automatically after the env var change. Restart your local backend (`npm run dev`) to pick up the change.
+
+### Step 4 — Test the full flow
+
+1. Register a new account with a real email address
+2. Confirm you receive the verification email from your custom domain sender
+3. Click the verification link — you should land on `/verify-email` and see the success screen
+4. Log in with the new credentials
+
+Also test the edge cases:
+
+- Trying to log in before verifying (should be blocked with "Please verify your email")
+- Resending the verification email
+- Expired verification tokens (24-hour window)
+- Password reset emails (these also use Resend)
+
+---
+
+## What Happens to Existing Users
+
+Users who registered **during the interim period** are already marked `email_verified = TRUE` in the database. They are unaffected and can continue logging in normally after the flag is removed.
+
+Users who register **after the flag is removed** will go through the full verification flow.
+
+---
+
+## Optional: Remove the Interim Code
+
+Once full verification is confirmed working, you can optionally clean up the interim code. This is not required — the code is harmless when the flag is absent — but keeps the codebase tidy.
+
+### In `src/controllers/authController.js` — `register` method
+
+Delete the block between the `INTERIM` comments:
+
+```js
+      // ── INTERIM: skip email verification when flag is set ──
+      if (process.env.SKIP_EMAIL_VERIFICATION === "true") {
+        await db.query(
+          `UPDATE users SET email_verified = TRUE WHERE id = $1`,
+          [user.id],
+        );
+
+        const token = generateToken(user);
+
+        return res.status(201).json({
+          success: true,
+          message: "Registration successful!",
+          data: {
+            token,
+            user: {
+              id: user.id,
+              username: user.username,
+              email: user.email,
+              first_name: user.first_name,
+              last_name: user.last_name,
+              bio: user.bio,
+              postal_code: user.postal_code,
+              city: user.city,
+              country: user.country,
+              avatar_url: user.avatar_url,
+              is_public: user.is_public,
+              created_at: user.created_at,
+            },
+          },
+        });
+      }
+      // ── END INTERIM ──
+```
+
+### In `src/controllers/authController.js` — `login` method
+
+Revert:
+
+```js
+      // Current (interim)
+      if (!user.email_verified && process.env.SKIP_EMAIL_VERIFICATION !== "true") {
+```
+
+Back to:
+
+```js
+      // Original
+      if (!user.email_verified) {
+```
+
+### Environment variables
+
+Delete `SKIP_EMAIL_VERIFICATION` from Render and local `.env` if you haven't already.
+
+---
+
+## Related Documentation
+
+- [Deployment Guide](../../LOMIR_DEPLOYMENT_GUIDE.md) — environment variables and deploy workflow
+- [Local Setup Guide](../../LOMIR_LOCAL_SETUP_GUIDE.md) — local `.env` configuration
+- Resend documentation: [https://resend.com/docs](https://resend.com/docs)

--- a/src/controllers/invitationController.js
+++ b/src/controllers/invitationController.js
@@ -7,6 +7,22 @@ const { computeDistanceScore, WEIGHTS } = require("./matchingController");
 const { serializeEmbeddedVacantRole } = require("../utils/vacantRoleSerializer");
 const { emitInsertedMessage } = require("../utils/socketMessageEmitter");
 
+// Remove an invitee's now-stale invitation notifications — the bell entries that
+// pointed at an invitation which has since been accepted, declined, or cancelled.
+// Covers both team (invitation_received) and role (role_invitation) invites, and
+// is scoped to the invitation id so unrelated notifications are untouched. Takes a
+// query function (the pool or a transaction client) so callers can run it inside
+// or outside a transaction.
+const deleteStaleInvitationNotifications = (queryFn, invitationId) =>
+  queryFn(
+    `DELETE FROM notifications
+     WHERE type IN ('invitation_received', 'role_invitation')
+       AND reference_type = 'team_invitation'
+       AND reference_id = $1
+       AND read_at IS NULL`,
+    [parseInt(invitationId, 10)],
+  );
+
 const buildRoleReopenedMessage = ({
   teamId,
   teamName,
@@ -898,6 +914,13 @@ const respondToInvitation = async (req, res) => {
     try {
       await client.query("BEGIN");
 
+      // The invitee is resolving this invitation (accept or decline), so their
+      // own pending invitation notification is no longer relevant.
+      await deleteStaleInvitationNotifications(
+        (text, params) => client.query(text, params),
+        invitationId,
+      );
+
       let roleFilled = false;
       let filledRoleName = null;
       let roleSwitched = false;
@@ -1308,6 +1331,13 @@ const respondToInvitation = async (req, res) => {
 
       await client.query("COMMIT");
 
+      // Refresh the invitee's own bell now that their invitation notification
+      // was cleared above.
+      req.app.get("io")?.to(`user:${userId}`).emit("notification:updated", {
+        type: "invitation_resolved",
+        invitationId: parseInt(invitationId, 10),
+      });
+
       res.status(200).json({
         success: true,
         message:
@@ -1410,13 +1440,10 @@ const cancelInvitation = async (req, res) => {
       [invitationId],
     );
 
-    // Remove stale invitation_received notification for the invitee
-    await db.pool.query(
-      `DELETE FROM notifications
-       WHERE type = 'invitation_received'
-         AND reference_id = $1
-         AND read_at IS NULL`,
-      [parseInt(invitationId)],
+    // Remove the invitee's now-stale invitation notifications (team + role).
+    await deleteStaleInvitationNotifications(
+      (text, params) => db.pool.query(text, params),
+      invitationId,
     );
 
     // System message format (parseable + clickable team/user)
@@ -1736,4 +1763,6 @@ module.exports = {
   cancelInvitation,
   cancelRoleInvitation,
   getTeamsWhereUserCanInvite,
+  // Exported for tests: the shared stale-invitation-notification cleanup.
+  deleteStaleInvitationNotifications,
 };

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -231,6 +231,90 @@ const getUnreadCount = async (req, res) => {
   }
 };
 
+// PUT /messages/read-all - Mark every unread conversation as read for the user
+// Clears both direct messages (messages.read_at) and team messages
+// (message_reads), mirroring the per-conversation "message:read" socket handler
+// but across all of the user's conversations at once. Emits "messages:read-all"
+// to the user's own socket room so the Navbar badges and the chat page's
+// conversation list can drop to zero in real time.
+const markAllAsRead = async (req, res) => {
+  try {
+    const userId = req.user.id;
+
+    // Direct messages received by the user that are still unread.
+    const directResult = await db.query(
+      `UPDATE messages
+         SET read_at = NOW()
+       WHERE receiver_id = $1
+         AND read_at IS NULL
+         AND team_id IS NULL
+         AND deleted_at IS NULL
+       RETURNING id`,
+      [userId],
+    );
+
+    // Team messages in teams the user belongs to that they have not read yet
+    // (and did not send themselves). Insert a read receipt for each.
+    const teamResult = await db.query(
+      `INSERT INTO message_reads (message_id, user_id, read_at)
+       SELECT m.id, $1, NOW()
+       FROM messages m
+       JOIN team_members tm ON m.team_id = tm.team_id AND tm.user_id = $1
+       WHERE m.team_id IS NOT NULL
+         AND m.sender_id != $1
+         AND m.deleted_at IS NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM message_reads mr
+           WHERE mr.message_id = m.id AND mr.user_id = $1
+         )
+       RETURNING message_id`,
+      [userId],
+    );
+
+    // @mention alerts are surfaced on the chat icon's tooltip, so clearing the
+    // chat also clears the mention notifications that feed that line.
+    const mentionResult = await db.query(
+      `UPDATE notifications
+         SET read_at = NOW()
+       WHERE user_id = $1
+         AND read_at IS NULL
+         AND type = 'message_mention'
+       RETURNING id`,
+      [userId],
+    );
+
+    const io = req.app.get("io");
+    if (io) {
+      io.to(`user:${userId}`).emit("messages:read-all", {
+        userId,
+        readAt: new Date().toISOString(),
+      });
+      // Refresh notification-derived counts (mentions) on the user's other tabs.
+      if (mentionResult.rows.length > 0) {
+        io.to(`user:${userId}`).emit("notification:updated", {
+          type: "message_mention",
+        });
+      }
+    }
+
+    res.status(200).json({
+      success: true,
+      data: {
+        markedDirect: directResult.rows.length,
+        markedTeam: teamResult.rows.length,
+        markedMentions: mentionResult.rows.length,
+      },
+    });
+  } catch (error) {
+    console.error("Error marking all messages as read:", error);
+    res.status(500).json({
+      success: false,
+      message: "Error marking all messages as read",
+      ...(process.env.NODE_ENV === "development" && { error: error.message }),
+    });
+  }
+};
+
 // Start a conversation by sending the first message
 const startConversation = async (req, res) => {
   try {
@@ -1317,4 +1401,5 @@ module.exports = {
   updateMessage,
   deleteMessage,
   getUnreadCount,
+  markAllAsRead,
 };

--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -324,6 +324,28 @@ const getUnreadCount = async (req, res) => {
       typeTeamCounts[row.type] = row.team_count;
     }
 
+    // Oldest unread notification per type, with its navigation target. The bell
+    // tooltip groups by type, so this lets a group jump straight to its oldest
+    // entry (and step through the rest as they are marked read) without having
+    // to fetch and page the whole notification list on the client.
+    const typeFirstUnreadResult = await db.query(
+      `SELECT DISTINCT ON (type)
+         id, type, team_id, reference_type, reference_id, actor_id, title, created_at
+       FROM notifications
+       WHERE user_id = $1 AND read_at IS NULL
+       ORDER BY type, created_at ASC`,
+      [userId],
+    );
+
+    const typeFirstUnread = {};
+    for (const row of typeFirstUnreadResult.rows) {
+      typeFirstUnread[row.type] = {
+        id: row.id,
+        createdAt: row.created_at,
+        navigateTo: getNavigationUrl(row),
+      };
+    }
+
     res.status(200).json({
       success: true,
       data: {
@@ -331,6 +353,7 @@ const getUnreadCount = async (req, res) => {
         firstUnread,
         typeCounts,
         typeTeamCounts,
+        typeFirstUnread,
       },
     });
   } catch (error) {

--- a/src/controllers/searchController.js
+++ b/src/controllers/searchController.js
@@ -168,6 +168,9 @@ const searchController = {
             sortBy: roleSort,
             sortDir: getRolesSortDir(roleSort, direction),
           },
+          userLocation: userLocation
+            ? { hasLocation: true, hasCoordinates: !!userLocation.hasCoordinates }
+            : { hasLocation: false, hasCoordinates: false },
         });
       }
 
@@ -550,6 +553,9 @@ const searchController = {
             sortBy: roleSort,
             sortDir: getRolesSortDir(roleSort, direction),
           },
+          userLocation: userLocation
+            ? { hasLocation: true, hasCoordinates: !!userLocation.hasCoordinates }
+            : { hasLocation: false, hasCoordinates: false },
         });
       }
 

--- a/src/routes/messageRoutes.js
+++ b/src/routes/messageRoutes.js
@@ -24,6 +24,13 @@ router.get(
   messageController.getUnreadCount,
 );
 
+// Mark every conversation as read for the current user
+router.put(
+  "/read-all",
+  authenticateToken,
+  messageController.markAllAsRead,
+);
+
 // Get specific conversation
 router.get(
   "/conversations/:id",

--- a/test/invitationController.staleNotifications.test.js
+++ b/test/invitationController.staleNotifications.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const invitationController = require("../src/controllers/invitationController");
+
+const { deleteStaleInvitationNotifications } = invitationController;
+
+test("deleteStaleInvitationNotifications clears both team and role invite notifications for the invitation", async () => {
+  const calls = [];
+  const queryFn = async (text, params) => {
+    calls.push({ text, params });
+    return { rows: [] };
+  };
+
+  await deleteStaleInvitationNotifications(queryFn, "42");
+
+  assert.equal(calls.length, 1);
+  const { text, params } = calls[0];
+
+  assert.match(text, /DELETE FROM notifications/);
+  // Both invite notification types are covered (role invites were missed before).
+  assert.match(text, /type IN \('invitation_received', 'role_invitation'\)/);
+  // Scoped to invitation notifications only, by invitation id.
+  assert.match(text, /reference_type = 'team_invitation'/);
+  assert.match(text, /reference_id = \$1/);
+  // Only unread entries are removed; already-read history is kept.
+  assert.match(text, /read_at IS NULL/);
+  // The id is normalised to an integer for the integer column.
+  assert.deepEqual(params, [42]);
+});
+
+test("deleteStaleInvitationNotifications accepts a numeric invitation id", async () => {
+  const calls = [];
+  const queryFn = async (text, params) => {
+    calls.push({ text, params });
+    return { rows: [] };
+  };
+
+  await deleteStaleInvitationNotifications(queryFn, 7);
+
+  assert.deepEqual(calls[0].params, [7]);
+});

--- a/test/invitationController.test.js
+++ b/test/invitationController.test.js
@@ -186,6 +186,11 @@ function buildRespondInvitationClientStub({
         return { rows: [] };
       }
 
+      // Stale-invitation-notification cleanup (the invitee resolved the invite).
+      if (sql.includes("DELETE FROM notifications")) {
+        return { rows: [] };
+      }
+
       if (sql.includes("SELECT id FROM team_members WHERE team_id = $1 AND user_id = $2")) {
         return { rows: isInternalMember ? [{ id: 1 }] : [] };
       }
@@ -770,6 +775,50 @@ test("respondToInvitation keeps the decline flow unchanged", async () => {
       payload.type === "invitation_declined",
   );
   assert.ok(declineSocketEvent);
+});
+
+test("respondToInvitation clears the invitee's stale invitation notification and refreshes their bell", async () => {
+  const { query: poolQuery } = buildRespondInvitationPoolQueryStub({ roleId: 9 });
+  const { client, calls: clientCalls } = buildRespondInvitationClientStub();
+  const { query: notificationQuery } = buildNotificationQueryStub();
+  const { io, emits } = createIoRecorder();
+
+  db.pool.query = poolQuery;
+  db.pool.connect = async () => client;
+  db.query = notificationQuery;
+
+  const req = createRequest({
+    invitationId: "77",
+    userId: 7,
+    body: { action: "decline" },
+    io,
+  });
+  const res = createResponse();
+
+  await invitationController.respondToInvitation(req, res);
+
+  assert.equal(res.statusCode, 200);
+
+  // The invitee's own pending invitation notification is removed, covering both
+  // team invites and role invites, scoped to this invitation only.
+  const cleanupCall = clientCalls.find(({ sql }) =>
+    sql.includes("DELETE FROM notifications"),
+  );
+  assert.ok(cleanupCall, "expected the stale-notification cleanup to run");
+  assert.match(
+    cleanupCall.sql,
+    /type IN \('invitation_received', 'role_invitation'\)/,
+  );
+  assert.match(cleanupCall.sql, /reference_type = 'team_invitation'/);
+  assert.match(cleanupCall.sql, /read_at IS NULL/);
+  assert.deepEqual(cleanupCall.params, [77]);
+
+  // The invitee's navbar is told to refetch so the badge drops right away.
+  const inviteeRefresh = emits.find(
+    ({ room, event }) => room === "user:7" && event === "notification:updated",
+  );
+  assert.ok(inviteeRefresh, "expected a bell refresh for the invitee");
+  assert.equal(inviteeRefresh.payload.invitationId, 77);
 });
 
 test("getTeamsWhereUserCanInvite includes teams where the invitee is already a member", async () => {

--- a/test/messageController.markAllAsRead.test.js
+++ b/test/messageController.markAllAsRead.test.js
@@ -1,0 +1,124 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const db = require("../src/config/database");
+const messageController = require("../src/controllers/messageController");
+
+const originalQuery = db.query;
+
+test.afterEach(() => {
+  db.query = originalQuery;
+});
+
+const createResponse = () => ({
+  statusCode: 200,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+const createReq = (emitted) => ({
+  user: { id: 10 },
+  app: {
+    get() {
+      return {
+        to(room) {
+          return {
+            emit(event, payload) {
+              emitted.push({ room, event, payload });
+            },
+          };
+        },
+      };
+    },
+  },
+});
+
+test("markAllAsRead clears direct and team unread messages and reports the counts", async () => {
+  const queries = [];
+  db.query = async (sql, params) => {
+    queries.push({ sql, params });
+
+    if (sql.includes("UPDATE messages") && sql.includes("SET read_at = NOW()")) {
+      return { rows: [{ id: 1 }, { id: 2 }] };
+    }
+
+    if (sql.includes("INSERT INTO message_reads")) {
+      return { rows: [{ message_id: 3 }, { message_id: 4 }, { message_id: 5 }] };
+    }
+
+    if (sql.includes("UPDATE notifications") && sql.includes("message_mention")) {
+      return { rows: [{ id: 6 }] };
+    }
+
+    throw new Error(`Unexpected query in markAllAsRead test: ${sql}`);
+  };
+
+  const emitted = [];
+  const req = createReq(emitted);
+  const res = createResponse();
+
+  await messageController.markAllAsRead(req, res);
+
+  const directQuery = queries.find(({ sql }) => sql.includes("UPDATE messages"));
+  const teamQuery = queries.find(({ sql }) =>
+    sql.includes("INSERT INTO message_reads"),
+  );
+
+  // Direct clears only the user's own unread received DMs.
+  assert.match(directQuery.sql, /receiver_id = \$1/);
+  assert.match(directQuery.sql, /read_at IS NULL/);
+  assert.match(directQuery.sql, /team_id IS NULL/);
+  assert.deepEqual(directQuery.params, [10]);
+
+  // Team read receipts skip the user's own messages and existing reads.
+  assert.match(teamQuery.sql, /m\.sender_id != \$1/);
+  assert.match(teamQuery.sql, /NOT EXISTS/);
+  assert.deepEqual(teamQuery.params, [10]);
+
+  const mentionQuery = queries.find(
+    ({ sql }) =>
+      sql.includes("UPDATE notifications") && sql.includes("message_mention"),
+  );
+  assert.match(mentionQuery.sql, /read_at IS NULL/);
+  assert.deepEqual(mentionQuery.params, [10]);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.markedDirect, 2);
+  assert.equal(res.body.data.markedTeam, 3);
+  assert.equal(res.body.data.markedMentions, 1);
+});
+
+test("markAllAsRead emits messages:read-all to the user's own room", async () => {
+  db.query = async (sql) => {
+    if (sql.includes("UPDATE messages")) return { rows: [] };
+    if (sql.includes("INSERT INTO message_reads")) return { rows: [] };
+    if (sql.includes("UPDATE notifications")) return { rows: [] };
+    throw new Error(`Unexpected query: ${sql}`);
+  };
+
+  const emitted = [];
+  const req = createReq(emitted);
+  const res = createResponse();
+
+  await messageController.markAllAsRead(req, res);
+
+  // With nothing to clear, only the messages:read-all signal is emitted (no
+  // mention refresh).
+  assert.equal(emitted.length, 1);
+  assert.equal(emitted[0].room, "user:10");
+  assert.equal(emitted[0].event, "messages:read-all");
+  assert.equal(emitted[0].payload.userId, 10);
+  assert.equal(res.statusCode, 200);
+  // Nothing to clear still succeeds with zero counts.
+  assert.equal(res.body.data.markedDirect, 0);
+  assert.equal(res.body.data.markedTeam, 0);
+  assert.equal(res.body.data.markedMentions, 0);
+});

--- a/test/notificationController.getUnreadCount.test.js
+++ b/test/notificationController.getUnreadCount.test.js
@@ -1,0 +1,108 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const db = require("../src/config/database");
+const notificationController = require("../src/controllers/notificationController");
+
+const originalQuery = db.query;
+
+test.afterEach(() => {
+  db.query = originalQuery;
+});
+
+const createResponse = () => ({
+  statusCode: 200,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+test("getUnreadCount returns the oldest unread notification per type with a navigation target", async () => {
+  db.query = async (sql) => {
+    if (sql.includes("first_unread_json")) {
+      return {
+        rows: [
+          {
+            count: "3",
+            first_unread_json: {
+              id: 10,
+              type: "application_approved",
+              team_id: 45,
+              reference_type: "message",
+              reference_id: 5,
+              actor_id: 7,
+              title: "Welcome",
+            },
+          },
+        ],
+      };
+    }
+
+    if (sql.includes("GROUP BY type")) {
+      return {
+        rows: [
+          { type: "application_approved", count: 1, team_count: 1 },
+          { type: "invitation_received", count: 2, team_count: 2 },
+        ],
+      };
+    }
+
+    if (sql.includes("DISTINCT ON (type)")) {
+      return {
+        rows: [
+          {
+            id: 10,
+            type: "application_approved",
+            team_id: 45,
+            reference_type: "message",
+            reference_id: 5,
+            actor_id: 7,
+            title: "Welcome",
+            created_at: "2026-01-01T00:00:00.000Z",
+          },
+          {
+            id: 22,
+            type: "invitation_received",
+            team_id: 45,
+            reference_type: "invitation",
+            reference_id: 99,
+            actor_id: 8,
+            title: "You are invited",
+            created_at: "2026-02-01T00:00:00.000Z",
+          },
+        ],
+      };
+    }
+
+    throw new Error(`Unexpected query in getUnreadCount test: ${sql}`);
+  };
+
+  const req = { user: { id: 1 } };
+  const res = createResponse();
+
+  await notificationController.getUnreadCount(req, res);
+
+  assert.equal(res.statusCode, 200);
+  const { typeFirstUnread } = res.body.data;
+
+  // application_approved points at the DM with the approver, highlighting the
+  // approval message.
+  assert.deepEqual(typeFirstUnread.application_approved, {
+    id: 10,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    navigateTo: "/chat/7?type=direct&highlightMessage=5",
+  });
+
+  // invitation_received points at the My Teams invitations tab.
+  assert.equal(typeFirstUnread.invitation_received.id, 22);
+  assert.match(
+    typeFirstUnread.invitation_received.navigateTo,
+    /\/teams\/my-teams\?tab=invitations&highlight=99/,
+  );
+});

--- a/test/searchController.test.js
+++ b/test/searchController.test.js
@@ -683,6 +683,70 @@ test("globalSearch proximity sort applies distance ordering to open roles in all
   assert.match(roleSql, /ORDER BY .*distance_km ASC/s);
 });
 
+test("globalSearch roles-only response reports userLocation so the frontend can offer the Nearest sort", async () => {
+  const { query } = buildQueryStub({
+    userLocation: {
+      latitude: "52.52",
+      longitude: "13.405",
+      postal_code: "10115",
+      city: "Berlin",
+    },
+  });
+  db.pool.query = query;
+
+  const req = {
+    query: {
+      query: "de",
+      page: "1",
+      limit: "15",
+      searchType: "roles",
+    },
+    user: { id: 99 },
+  };
+  const res = createResponse();
+
+  await searchController.globalSearch(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.data.teams, []);
+  assert.deepEqual(res.body.data.users, []);
+  assert.deepEqual(res.body.userLocation, {
+    hasLocation: true,
+    hasCoordinates: true,
+  });
+});
+
+test("globalSearch roles-only response reports no coordinates when the user has none", async () => {
+  const { query } = buildQueryStub({
+    userLocation: {
+      latitude: null,
+      longitude: null,
+      postal_code: null,
+      city: null,
+    },
+  });
+  db.pool.query = query;
+
+  const req = {
+    query: {
+      query: "de",
+      page: "1",
+      limit: "15",
+      searchType: "roles",
+    },
+    user: { id: 99 },
+  };
+  const res = createResponse();
+
+  await searchController.globalSearch(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body.userLocation, {
+    hasLocation: false,
+    hasCoordinates: false,
+  });
+});
+
 test("globalSearch excludes own teams for authenticated users and keeps user results unchanged", async () => {
   const { query, calls } = buildQueryStub();
   db.pool.query = query;


### PR DESCRIPTION
Ships to production:

- Add PUT /api/messages/read-all — clears direct and team messages plus  message_mention, emits messages:read-all
- Extend getUnreadCount with typeFirstUnread so the bell tooltip can jump  to the oldest unread notification per type
- Proactively clean up stale notifications for resolved invitations
- Fix roles-only search response to include userLocation so the Nearest  sort option appears (PR #302)

Verified: 108/108 tests pass.