### PR TITLE
Release dev → main: remove the two dead API endpoints (#309)

### DIFF
--- a/src/controllers/messageController.js
+++ b/src/controllers/messageController.js
@@ -315,71 +315,6 @@ const markAllAsRead = async (req, res) => {
   }
 };
 
-// Start a conversation by sending the first message
-const startConversation = async (req, res) => {
-  try {
-    const userId = req.user.id;
-    // The frontend snake_cases request bodies, so accept both spellings.
-    const recipientId = req.body.recipientId ?? req.body.recipient_id;
-    const initialMessage =
-      req.body.initialMessage ?? req.body.initial_message;
-
-    if (!recipientId) {
-      return res.status(400).json({
-        success: false,
-        message: "Recipient ID is required",
-      });
-    }
-
-    const senderId = parseInt(userId);
-    const receiverId = parseInt(recipientId);
-
-    // Check if recipient exists
-    const recipientResult = await db.query(
-      `SELECT id FROM users WHERE id = $1`,
-      [receiverId],
-    );
-
-    if (recipientResult.rows.length === 0) {
-      return res.status(404).json({
-        success: false,
-        message: "Recipient not found",
-      });
-    }
-
-    if (await userModel.isBlockedBetween(senderId, receiverId)) {
-      return res.status(403).json({
-        success: false,
-        message: "You can no longer message this user",
-      });
-    }
-
-    // Only send a message if there's actual content
-    if (initialMessage && initialMessage.trim() !== "") {
-      await db.query(
-        `INSERT INTO messages (sender_id, receiver_id, content, sent_at)
-         VALUES ($1, $2, $3, NOW())`,
-        [senderId, receiverId, initialMessage.trim()],
-      );
-    }
-
-    // Always return success - the frontend will handle showing the conversation
-    res.status(201).json({
-      success: true,
-      data: {
-        conversationId: receiverId,
-      },
-    });
-  } catch (error) {
-    console.error("Error starting conversation:", error);
-    res.status(500).json({
-      success: false,
-      message: "Error starting conversation",
-      ...(process.env.NODE_ENV === "development" && { error: error.message }),
-    });
-  }
-};
-
 // Get all conversations for current user
 const getConversations = async (req, res) => {
   try {
@@ -1391,7 +1326,6 @@ const deleteMessage = async (req, res) => {
 };
 
 module.exports = {
-  startConversation,
   getConversations,
   getConversationById,
   sendMessage,

--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -367,75 +367,6 @@ const getUnreadCount = async (req, res) => {
 };
 
 // ============================================================================
-// GET /notifications - Get all notifications for the user
-// ============================================================================
-const getNotifications = async (req, res) => {
-  try {
-    const userId = req.user.id;
-    const { limit = 50, offset = 0, unreadOnly = false } = req.query;
-
-    let query = `
-      SELECT 
-        n.id,
-        n.type,
-        n.title,
-        n.message,
-        n.reference_type as "referenceType",
-        n.reference_id as "referenceId",
-        n.team_id as "teamId",
-        n.actor_id as "actorId",
-        n.read_at as "readAt",
-        n.created_at as "createdAt",
-        t.name as "teamName",
-        u.username as "actorUsername",
-        u.first_name as "actorFirstName",
-        u.last_name as "actorLastName",
-        u.avatar_url as "actorAvatarUrl"
-      FROM notifications n
-      LEFT JOIN teams t ON n.team_id = t.id
-      LEFT JOIN users u ON n.actor_id = u.id
-      WHERE n.user_id = $1
-    `;
-
-    const params = [userId];
-
-    if (unreadOnly === "true") {
-      query += ` AND n.read_at IS NULL`;
-    }
-
-    query += ` ORDER BY n.created_at DESC LIMIT $2 OFFSET $3`;
-    params.push(parseInt(limit), parseInt(offset));
-
-    const result = await db.query(query, params);
-
-    // Add navigation URL to each notification
-    const notifications = result.rows.map((notification) => ({
-      ...notification,
-      navigateTo: getNavigationUrl({
-        type: notification.type,
-        team_id: notification.teamId,
-        reference_type: notification.referenceType,
-        reference_id: notification.referenceId,
-        actor_id: notification.actorId,
-        title: notification.title,
-      }),
-    }));
-
-    res.status(200).json({
-      success: true,
-      data: notifications,
-    });
-  } catch (error) {
-    console.error("Error fetching notifications:", error);
-    res.status(500).json({
-      success: false,
-      message: "Error fetching notifications",
-      ...(process.env.NODE_ENV === "development" && { error: error.message }),
-    });
-  }
-};
-
-// ============================================================================
 // PUT /notifications/:id/read - Mark a single notification as read
 // ============================================================================
 const markAsRead = async (req, res) => {
@@ -542,7 +473,6 @@ const deleteNotification = async (req, res) => {
 module.exports = {
   // API endpoints
   getUnreadCount,
-  getNotifications,
   markAsRead,
   markAllAsRead,
   deleteNotification,

--- a/src/routes/messageRoutes.js
+++ b/src/routes/messageRoutes.js
@@ -4,13 +4,6 @@ const { authenticateToken } = require("../middlewares/auth");
 
 const router = express.Router();
 
-// Start a new conversation
-router.post(
-  "/conversations",
-  authenticateToken,
-  messageController.startConversation,
-);
-
 // Get all conversations for current user
 router.get(
   "/conversations",

--- a/src/routes/notificationRoutes.js
+++ b/src/routes/notificationRoutes.js
@@ -9,9 +9,6 @@ router.use(authenticateToken);
 // Get unread notification count (with firstUnread for navigation)
 router.get("/unread-count", notificationController.getUnreadCount);
 
-// Get all notifications
-router.get("/", notificationController.getNotifications);
-
 // Mark a single notification as read
 router.put("/:id/read", notificationController.markAsRead);
 

--- a/test/messageController.bodyCasing.test.js
+++ b/test/messageController.bodyCasing.test.js
@@ -1,6 +1,6 @@
 // The frontend api.js snake_cases request bodies, and messageService sends
-// startConversation / sendMessage payloads in snake_case explicitly (with
-// skipRequestCaseTransform). These tests drive the controllers with the exact
+// sendMessage payloads in snake_case explicitly (with
+// skipRequestCaseTransform). These tests drive the controller with the exact
 // snake_case shape the frontend puts on the wire, so a camelCase-only read
 // fails here instead of silently resolving to undefined in production.
 // Each snake_case case is paired with a camelCase one to keep both accepted.
@@ -9,15 +9,12 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const db = require("../src/config/database");
-const userModel = require("../src/models/userModel");
 const messageController = require("../src/controllers/messageController");
 
 const originalQuery = db.query;
-const originalIsBlockedBetween = userModel.isBlockedBetween;
 
 test.afterEach(() => {
   db.query = originalQuery;
-  userModel.isBlockedBetween = originalIsBlockedBetween;
 });
 
 const createResponse = () => ({
@@ -31,75 +28,6 @@ const createResponse = () => ({
     this.body = payload;
     return this;
   },
-});
-
-// --- startConversation -------------------------------------------------
-
-const stubStartConversationQueries = (inserts) => {
-  db.query = async (sql, params) => {
-    if (sql.includes("SELECT id FROM users")) {
-      return { rows: [{ id: 42 }] };
-    }
-
-    if (sql.includes("INSERT INTO messages")) {
-      inserts.push(params);
-      return { rows: [] };
-    }
-
-    return { rows: [] };
-  };
-
-  userModel.isBlockedBetween = async () => false;
-};
-
-test("startConversation accepts the snake_case body the frontend sends", async () => {
-  const inserts = [];
-  stubStartConversationQueries(inserts);
-
-  const req = {
-    user: { id: 10 },
-    body: { recipient_id: 42, initial_message: "Hello there" },
-  };
-  const res = createResponse();
-
-  await messageController.startConversation(req, res);
-
-  assert.equal(res.statusCode, 201);
-  assert.equal(res.body.success, true);
-  assert.equal(res.body.data.conversationId, 42);
-  assert.equal(inserts.length, 1);
-  assert.deepEqual(inserts[0], [10, 42, "Hello there"]);
-});
-
-test("startConversation still accepts a camelCase body", async () => {
-  const inserts = [];
-  stubStartConversationQueries(inserts);
-
-  const req = {
-    user: { id: 10 },
-    body: { recipientId: 42, initialMessage: "Hello there" },
-  };
-  const res = createResponse();
-
-  await messageController.startConversation(req, res);
-
-  assert.equal(res.statusCode, 201);
-  assert.equal(res.body.data.conversationId, 42);
-  assert.deepEqual(inserts[0], [10, 42, "Hello there"]);
-});
-
-test("startConversation rejects a body with no recipient in either spelling", async () => {
-  const inserts = [];
-  stubStartConversationQueries(inserts);
-
-  const req = { user: { id: 10 }, body: { initial_message: "Hello" } };
-  const res = createResponse();
-
-  await messageController.startConversation(req, res);
-
-  assert.equal(res.statusCode, 400);
-  assert.equal(res.body.success, false);
-  assert.equal(inserts.length, 0);
 });
 
 // --- sendMessage -------------------------------------------------------


### PR DESCRIPTION
## Release dev → main

No user-facing changes. This release is the full delta between dev and
main: backend PR #309, removing the two API endpoints whose only
frontend consumers were already deleted and released.

### What
- Removes GET /api/notifications (notificationController.getNotifications)
  and its route. Its only client, notificationService.getNotifications,
  was removed in frontend PR #563.
- Removes POST /api/messages/conversations
  (messageController.startConversation) and its route. Its only client,
  the SendMessageButton direct branch plus messageService.startConversation,
  was removed in frontend PR #564.
- Drops the startConversation cases from
  test/messageController.bodyCasing.test.js.

Both endpoints were already caller-less in production after the frontend
release, so removing them is safe and resyncs the API surface with its
clients.

### Files
- src/controllers/notificationController.js
- src/controllers/messageController.js
- src/routes/notificationRoutes.js
- src/routes/messageRoutes.js
- test/messageController.bodyCasing.test.js

### Coupling
This is the backend half of the coupled release; the frontend half
(PRs #563–#567) is already merged to main and in production.

### Verification
node --check clean, backend test suite green (114 tests).
