### PR TITLE
chore(api): remove the two endpoints that lost their last consumer

### DIFF
--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -315,71 +315,6 @@ const markAllAsRead = async (req, res) => {
   }
 };
 
-// Start a conversation by sending the first message
-const startConversation = async (req, res) => {
-  try {
-    const userId = req.user.id;
-    // The frontend snake_cases request bodies, so accept both spellings.
-    const recipientId = req.body.recipientId ?? req.body.recipient_id;
-    const initialMessage =
-      req.body.initialMessage ?? req.body.initial_message;
-
-    if (!recipientId) {
-      return res.status(400).json({
-        success: false,
-        message: "Recipient ID is required",
-      });
-    }
-
-    const senderId = parseInt(userId);
-    const receiverId = parseInt(recipientId);
-
-    // Check if recipient exists
-    const recipientResult = await db.query(
-      `SELECT id FROM users WHERE id = $1`,
-      [receiverId],
-    );
-
-    if (recipientResult.rows.length === 0) {
-      return res.status(404).json({
-        success: false,
-        message: "Recipient not found",
-      });
-    }
-
-    if (await userModel.isBlockedBetween(senderId, receiverId)) {
-      return res.status(403).json({
-        success: false,
-        message: "You can no longer message this user",
-      });
-    }
-
-    // Only send a message if there's actual content
-    if (initialMessage && initialMessage.trim() !== "") {
-      await db.query(
-        `INSERT INTO messages (sender_id, receiver_id, content, sent_at)
-         VALUES ($1, $2, $3, NOW())`,
-        [senderId, receiverId, initialMessage.trim()],
-      );
-    }
-
-    // Always return success - the frontend will handle showing the conversation
-    res.status(201).json({
-      success: true,
-      data: {
-        conversationId: receiverId,
-      },
-    });
-  } catch (error) {
-    console.error("Error starting conversation:", error);
-    res.status(500).json({
-      success: false,
-      message: "Error starting conversation",
-      ...(process.env.NODE_ENV === "development" && { error: error.message }),
-    });
-  }
-};
-
 // Get all conversations for current user
 const getConversations = async (req, res) => {
   try {
@@ -1391,7 +1326,6 @@ const deleteMessage = async (req, res) => {
 };
 
 module.exports = {
-  startConversation,
   getConversations,
   getConversationById,
   sendMessage,

--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -367,75 +367,6 @@ const getUnreadCount = async (req, res) => {
 };
 
 // ============================================================================
-// GET /notifications - Get all notifications for the user
-// ============================================================================
-const getNotifications = async (req, res) => {
-  try {
-    const userId = req.user.id;
-    const { limit = 50, offset = 0, unreadOnly = false } = req.query;
-
-    let query = `
-      SELECT 
-        n.id,
-        n.type,
-        n.title,
-        n.message,
-        n.reference_type as "referenceType",
-        n.reference_id as "referenceId",
-        n.team_id as "teamId",
-        n.actor_id as "actorId",
-        n.read_at as "readAt",
-        n.created_at as "createdAt",
-        t.name as "teamName",
-        u.username as "actorUsername",
-        u.first_name as "actorFirstName",
-        u.last_name as "actorLastName",
-        u.avatar_url as "actorAvatarUrl"
-      FROM notifications n
-      LEFT JOIN teams t ON n.team_id = t.id
-      LEFT JOIN users u ON n.actor_id = u.id
-      WHERE n.user_id = $1
-    `;
-
-    const params = [userId];
-
-    if (unreadOnly === "true") {
-      query += ` AND n.read_at IS NULL`;
-    }
-
-    query += ` ORDER BY n.created_at DESC LIMIT $2 OFFSET $3`;
-    params.push(parseInt(limit), parseInt(offset));
-
-    const result = await db.query(query, params);
-
-    // Add navigation URL to each notification
-    const notifications = result.rows.map((notification) => ({
-      ...notification,
-      navigateTo: getNavigationUrl({
-        type: notification.type,
-        team_id: notification.teamId,
-        reference_type: notification.referenceType,
-        reference_id: notification.referenceId,
-        actor_id: notification.actorId,
-        title: notification.title,
-      }),
-    }));
-
-    res.status(200).json({
-      success: true,
-      data: notifications,
-    });
-  } catch (error) {
-    console.error("Error fetching notifications:", error);
-    res.status(500).json({
-      success: false,
-      message: "Error fetching notifications",
-      ...(process.env.NODE_ENV === "development" && { error: error.message }),
-    });
-  }
-};
-
-// ============================================================================
 // PUT /notifications/:id/read - Mark a single notification as read
 // ============================================================================
 const markAsRead = async (req, res) => {
@@ -542,7 +473,6 @@ const deleteNotification = async (req, res) => {
 module.exports = {
   // API endpoints
   getUnreadCount,
-  getNotifications,
   markAsRead,
   markAllAsRead,
   deleteNotification,

--- a/src/routes/messageRoutes.js
+++ b/src/routes/messageRoutes.js
@@ -4,13 +4,6 @@ const { authenticateToken } = require("../middlewares/auth");
 
 const router = express.Router();
 
-// Start a new conversation
-router.post(
-  "/conversations",
-  authenticateToken,
-  messageController.startConversation,
-);
-
 // Get all conversations for current user
 router.get(
   "/conversations",

--- a/src/routes/notificationRoutes.js
+++ b/src/routes/notificationRoutes.js
@@ -9,9 +9,6 @@ router.use(authenticateToken);
 // Get unread notification count (with firstUnread for navigation)
 router.get("/unread-count", notificationController.getUnreadCount);
 
-// Get all notifications
-router.get("/", notificationController.getNotifications);
-
 // Mark a single notification as read
 router.put("/:id/read", notificationController.markAsRead);
 

--- a/test/messageController.bodyCasing.test.js
+++ b/test/messageController.bodyCasing.test.js
@@ -1,6 +1,6 @@
 // The frontend api.js snake_cases request bodies, and messageService sends
-// startConversation / sendMessage payloads in snake_case explicitly (with
-// skipRequestCaseTransform). These tests drive the controllers with the exact
+// sendMessage payloads in snake_case explicitly (with
+// skipRequestCaseTransform). These tests drive the controller with the exact
 // snake_case shape the frontend puts on the wire, so a camelCase-only read
 // fails here instead of silently resolving to undefined in production.
 // Each snake_case case is paired with a camelCase one to keep both accepted.
@@ -9,15 +9,12 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const db = require("../src/config/database");
-const userModel = require("../src/models/userModel");
 const messageController = require("../src/controllers/messageController");
 
 const originalQuery = db.query;
-const originalIsBlockedBetween = userModel.isBlockedBetween;
 
 test.afterEach(() => {
   db.query = originalQuery;
-  userModel.isBlockedBetween = originalIsBlockedBetween;
 });
 
 const createResponse = () => ({
@@ -31,75 +28,6 @@ const createResponse = () => ({
     this.body = payload;
     return this;
   },
-});
-
-// --- startConversation -------------------------------------------------
-
-const stubStartConversationQueries = (inserts) => {
-  db.query = async (sql, params) => {
-    if (sql.includes("SELECT id FROM users")) {
-      return { rows: [{ id: 42 }] };
-    }
-
-    if (sql.includes("INSERT INTO messages")) {
-      inserts.push(params);
-      return { rows: [] };
-    }
-
-    return { rows: [] };
-  };
-
-  userModel.isBlockedBetween = async () => false;
-};
-
-test("startConversation accepts the snake_case body the frontend sends", async () => {
-  const inserts = [];
-  stubStartConversationQueries(inserts);
-
-  const req = {
-    user: { id: 10 },
-    body: { recipient_id: 42, initial_message: "Hello there" },
-  };
-  const res = createResponse();
-
-  await messageController.startConversation(req, res);
-
-  assert.equal(res.statusCode, 201);
-  assert.equal(res.body.success, true);
-  assert.equal(res.body.data.conversationId, 42);
-  assert.equal(inserts.length, 1);
-  assert.deepEqual(inserts[0], [10, 42, "Hello there"]);
-});
-
-test("startConversation still accepts a camelCase body", async () => {
-  const inserts = [];
-  stubStartConversationQueries(inserts);
-
-  const req = {
-    user: { id: 10 },
-    body: { recipientId: 42, initialMessage: "Hello there" },
-  };
-  const res = createResponse();
-
-  await messageController.startConversation(req, res);
-
-  assert.equal(res.statusCode, 201);
-  assert.equal(res.body.data.conversationId, 42);
-  assert.deepEqual(inserts[0], [10, 42, "Hello there"]);
-});
-
-test("startConversation rejects a body with no recipient in either spelling", async () => {
-  const inserts = [];
-  stubStartConversationQueries(inserts);
-
-  const req = { user: { id: 10 }, body: { initial_message: "Hello" } };
-  const res = createResponse();
-
-  await messageController.startConversation(req, res);
-
-  assert.equal(res.statusCode, 400);
-  assert.equal(res.body.success, false);
-  assert.equal(inserts.length, 0);
 });
 
 // --- sendMessage -------------------------------------------------------


### PR DESCRIPTION
<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Closes out the two frontend cleanups from FE PRs #563 and #564. Both removed a service method whose backend endpoint then had no consumer left. Route removal is public API surface, so it was kept as a separate decision rather than folded into those PRs — this is that decision.</p><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What is removed</h3>
Endpoint | Controller
-- | --
GET /api/notifications | notificationController.getNotifications
POST /api/messages/conversations | messageController.startConversation

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">220 lines deleted, 2 added.</p><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Checked before removing</h3><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong>Backend-internal callers:</strong><span> </span>none. Each function was referenced only by its own route.</li><li><strong>Postman:</strong><span> </span>neither collection references them —<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">lomir-docs-internal/lomir-api.postman_collection.json</code><span> </span>and<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Lomir-backend/docs/postman/Lomir App.postman_collection.json</code><span> </span>both only cover<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">/api/auth</code>.</li><li><strong>The frontend currently in production (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">main</code>):</strong><span> </span>no reachable caller.<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SendMessageButton</code><span> </span>still contains the<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">startConversation</code><span> </span>call there, but its only call site passes<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">type="team"</code>, so that branch never runs;<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">notificationService.getNotifications</code><span> </span>likewise had no caller on<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">main</code>.<span> </span><strong>Backend and frontend can therefore be released in either order.</strong></li><li><strong>README:</strong><span> </span>documents neither endpoint. The API table is grouped per route prefix, and both affected rows describe only endpoints that remain (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">unread-count</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">read-all</code>, message history). No doc change needed.</li></ul><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Tests</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The three <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">startConversation</code> cases in <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">messageController.bodyCasing.test.js</code> go with the function. They were added in PR #307 for the casing fix on exactly that endpoint. The six <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sendMessage</code> cases stay — that half of PR #307 covered a latent bug on a path that is still live. The <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">userModel</code> import and its <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">isBlockedBetween</code> stub went too; only those three tests used them.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Suite is <strong>114 passing</strong>, down from 117 by exactly those three.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getNavigationUrl</code> stays in <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">notificationController</code> — <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">getUnreadCount</code> and <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">markAllAsRead</code> still use it.</p><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Verification</h3><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">node --check</code><span> </span>on all five changed files</li><li><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">npm test</code><span> </span>— 114/114</li><li>Server boots (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">PORT=5099</code>)</li><li>Router stacks inspected to confirm the removal, because HTTP probing was inconclusive for one of them:<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">notificationRoutes</code><span> </span>applies<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">authenticateToken</code><span> </span>router-wide, so an unauthenticated<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">GET /api/notifications</code><span> </span>returns 401 whether or not the route exists.<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">messageRoutes</code><span> </span>authenticates per route and correctly returns 404.</li><li><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">POST /conversations/:id/messages</code><span> </span>— the live send-message endpoint, and a near-neighbour of the removed path — confirmed intact</li></ul><h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">No smoke test</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Nothing calls the removed endpoints. If a sanity check is wanted anyway, the bell tooltip exercises the neighbouring notification routes (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">unread-count</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">read-all</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">:id/read</code>) and sending a chat message exercises the neighbouring message route.</p>