### PR TITLE
Release: fix silently failing snake_case request bodies in messageController

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ That suite covers abuse report persistence, reference ID responses, email-forwar
 Lomir-backend/
 ├── src/
 │   ├── app.js                  # Express app setup, middleware, route mounting
-│   ├── server.js               # HTTP server + Socket.IO setup
+│   ├── server.js               # Bootstrap: startup guards, HTTP server, initSocket, scheduled jobs, listen
 │   ├── config/
 │   │   ├── database.js         # PostgreSQL connection pool (Neon)
 │   │   ├── imagekit.js         # ImageKit client configuration
@@ -229,6 +229,16 @@ Lomir-backend/
 │   ├── services/
 │   │   ├── emailService.js     # Transactional email methods + templates (verification, password reset/changed, email-change, contact forwarding, report receipt)
 │   │   └── mailProvider.js     # Brevo HTTPS transport (single seam; swap provider here)
+│   ├── socket/
+│   │   ├── index.js            # initSocket(server, app): io + CORS, app.set("io"), auth, handler registration
+│   │   ├── socketAuth.js       # Handshake authentication (session cookie, auth-token fallback)
+│   │   ├── access.js           # Shared authorization helpers (team membership, DM access, reply access, blocked-user rooms, chat-file expiry)
+│   │   ├── presence.js         # Connected-users map, room joins, users:online, disconnect
+│   │   └── handlers/
+│   │       ├── conversationHandlers.js # conversation:join / conversation:leave
+│   │       ├── messageHandlers.js      # message:new incl. @mention notification fanout
+│   │       ├── typingHandlers.js       # typing:start / typing:stop
+│   │       └── readHandlers.js         # message:read
 │   ├── utils/
 │   │   ├── booleanSearchParser.js
 │   │   ├── imagekitUtils.js
@@ -270,6 +280,7 @@ Lomir-backend/
 │   ├── contactController.test.js
 │   ├── messageController.sendMessage.test.js
 │   ├── messageController.markAllAsRead.test.js
+│   ├── messageController.bodyCasing.test.js # Drives controllers with the snake_case bodies the frontend sends
 │   ├── notificationController.getUnreadCount.test.js
 │   ├── locationDerivation.test.js
 │   ├── searchController.test.js

--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -319,7 +319,10 @@ const markAllAsRead = async (req, res) => {
 const startConversation = async (req, res) => {
   try {
     const userId = req.user.id;
-    const { recipientId, initialMessage } = req.body;
+    // The frontend snake_cases request bodies, so accept both spellings.
+    const recipientId = req.body.recipientId ?? req.body.recipient_id;
+    const initialMessage =
+      req.body.initialMessage ?? req.body.initial_message;
 
     if (!recipientId) {
       return res.status(400).json({
@@ -958,16 +961,12 @@ const sendMessage = async (req, res) => {
   try {
     const userId = req.user.id;
     const conversationId = req.params.id;
-    const {
-      content,
-      type,
-      imageUrl,
-      fileUrl,
-      fileName,
-      replyToId: bodyReplyToId,
-      reply_to_id: bodyReplyToIdSnake,
-    } = req.body;
-    const replyToId = bodyReplyToId || bodyReplyToIdSnake || null;
+    const { content, type } = req.body;
+    // The frontend snake_cases request bodies, so accept both spellings.
+    const imageUrl = req.body.imageUrl ?? req.body.image_url;
+    const fileUrl = req.body.fileUrl ?? req.body.file_url;
+    const fileName = req.body.fileName ?? req.body.file_name;
+    const replyToId = req.body.replyToId || req.body.reply_to_id || null;
     const messageType = type === "team" ? "team" : "direct";
 
     // Allow content OR imageUrl OR fileUrl (or combinations)

--- a/test/messageController.bodyCasing.test.js
+++ b/test/messageController.bodyCasing.test.js
@@ -1,0 +1,268 @@
+// The frontend api.js snake_cases request bodies, and messageService sends
+// startConversation / sendMessage payloads in snake_case explicitly (with
+// skipRequestCaseTransform). These tests drive the controllers with the exact
+// snake_case shape the frontend puts on the wire, so a camelCase-only read
+// fails here instead of silently resolving to undefined in production.
+// Each snake_case case is paired with a camelCase one to keep both accepted.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const db = require("../src/config/database");
+const userModel = require("../src/models/userModel");
+const messageController = require("../src/controllers/messageController");
+
+const originalQuery = db.query;
+const originalIsBlockedBetween = userModel.isBlockedBetween;
+
+test.afterEach(() => {
+  db.query = originalQuery;
+  userModel.isBlockedBetween = originalIsBlockedBetween;
+});
+
+const createResponse = () => ({
+  statusCode: 200,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(payload) {
+    this.body = payload;
+    return this;
+  },
+});
+
+// --- startConversation -------------------------------------------------
+
+const stubStartConversationQueries = (inserts) => {
+  db.query = async (sql, params) => {
+    if (sql.includes("SELECT id FROM users")) {
+      return { rows: [{ id: 42 }] };
+    }
+
+    if (sql.includes("INSERT INTO messages")) {
+      inserts.push(params);
+      return { rows: [] };
+    }
+
+    return { rows: [] };
+  };
+
+  userModel.isBlockedBetween = async () => false;
+};
+
+test("startConversation accepts the snake_case body the frontend sends", async () => {
+  const inserts = [];
+  stubStartConversationQueries(inserts);
+
+  const req = {
+    user: { id: 10 },
+    body: { recipient_id: 42, initial_message: "Hello there" },
+  };
+  const res = createResponse();
+
+  await messageController.startConversation(req, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.success, true);
+  assert.equal(res.body.data.conversationId, 42);
+  assert.equal(inserts.length, 1);
+  assert.deepEqual(inserts[0], [10, 42, "Hello there"]);
+});
+
+test("startConversation still accepts a camelCase body", async () => {
+  const inserts = [];
+  stubStartConversationQueries(inserts);
+
+  const req = {
+    user: { id: 10 },
+    body: { recipientId: 42, initialMessage: "Hello there" },
+  };
+  const res = createResponse();
+
+  await messageController.startConversation(req, res);
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(res.body.data.conversationId, 42);
+  assert.deepEqual(inserts[0], [10, 42, "Hello there"]);
+});
+
+test("startConversation rejects a body with no recipient in either spelling", async () => {
+  const inserts = [];
+  stubStartConversationQueries(inserts);
+
+  const req = { user: { id: 10 }, body: { initial_message: "Hello" } };
+  const res = createResponse();
+
+  await messageController.startConversation(req, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.success, false);
+  assert.equal(inserts.length, 0);
+});
+
+// --- sendMessage -------------------------------------------------------
+
+const stubTeamSendQueries = (inserts) => {
+  db.query = async (sql, params) => {
+    if (sql.includes("FROM team_members tm")) {
+      return { rows: [{ "?column?": 1 }] };
+    }
+
+    if (sql.includes("INSERT INTO messages")) {
+      inserts.push(params);
+      return {
+        rows: [
+          {
+            id: 123,
+            sender_id: 10,
+            team_id: 20,
+            content: "See the attachment",
+            reply_to_id: null,
+            image_url: null,
+            file_url: null,
+            file_name: params[6],
+            file_size: null,
+            file_expires_at: null,
+            sent_at: new Date("2026-07-20T10:00:00.000Z"),
+          },
+        ],
+      };
+    }
+
+    if (sql.includes("SELECT username, first_name, last_name FROM users")) {
+      return { rows: [{ username: "jane", first_name: "Jane", last_name: "Doe" }] };
+    }
+
+    if (sql.includes("SELECT COUNT(*)::int AS recipient_count")) {
+      return { rows: [{ recipient_count: 1 }] };
+    }
+
+    return { rows: [] };
+  };
+};
+
+const createTeamSendRequest = (body) => ({
+  user: { id: 10 },
+  params: { id: "20" },
+  body,
+  app: {
+    get() {
+      return {
+        to() {
+          return { emit() {} };
+        },
+      };
+    },
+  },
+});
+
+test("sendMessage persists file_name from a snake_case body", async () => {
+  const inserts = [];
+  stubTeamSendQueries(inserts);
+
+  const res = createResponse();
+  await messageController.sendMessage(
+    createTeamSendRequest({
+      type: "team",
+      content: "See the attachment",
+      file_name: "quarterly-report.pdf",
+    }),
+    res,
+  );
+
+  assert.equal(res.statusCode, 201);
+  // INSERT params: sender, conversation, content, reply_to, image, file, file_name, ...
+  assert.equal(inserts[0][6], "quarterly-report.pdf");
+});
+
+test("sendMessage still persists fileName from a camelCase body", async () => {
+  const inserts = [];
+  stubTeamSendQueries(inserts);
+
+  const res = createResponse();
+  await messageController.sendMessage(
+    createTeamSendRequest({
+      type: "team",
+      content: "See the attachment",
+      fileName: "quarterly-report.pdf",
+    }),
+    res,
+  );
+
+  assert.equal(res.statusCode, 201);
+  assert.equal(inserts[0][6], "quarterly-report.pdf");
+});
+
+// A camelCase-only read would leave imageUrl undefined, so an image-only
+// message would fail the "content, image, or file is required" check instead
+// of reaching file validation. Asserting on which rejection comes back
+// distinguishes the two without needing a real ImageKit URL.
+const CONTENT_REQUIRED = "Message content, image, or file is required";
+
+test("sendMessage reads image_url from a snake_case body", async () => {
+  stubTeamSendQueries([]);
+
+  const res = createResponse();
+  await messageController.sendMessage(
+    createTeamSendRequest({
+      type: "team",
+      content: "",
+      image_url: "https://example.com/not-imagekit.jpg",
+    }),
+    res,
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.notEqual(res.body.message, CONTENT_REQUIRED);
+  assert.equal(res.body.message, "Files must be uploaded through Lomir");
+});
+
+test("sendMessage reads file_url from a snake_case body", async () => {
+  stubTeamSendQueries([]);
+
+  const res = createResponse();
+  await messageController.sendMessage(
+    createTeamSendRequest({
+      type: "team",
+      content: "",
+      file_url: "https://example.com/not-imagekit.pdf",
+    }),
+    res,
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.notEqual(res.body.message, CONTENT_REQUIRED);
+  assert.equal(res.body.message, "Files must be uploaded through Lomir");
+});
+
+test("sendMessage still reads imageUrl from a camelCase body", async () => {
+  stubTeamSendQueries([]);
+
+  const res = createResponse();
+  await messageController.sendMessage(
+    createTeamSendRequest({
+      type: "team",
+      content: "",
+      imageUrl: "https://example.com/not-imagekit.jpg",
+    }),
+    res,
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, "Files must be uploaded through Lomir");
+});
+
+test("sendMessage still rejects a message with no content, image, or file", async () => {
+  stubTeamSendQueries([]);
+
+  const res = createResponse();
+  await messageController.sendMessage(
+    createTeamSendRequest({ type: "team", content: "" }),
+    res,
+  );
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.body.message, CONTENT_REQUIRED);
+});


### PR DESCRIPTION
Backend-only release. No socket event, payload, or endpoint contract
changed, so no matching frontend release is needed.

Fixes two casing mismatches between what the frontend sends and what
messageController reads. The frontend api.js snake_cases every request
body, and messageService sends these two payloads in snake_case
explicitly (skipRequestCaseTransform), while both controllers read only
camelCase — so the fields resolved to undefined.

- startConversation was failing on every call: it read recipientId, the
  frontend sends recipient_id, so it returned 400 Recipient ID is
  required. This affected every click on the Send Message button on a
  user profile. The failure was invisible because its only caller,
  SendMessageButton, opens the same chat URL on success and on error,
  so the rejected request never surfaced in the UI.
- sendMessage silently dropped imageUrl, fileUrl and fileName for the
  same reason. This one was latent rather than live: the chat itself
  sends via socket, which does not pass through the interceptor, and
  the three HTTP callers send text only.

Both now accept either spelling, so existing camelCase callers keep
working. replyToId deliberately keeps its || fallback rather than moving
to ??, because the previous code treated an empty string as absent and
changing that is a behaviour change that does not belong in a casing fix.

Adds test/messageController.bodyCasing.test.js (9 tests, 117 total),
which drives the controllers with the exact snake_case shape the
frontend puts on the wire. The four snake_case tests were verified to
fail against the unfixed controller, so they would have caught this.

Also updates the README: the directory tree still described server.js as
the HTTP server plus Socket.IO setup, which stopped being true with the
previous release.

Found during a systematic audit of req.body reads across all 14
controllers that read one (90 fields, 18 camelCase). The remaining
camelCase reads all have same-expression ?? fallbacks covering both
spellings, verified individually.

Verified: 117/117 tests pass. Smoke tested against a running server:
POST /api/messages/conversations with recipient_id went from 400 to 201,
camelCase still returns 201, a body with no recipient in either spelling
still returns 400, and POST to a team conversation with file_name
persisted and returned the file name.

Post-deploy check: open a user profile and click Send Message — the
POST to /api/messages/conversations should return 201 rather than 400.
Note the request fires in the tab where you click, not in the chat tab
that opens afterwards.
