### PR TITLE
Off-provider database backup script and daily launchd agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,15 @@ Thumbs.db
 *.backup
 *.old
 
+# Database dumps — belt-and-braces only.
+# scripts/backup-db.sh refuses to write inside the repo (see its guard), and the
+# configured location is outside both the repo and OneDrive. These patterns
+# exist so that a hand-rolled pg_dump run in the wrong directory still cannot be
+# committed: this repo is public, and a dump holds every user's email, password
+# hash, private messages and location.
+*.dump
+LomirBackups/
+
 # Test files
 test-results/
 coverage/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "seed": "node seed.js",
     "backup": "./scripts/backup-db.sh",
     "backup:status": "./scripts/backup-db.sh --status",
-    "backup:open": "open \"${LOMIR_BACKUP_DIR:-$HOME/LomirBackups}\""
+    "backup:open": "open \"${LOMIR_BACKUP_DIR:-$HOME/LomirBackups}\"",
+    "backup:install": "./scripts/install-backup-agent.sh",
+    "backup:uninstall": "./scripts/install-backup-agent.sh --uninstall"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "dev": "nodemon src/server.js",
     "test": "node --test",
     "migrate": "node migrate.js",
-    "seed": "node seed.js"
+    "seed": "node seed.js",
+    "backup": "./scripts/backup-db.sh",
+    "backup:status": "./scripts/backup-db.sh --status",
+    "backup:open": "open \"${LOMIR_BACKUP_DIR:-$HOME/LomirBackups}\""
   },
   "repository": {
     "type": "git",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,24 +6,31 @@ plus the database backup script.
 ## Backups — `backup-db.sh`
 
 ```bash
-npm run backup           # create a backup of the production database
+npm run backup           # create a backup now (do this before risky migrations)
 npm run backup:status    # list existing backups and the age of the newest
 npm run backup:open      # reveal the backup folder in Finder
+npm run backup:install   # install/refresh the daily launchd agent, then verify it
+npm run backup:uninstall # remove the agent (existing backups are kept)
 ```
 
-Dumps go to `~/LomirBackups` (override with `LOMIR_BACKUP_DIR`), are kept for
-30 days, and are verified with `pg_restore --list` before the script reports
-success. Requires `brew install postgresql@17`.
+A **launchd agent runs the backup daily at 10:00**, catching up after boot if a
+run was missed. Dumps go to `~/LomirBackups` (override with `LOMIR_BACKUP_DIR`),
+are kept for 30 days, and are verified with `pg_restore --list` before the
+script reports success. Requires `brew install postgresql@17`.
+
+**The agent runs from `~/.lomir/backup-db.sh`, not from this repo** — macOS
+denies background agents any access to `~/Library/CloudStorage` (OneDrive), so
+pointing launchd at the repo fails silently. **Re-run `npm run backup:install`
+after editing `backup-db.sh` or rotating the database password**, or the agent
+keeps using the old copy. Details: `install-backup-agent.sh` and the runbook.
 
 **The storage location is a safety decision, not a preference.** A dump contains
 every user's email, password hash, private messages and location, so the script
 **refuses** to write anywhere inside this repository (public on GitHub) or
 inside OneDrive (synced to a processor that is not in the DPA register).
 
-Run it **monthly** — alongside the `npm audit` pass — and manually before any
-risky migration. Neon's own PITR and snapshot branches are the first line of
-defence for everyday mistakes; this script exists for the case where Neon itself
-is unavailable.
+Neon's own PITR and snapshot branches are the first line of defence for everyday
+mistakes; this script exists for the case where Neon itself is unavailable.
 
 **Restore procedure and full reasoning:**
 `lomir-docs-internal/BACKUP_RESTORE_RUNBOOK.md`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,36 @@
 # Database Scripts
 
-This folder contains SQL scripts for seeding and managing the Lomir database.
+This folder contains SQL scripts for seeding and managing the Lomir database,
+plus the database backup script.
+
+## Backups — `backup-db.sh`
+
+```bash
+npm run backup           # create a backup of the production database
+npm run backup:status    # list existing backups and the age of the newest
+npm run backup:open      # reveal the backup folder in Finder
+```
+
+Dumps go to `~/LomirBackups` (override with `LOMIR_BACKUP_DIR`), are kept for
+30 days, and are verified with `pg_restore --list` before the script reports
+success. Requires `brew install postgresql@17`.
+
+**The storage location is a safety decision, not a preference.** A dump contains
+every user's email, password hash, private messages and location, so the script
+**refuses** to write anywhere inside this repository (public on GitHub) or
+inside OneDrive (synced to a processor that is not in the DPA register).
+
+Run it **monthly** — alongside the `npm audit` pass — and manually before any
+risky migration. Neon's own PITR and snapshot branches are the first line of
+defence for everyday mistakes; this script exists for the case where Neon itself
+is unavailable.
+
+**Restore procedure and full reasoning:**
+`lomir-docs-internal/BACKUP_RESTORE_RUNBOOK.md`.
+
+---
+
+## SQL scripts
 
 ## How to Run Scripts in Neon
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,8 +26,19 @@ keeps using the old copy. Details: `install-backup-agent.sh` and the runbook.
 
 **The storage location is a safety decision, not a preference.** A dump contains
 every user's email, password hash, private messages and location, so the script
-**refuses** to write anywhere inside this repository (public on GitHub) or
-inside OneDrive (synced to a processor that is not in the DPA register).
+**refuses** to write anywhere inside this repository (public on GitHub) or into
+any cloud-synced folder — `~/Library/CloudStorage` (OneDrive, Google Drive, Box,
+Dropbox), `~/Library/Mobile Documents` (iCloud Drive), `~/Dropbox`,
+`~/Google Drive`. Check a path without writing anything:
+
+```bash
+LOMIR_BACKUP_DIR=<path> ./scripts/backup-db.sh --check-dir
+```
+
+**Both operators run this on their own machine** — two laptops mean a period
+with one switched off is still covered. Requirements before installing on a
+machine: full-disk encryption on, and that machine legitimately holds the
+production `DATABASE_URL` already. See runbook §5.
 
 Neon's own PITR and snapshot branches are the first line of defence for everyday
 mistakes; this script exists for the case where Neon itself is unavailable.

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# Creates a compressed, self-contained backup of the Lomir production database.
+#
+# This is the OFF-PROVIDER leg of the backup strategy. Neon's own point-in-time
+# recovery and snapshot branches are the first line of defence and cover the
+# likely failure modes (bad migration, wrong UPDATE, destructive test). This
+# script covers the one thing they cannot: losing access to Neon itself.
+#
+# Full context, restore procedure and the reasoning behind the storage location:
+#   lomir-docs-internal/BACKUP_RESTORE_RUNBOOK.md
+#
+# Usage:
+#   npm run backup                 # create a backup
+#   npm run backup:status          # show existing backups and their age
+#   ./scripts/backup-db.sh --status
+#
+# Configuration (environment variables, all optional):
+#   LOMIR_BACKUP_DIR       target directory (default: $HOME/LomirBackups)
+#   LOMIR_BACKUP_KEEP_DAYS how long to keep old dumps (default: 30)
+#   DATABASE_URL           read from the repo's .env when not already set
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKUP_DIR="${LOMIR_BACKUP_DIR:-$HOME/LomirBackups}"
+KEEP_DAYS="${LOMIR_BACKUP_KEEP_DAYS:-30}"
+STALE_AFTER_DAYS=30
+
+# --- helpers -----------------------------------------------------------------
+
+die() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+# Age of a file in whole days. macOS stat, not GNU stat.
+file_age_days() {
+  local mtime now
+  mtime="$(stat -f %m "$1")"
+  now="$(date +%s)"
+  echo $(((now - mtime) / 86400))
+}
+
+report_existing_backups() {
+  local newest age count
+  count="$(find "$BACKUP_DIR" -maxdepth 1 -name 'lomir-*.dump' -type f 2>/dev/null | wc -l | tr -d ' ')"
+
+  if [ "$count" -eq 0 ]; then
+    printf 'No backups in %s yet.\n' "$BACKUP_DIR"
+    return
+  fi
+
+  printf 'Backups in %s (%s total):\n\n' "$BACKUP_DIR" "$count"
+  # Newest last, so the most recent line is closest to the summary below.
+  find "$BACKUP_DIR" -maxdepth 1 -name 'lomir-*.dump' -type f -print0 |
+    xargs -0 ls -lht |
+    awk '{printf "  %-7s %s %s %s  %s\n", $5, $6, $7, $8, $9}' |
+    tail -r
+
+  newest="$(find "$BACKUP_DIR" -maxdepth 1 -name 'lomir-*.dump' -type f -print0 |
+    xargs -0 ls -t | head -1)"
+  age="$(file_age_days "$newest")"
+
+  printf '\nNewest backup is %s day(s) old.\n' "$age"
+  if [ "$age" -ge "$STALE_AFTER_DAYS" ]; then
+    printf '\n  WARNING: that is older than %s days. Run: npm run backup\n' "$STALE_AFTER_DAYS"
+  fi
+}
+
+# --- --status short-circuit --------------------------------------------------
+
+if [ "${1:-}" = "--status" ]; then
+  report_existing_backups
+  exit 0
+fi
+
+# --- guard the storage location ----------------------------------------------
+#
+# The location is a deliberate decision, not a default: a dump of this database
+# contains every user's email, password hash, private messages and location.
+# Two places it must never land, both of which would leak it:
+#
+#   - inside the repo, which is PUBLIC on GitHub. Git itself does not follow
+#     symlinks and would only ever commit a link path, but a plain file could
+#     be committed by a stray `git add -A`, and a commit to a public repo is
+#     irreversible (history, forks, caches).
+#   - inside OneDrive, which syncs regardless of git and regardless of
+#     .gitignore. Microsoft is not in the project's DPA register.
+#
+# Both are cheap to detect, so the script refuses rather than trusting the
+# operator to remember.
+
+case "$BACKUP_DIR" in
+*/Library/CloudStorage/*)
+  die "refusing to write to '$BACKUP_DIR': that path is inside OneDrive/CloudStorage.
+       Backups contain personal data and must not be synced to a third party.
+       Use a local path such as \$HOME/LomirBackups."
+  ;;
+esac
+
+case "$BACKUP_DIR" in
+"$REPO_ROOT" | "$REPO_ROOT"/*)
+  die "refusing to write to '$BACKUP_DIR': that path is inside the repository,
+       which is public on GitHub. Use a local path such as \$HOME/LomirBackups."
+  ;;
+esac
+
+# --- resolve the connection string -------------------------------------------
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  [ -f "$REPO_ROOT/.env" ] || die "no DATABASE_URL in the environment and no .env at $REPO_ROOT"
+  DATABASE_URL="$(grep -E '^DATABASE_URL=' "$REPO_ROOT/.env" | head -1 | cut -d= -f2- | tr -d '"'"'"'' | sed 's/[[:space:]]*$//')"
+  [ -n "$DATABASE_URL" ] || die "DATABASE_URL is empty or missing in $REPO_ROOT/.env"
+fi
+
+command -v pg_dump >/dev/null 2>&1 || die "pg_dump not found. Install it with: brew install postgresql@17"
+command -v pg_restore >/dev/null 2>&1 || die "pg_restore not found. Install it with: brew install postgresql@17"
+
+# --- create the backup -------------------------------------------------------
+
+mkdir -p "$BACKUP_DIR"
+chmod 700 "$BACKUP_DIR"
+
+STAMP="$(date +%Y-%m-%d-%H%M)"
+TARGET="$BACKUP_DIR/lomir-$STAMP.dump"
+
+printf 'Backing up to %s\n' "$TARGET"
+
+# -Fc is the custom format: compressed, and pg_restore can filter it per table
+# on the way back in. --no-owner/--no-privileges keep the dump restorable into
+# a database whose role is not neondb_owner (a Neon branch, or local Postgres).
+if ! pg_dump "$DATABASE_URL" \
+  --format=custom \
+  --no-owner \
+  --no-privileges \
+  --file="$TARGET"; then
+  rm -f "$TARGET"
+  die "pg_dump failed. No backup was written."
+fi
+
+# Personal data: readable by the owner only.
+chmod 600 "$TARGET"
+
+# Verify the archive is actually readable rather than trusting the exit code.
+# pg_restore --list parses the whole table of contents, so a truncated or
+# corrupt dump fails here instead of on the day it is needed.
+if ! pg_restore --list "$TARGET" >/dev/null 2>&1; then
+  rm -f "$TARGET"
+  die "the dump was written but pg_restore could not read it. It has been deleted."
+fi
+
+TABLES="$(pg_restore --list "$TARGET" | grep -c 'TABLE DATA' || true)"
+SIZE="$(du -h "$TARGET" | cut -f1 | tr -d ' ')"
+
+printf 'OK: %s, %s tables with data, archive verified.\n' "$SIZE" "$TABLES"
+
+# --- prune old backups -------------------------------------------------------
+#
+# Retention is a privacy requirement, not just housekeeping: without it, users
+# who deleted their account keep living in the backups indefinitely. The window
+# is recorded in lomir-compliance (RECORDS_OF_PROCESSING / TOM).
+
+PRUNED="$(find "$BACKUP_DIR" -maxdepth 1 -name 'lomir-*.dump' -type f -mtime "+$KEEP_DAYS" -print -delete | wc -l | tr -d ' ')"
+if [ "$PRUNED" -gt 0 ]; then
+  printf 'Pruned %s backup(s) older than %s days.\n' "$PRUNED" "$KEEP_DAYS"
+fi
+
+printf '\n'
+report_existing_backups

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -113,11 +113,34 @@ fi
 # Both are cheap to detect, so the script refuses rather than trusting the
 # operator to remember.
 
+# Every cloud-sync location known on macOS, not just OneDrive. This machine's
+# repo happens to live in CloudStorage, but the script also runs on a second
+# operator's laptop whose setup we do not know — an unguarded iCloud or Dropbox
+# folder would ship the whole database to a provider nobody vetted.
+#
+#   ~/Library/CloudStorage/   OneDrive, Google Drive, Box, current Dropbox
+#   ~/Library/Mobile Documents/  iCloud Drive (NOT under CloudStorage)
+#   ~/Dropbox, ~/Google Drive    legacy clients that still use home-level folders
+SYNC_HINT="Backups contain every user's email, password hash, private messages
+       and location. They must not be synced to a third party.
+       Use a local path such as \$HOME/LomirBackups."
+
 case "$BACKUP_DIR" in
 */Library/CloudStorage/*)
   die "refusing to write to '$BACKUP_DIR': that path is inside OneDrive/CloudStorage.
-       Backups contain personal data and must not be synced to a third party.
-       Use a local path such as \$HOME/LomirBackups."
+       $SYNC_HINT"
+  ;;
+*/Library/Mobile\ Documents/*)
+  die "refusing to write to '$BACKUP_DIR': that path is inside iCloud Drive.
+       $SYNC_HINT"
+  ;;
+"$HOME"/Dropbox | "$HOME"/Dropbox/* | *"/Dropbox ("*)
+  die "refusing to write to '$BACKUP_DIR': that path is inside Dropbox.
+       $SYNC_HINT"
+  ;;
+"$HOME"/Google\ Drive | "$HOME"/Google\ Drive/*)
+  die "refusing to write to '$BACKUP_DIR': that path is inside Google Drive.
+       $SYNC_HINT"
   ;;
 esac
 
@@ -128,6 +151,13 @@ if [ "$IN_REPO" = true ]; then
        which is public on GitHub. Use a local path such as \$HOME/LomirBackups."
     ;;
   esac
+fi
+
+# The installer validates the target before creating anything, by calling this
+# script rather than repeating the patterns above — one source of truth.
+if [ "${1:-}" = "--check-dir" ]; then
+  printf 'Backup directory is safe: %s\n' "$BACKUP_DIR"
+  exit 0
 fi
 
 # --- resolve the connection string -------------------------------------------

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -26,6 +26,28 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BACKUP_DIR="${LOMIR_BACKUP_DIR:-$HOME/LomirBackups}"
 KEEP_DAYS="${LOMIR_BACKUP_KEEP_DAYS:-30}"
 STALE_AFTER_DAYS=30
+AGENT_CONFIG="$HOME/.lomir/backup.env"
+
+# This script runs from two places, and the difference matters.
+#
+#   1. From the repo, invoked by hand as `npm run backup`.
+#   2. From ~/.lomir, invoked by the launchd agent (see
+#      scripts/install-backup-agent.sh).
+#
+# Case 2 exists because the repo lives inside ~/Library/CloudStorage (OneDrive),
+# and macOS denies background agents *any* access there — verified 2026-07-28:
+# a launchd agent could not list the repo directory, read .env, or even read
+# this script (exit 126, "Operation not permitted"). Granting the access would
+# mean giving /bin/bash Full Disk Access, which is far too broad a permission
+# to hand out for a backup job. So the agent runs from a copy outside OneDrive
+# and never touches the repo at runtime.
+#
+# IN_REPO tells the two apart: only a real checkout has package.json one level
+# up. It must not be assumed, because when the installed copy sits in
+# $HOME/.lomir, REPO_ROOT resolves to $HOME — and the repo guard below would
+# then reject the perfectly good default backup directory underneath it.
+IN_REPO=false
+[ -f "$REPO_ROOT/package.json" ] && IN_REPO=true
 
 # --- helpers -----------------------------------------------------------------
 
@@ -99,19 +121,34 @@ case "$BACKUP_DIR" in
   ;;
 esac
 
-case "$BACKUP_DIR" in
-"$REPO_ROOT" | "$REPO_ROOT"/*)
-  die "refusing to write to '$BACKUP_DIR': that path is inside the repository,
+if [ "$IN_REPO" = true ]; then
+  case "$BACKUP_DIR" in
+  "$REPO_ROOT" | "$REPO_ROOT"/*)
+    die "refusing to write to '$BACKUP_DIR': that path is inside the repository,
        which is public on GitHub. Use a local path such as \$HOME/LomirBackups."
-  ;;
-esac
+    ;;
+  esac
+fi
 
 # --- resolve the connection string -------------------------------------------
 
+# Resolution order: environment, then the agent's own config outside OneDrive,
+# then the repo .env. The agent copy can only ever reach the second.
+read_database_url_from() {
+  grep -E '^DATABASE_URL=' "$1" | head -1 | cut -d= -f2- | tr -d '"'"'"'' | sed 's/[[:space:]]*$//'
+}
+
+if [ -z "${DATABASE_URL:-}" ] && [ -f "$AGENT_CONFIG" ]; then
+  DATABASE_URL="$(read_database_url_from "$AGENT_CONFIG")"
+fi
+
+if [ -z "${DATABASE_URL:-}" ] && [ "$IN_REPO" = true ] && [ -f "$REPO_ROOT/.env" ]; then
+  DATABASE_URL="$(read_database_url_from "$REPO_ROOT/.env")"
+fi
+
 if [ -z "${DATABASE_URL:-}" ]; then
-  [ -f "$REPO_ROOT/.env" ] || die "no DATABASE_URL in the environment and no .env at $REPO_ROOT"
-  DATABASE_URL="$(grep -E '^DATABASE_URL=' "$REPO_ROOT/.env" | head -1 | cut -d= -f2- | tr -d '"'"'"'' | sed 's/[[:space:]]*$//')"
-  [ -n "$DATABASE_URL" ] || die "DATABASE_URL is empty or missing in $REPO_ROOT/.env"
+  die "no DATABASE_URL found. Looked in: the environment, $AGENT_CONFIG$([ "$IN_REPO" = true ] && echo ", $REPO_ROOT/.env").
+       If this ran as the launchd agent, re-run 'npm run backup:install' from the repo."
 fi
 
 command -v pg_dump >/dev/null 2>&1 || die "pg_dump not found. Install it with: brew install postgresql@17"
@@ -122,7 +159,10 @@ command -v pg_restore >/dev/null 2>&1 || die "pg_restore not found. Install it w
 mkdir -p "$BACKUP_DIR"
 chmod 700 "$BACKUP_DIR"
 
-STAMP="$(date +%Y-%m-%d-%H%M)"
+# Seconds matter: with minute granularity, two runs in the same minute — a
+# manual `npm run backup` and the launchd agent firing right after it, which is
+# exactly what the installer does — silently overwrite each other.
+STAMP="$(date +%Y-%m-%d-%H%M%S)"
 TARGET="$BACKUP_DIR/lomir-$STAMP.dump"
 
 printf 'Backing up to %s\n' "$TARGET"

--- a/scripts/install-backup-agent.sh
+++ b/scripts/install-backup-agent.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# Installs (or refreshes) the launchd agent that runs the database backup daily.
+#
+#   npm run backup:install     install / update the agent
+#   npm run backup:uninstall   remove it again
+#
+# WHY THIS EXISTS AT ALL
+#
+# The obvious approach — point launchd straight at scripts/backup-db.sh in the
+# repo — does not work, and fails *silently* in the worst way: the job reports
+# an error to a log nobody reads while you believe backups are running.
+#
+# The repo lives inside ~/Library/CloudStorage (OneDrive). macOS denies
+# background agents any access to that location. Measured 2026-07-28 with a
+# probe agent: listing the repo directory, reading .env and even reading the
+# backup script itself were all refused ("Operation not permitted", exit 126).
+# Only a Full Disk Access grant to /bin/bash would lift it, which would hand
+# every shell script on the machine full access — not an acceptable trade for
+# a backup job.
+#
+# So the agent gets its own copy of everything it needs, outside OneDrive:
+#
+#   ~/.lomir/backup-db.sh   copy of the repo script
+#   ~/.lomir/backup.env     DATABASE_URL only, chmod 600
+#
+# Re-run this script after changing backup-db.sh or rotating the database
+# credentials — the copy does not update itself. That duplication is the price
+# of keeping the repo in OneDrive; moving the repos out would remove the need
+# for this file entirely (and would also fix the known ETIMEDOUT build stalls).
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_DIR="$HOME/.lomir"
+AGENT_SCRIPT="$INSTALL_DIR/backup-db.sh"
+AGENT_CONFIG="$INSTALL_DIR/backup.env"
+LABEL="com.lomir.backup"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+BACKUP_DIR="${LOMIR_BACKUP_DIR:-$HOME/LomirBackups}"
+HOUR="${LOMIR_BACKUP_HOUR:-10}"
+
+die() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+# --- uninstall ---------------------------------------------------------------
+
+if [ "${1:-}" = "--uninstall" ]; then
+  launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+  rm -f "$PLIST"
+  rm -rf "$INSTALL_DIR"
+  printf 'Removed the launchd agent and %s.\n' "$INSTALL_DIR"
+  printf 'Existing backups in %s were kept.\n' "$BACKUP_DIR"
+  exit 0
+fi
+
+# --- checks ------------------------------------------------------------------
+
+[ -f "$REPO_ROOT/scripts/backup-db.sh" ] || die "scripts/backup-db.sh not found next to this script"
+[ -f "$REPO_ROOT/.env" ] || die "no .env at $REPO_ROOT - cannot read DATABASE_URL"
+command -v pg_dump >/dev/null 2>&1 || die "pg_dump not found. Install it with: brew install postgresql@17"
+
+DB_URL="$(grep -E '^DATABASE_URL=' "$REPO_ROOT/.env" | head -1 | cut -d= -f2- | tr -d '"'"'"'' | sed 's/[[:space:]]*$//')"
+[ -n "$DB_URL" ] || die "DATABASE_URL is empty or missing in $REPO_ROOT/.env"
+
+# pg_dump must be on the agent's PATH; launchd jobs inherit no login shell.
+BASE_PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+PG_BIN="$(dirname "$(command -v pg_dump)")"
+case ":$BASE_PATH:" in
+*":$PG_BIN:"*) AGENT_PATH="$BASE_PATH" ;;
+*) AGENT_PATH="$PG_BIN:$BASE_PATH" ;;
+esac
+
+# --- provision the runtime copy ----------------------------------------------
+
+mkdir -p "$INSTALL_DIR"
+chmod 700 "$INSTALL_DIR"
+
+cp "$REPO_ROOT/scripts/backup-db.sh" "$AGENT_SCRIPT"
+chmod 700 "$AGENT_SCRIPT"
+
+# A second copy of the credential now exists outside the repo. Keep it readable
+# by the owner only; FileVault covers it at rest.
+umask 077
+printf 'DATABASE_URL=%s\n' "$DB_URL" >"$AGENT_CONFIG"
+chmod 600 "$AGENT_CONFIG"
+
+mkdir -p "$BACKUP_DIR"
+chmod 700 "$BACKUP_DIR"
+
+# --- write and load the agent ------------------------------------------------
+
+mkdir -p "$HOME/Library/LaunchAgents"
+
+cat >"$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>$AGENT_SCRIPT</string>
+  </array>
+
+  <!-- launchd jobs inherit no login shell, so pg_dump must be given explicitly. -->
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>$AGENT_PATH</string>
+    <key>HOME</key>
+    <string>$HOME</string>
+    <key>LOMIR_BACKUP_DIR</key>
+    <string>$BACKUP_DIR</string>
+  </dict>
+
+  <!-- Daily. Unlike cron, launchd remembers a missed occurrence and runs the
+       job once shortly after the next boot or wake, coalescing several missed
+       runs into one. A laptop that was off for weeks backs up on next start. -->
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key><integer>$HOUR</integer>
+    <key>Minute</key><integer>0</integer>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>$BACKUP_DIR/backup.log</string>
+  <key>StandardErrorPath</key>
+  <string>$BACKUP_DIR/backup.log</string>
+</dict>
+</plist>
+PLIST_EOF
+
+chmod 644 "$PLIST"
+plutil -lint "$PLIST" >/dev/null || die "the generated plist is malformed: $PLIST"
+
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST" || die "launchctl bootstrap failed for $PLIST"
+
+# --- prove it actually runs --------------------------------------------------
+#
+# An installed-but-broken backup job is worse than none, because it creates
+# false confidence. So trigger it once and require a new dump to appear.
+
+printf 'Agent installed. Verifying with a real run...\n\n'
+
+# Detect the new dump by modification time against a marker, not by counting
+# files: a run that lands in the same second as an earlier one reuses the
+# filename, so the count can stay flat even though the agent worked perfectly.
+MARKER="$INSTALL_DIR/.verify-marker"
+touch "$MARKER"
+sleep 1
+: >"$BACKUP_DIR/backup.log"
+
+launchctl kickstart -p "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || true
+
+FRESH=0
+for _ in $(seq 1 30); do
+  sleep 1
+  FRESH="$(find "$BACKUP_DIR" -maxdepth 1 -name 'lomir-*.dump' -type f -newer "$MARKER" | wc -l | tr -d ' ')"
+  [ "$FRESH" -gt 0 ] && break
+done
+rm -f "$MARKER"
+
+if [ "$FRESH" -gt 0 ]; then
+  cat "$BACKUP_DIR/backup.log"
+  printf '\nVerified: the agent produced a backup. It will run daily at %s:00.\n' "$HOUR"
+  printf 'Log: %s\n' "$BACKUP_DIR/backup.log"
+else
+  printf 'The agent did NOT produce a backup. Log follows:\n\n'
+  cat "$BACKUP_DIR/backup.log" 2>/dev/null || printf '(log is empty)\n'
+  printf '\nStatus: %s\n' "$(launchctl list "$LABEL" 2>/dev/null | grep LastExitStatus || echo unknown)"
+  die "installation is not working - do not rely on it until this is fixed."
+fi

--- a/scripts/install-backup-agent.sh
+++ b/scripts/install-backup-agent.sh
@@ -62,6 +62,12 @@ fi
 [ -f "$REPO_ROOT/.env" ] || die "no .env at $REPO_ROOT - cannot read DATABASE_URL"
 command -v pg_dump >/dev/null 2>&1 || die "pg_dump not found. Install it with: brew install postgresql@17"
 
+# Validate the target before creating any directory, so a cloud-synced path is
+# rejected rather than silently created. The check lives in backup-db.sh so the
+# rules are not duplicated here.
+LOMIR_BACKUP_DIR="$BACKUP_DIR" "$REPO_ROOT/scripts/backup-db.sh" --check-dir ||
+  die "refusing to install with this backup directory. Set LOMIR_BACKUP_DIR to a local path."
+
 DB_URL="$(grep -E '^DATABASE_URL=' "$REPO_ROOT/.env" | head -1 | cut -d= -f2- | tr -d '"'"'"'' | sed 's/[[:space:]]*$//')"
 [ -n "$DB_URL" ] || die "DATABASE_URL is empty or missing in $REPO_ROOT/.env"
 


### PR DESCRIPTION
What this releases
A single merged PR, #311 (e5097de), plus its three commits. This is the only content difference between dev and main.

Deployment risk: none
The diff touches no src/ file — only scripts/, package.json (five new npm scripts) and .gitignore. Nothing in the deployed runtime changes; Render will build and serve exactly the code it serves today. This release exists so the backup tooling stops sitting on dev indefinitely.


 .gitignore                      |   9 ++
 package.json                    |   7 +-
 scripts/README.md               |  50 ++++++++-
 scripts/backup-db.sh            | 240 ++++++++++++++++++++++++++++++
 scripts/install-backup-agent.sh | 184 ++++++++++++++++++++++++++++++
Why
The database had no restore path that we had actually executed. The design has two layers, deliberately covering different failures:

Neon PITR / snapshot branches — the first line. Covers our own mistakes (a bad migration, a wrong UPDATE, a destructive test) instantly, and with zero compliance impact because no personal data leaves Neon.
Local pg_dump — the disaster leg. Covers the one thing Neon cannot: losing Neon itself. A copy inside the same account is not independent of that account.
What it adds
scripts/backup-db.sh — pg_dump to ~/LomirBackups, 30-day retention, plus a --status and a --check-dir mode.
scripts/install-backup-agent.sh — installs a daily launchd agent (com.lomir.backup), or removes it with --uninstall.
npm scripts: backup, backup:status, backup:open, backup:install, backup:uninstall.
scripts/README.md — usage; the full operational runbook lives in the internal docs.
Two decisions worth knowing
The backup target is guarded, not just documented. The script refuses to write into a cloud-synced or in-repo location, because all three obvious destinations are wrong for a concrete reason: these repos are public, so a committed dump is irreversible; OneDrive syncs regardless of .gitignore and Microsoft is not in our DPA register; and GitHub Actions artifacts on a public repo are downloadable by anyone, which rules out the otherwise obvious scheduled-Action approach. Six sync-path patterns are rejected (~/Library/CloudStorage, iCloud's ~/Library/Mobile Documents, legacy Dropbox and Google Drive locations among them).

The agent runs from ~/.lomir, not from the repo — and that is load-bearing. macOS denies background agents any access to ~/Library/CloudStorage, where these repos live, and the failure is silent: the first install produced no backup while reporting success into a log nobody reads. The installer therefore provisions a copy of the script and its credentials outside OneDrive (chmod 600). Re-run npm run backup:install after changing the script or rotating the database password.

Verification
Backend test suite 114/114.
Both location guards tested against real rejected paths.
Install verified by triggering a real run and requiring a fresh artifact — launchctl bootstrap exit codes are not trusted, since an installed-but-broken backup job is worse than none.
Restore actually executed, not just written down: dump loaded into a throwaway PostgreSQL 17 instance; all 9 spot-checked table counts identical to production, 6 views present, ltree present, sequence value matching. 23 MB database to a 1.0 MB dump in roughly 4 seconds; restore in 1.1 seconds.
Note for future restore checks: pg_dump does not copy materialized view contents — it emits the definition plus a REFRESH, so a restored copy is recomputed and may legitimately differ from a stale production one. That difference is not a failed restore.