### PR TITLE
Fix/backup agent three daily slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Verify it's running by visiting `http://localhost:5001` — you should see **"Lo
 | `npm run migrate` | Run database migrations |
 | `npm run seed` | Seed the database with initial data |
 | `npm test` | Run tests (`node --test`) |
+| `npm run backup` | Create a database dump now (see [Database Backups](#database-backups)) |
+| `npm run backup:status` | List existing dumps with their age |
+| `npm run backup:install` | Install or refresh the scheduled backup agent |
+| `npm run backup:uninstall` | Remove the scheduled backup agent |
 
 ### Test Notes
 
@@ -435,6 +439,31 @@ picked up related records during development or test activity.
 
 ---
 
+## Database Backups
+
+Two layers with different jobs. The scheduled agent below is an operator tool that runs on a developer machine, not one of the server-side [Scheduled Jobs](#scheduled-jobs).
+
+- **Neon point-in-time recovery and snapshot branches** — the first line of defence, covering the likely failure modes: a bad migration, a wrong `UPDATE`, a destructive test. How far back it reaches depends on the history retention of the Neon plan.
+- **Local `pg_dump` archives** — the off-provider leg, covering the one thing Neon cannot: losing access to Neon itself.
+
+Dumps are written to `~/LomirBackups` as `lomir-<timestamp>.dump` in the custom `pg_dump` format, with the directory `chmod 700`, and are pruned after 30 days. Pruning only runs after a new dump succeeded, so a run of failures can never delete the last remaining backup. `npm run backup:status` reports the age of the newest dump and warns once it passes 30 days.
+
+The agent installed by `npm run backup:install` runs at **10:00, 14:00, and 17:00**. Three slots rather than one because a laptop asleep at a given time misses that run: launchd then fires it once on wake, when Wi-Fi may not be up yet, and `pg_dump` fails to resolve the database host. The later slots turn a missed slot into a retry a few hours later instead of a lost day. `backup:install` verifies itself by forcing a real run and fails loudly if no dump appears — an installed-but-broken backup job is worse than none, because it creates false confidence.
+
+Configuration, all optional shell variables:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `LOMIR_BACKUP_DIR` | `~/LomirBackups` | Target directory. Cloud-synced paths (OneDrive, iCloud Drive, Dropbox, Google Drive) and paths inside the repo are refused |
+| `LOMIR_BACKUP_KEEP_DAYS` | `30` | How long dumps are kept |
+| `LOMIR_BACKUP_HOURS` | `10,14,17` | Agent schedule, comma-separated hours 0-23; applied by `backup:install` |
+
+`DATABASE_URL` is read from the repo's `.env`. The agent cannot read it there, because the repo lives inside `~/Library/CloudStorage` and macOS denies background agents any access to that location, so `backup:install` provisions its own copy of the script and the credential under `~/.lomir` (`chmod 600`). **Re-run `npm run backup:install` after changing `scripts/backup-db.sh` or rotating the database credentials** — that copy does not update itself.
+
+Requires `pg_dump` on the `PATH` (`brew install postgresql@17`). The restore procedure is kept in an internal runbook outside this repository.
+
+---
+
 ## Account Deletion
 
 Full transactional account deletion. Key highlights:
@@ -491,6 +520,8 @@ Covered by `teamController.deleteTeam.test.js`, `cleanupArchivedTeams.test.js`, 
 - **Email provider is not configured** — Set `BREVO_API_KEY` and `BREVO_SENDER_EMAIL` (the sender must be verified in Brevo)
 - **Port already in use** — `lsof -i :5001` to find the process, `kill -9 <PID>` to free the port
 - **CAPTCHA not loading locally** — Expected when no Turnstile key is configured; the CAPTCHA check runs in the deployed environment.
+- **Scheduled backup logs `could not translate host name`** — The machine was asleep at the scheduled time, so launchd started the job on wake before the network was up. A later slot covers it; `npm run backup:status` shows whether a dump landed that day. `npm run backup` any time to close the gap.
+- **Scheduled backup stopped producing dumps** — `launchctl list com.lomir.backup` shows the last exit status, and `~/LomirBackups/backup.log` holds the output of agent runs only (a manual `npm run backup` writes to the terminal instead, so the log is not a reliable status indicator — use `npm run backup:status`).
 
 ---
 

--- a/scripts/install-backup-agent.sh
+++ b/scripts/install-backup-agent.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Installs (or refreshes) the launchd agent that runs the database backup daily.
+# Installs (or refreshes) the launchd agent that runs the database backup at
+# several fixed times each day.
 #
 #   npm run backup:install     install / update the agent
 #   npm run backup:uninstall   remove it again
@@ -38,7 +39,16 @@ AGENT_CONFIG="$INSTALL_DIR/backup.env"
 LABEL="com.lomir.backup"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 BACKUP_DIR="${LOMIR_BACKUP_DIR:-$HOME/LomirBackups}"
-HOUR="${LOMIR_BACKUP_HOUR:-10}"
+
+# Three slots a day rather than one. A single 10:00 run is missed whenever the
+# laptop is asleep at that moment, and launchd then fires it on wake, before
+# Wi-Fi is up - pg_dump fails to resolve the database host and no backup is
+# written. That is what left 2026-07-29 and 07-30 without one. Later slots cost
+# about 1 MB each and turn a missed slot into a retry a few hours later.
+#
+# Override with LOMIR_BACKUP_HOURS as a comma-separated list of hours, e.g.
+# LOMIR_BACKUP_HOURS=9,21. The older singular LOMIR_BACKUP_HOUR still works.
+HOURS="${LOMIR_BACKUP_HOURS:-${LOMIR_BACKUP_HOUR:-10,14,17}}"
 
 die() {
   printf 'ERROR: %s\n' "$1" >&2
@@ -78,6 +88,33 @@ case ":$BASE_PATH:" in
 *":$PG_BIN:"*) AGENT_PATH="$BASE_PATH" ;;
 *) AGENT_PATH="$PG_BIN:$BASE_PATH" ;;
 esac
+
+# --- build the schedule ------------------------------------------------------
+#
+# Validated here rather than left to launchd: plutil accepts an out-of-range
+# hour, and the agent then simply never fires.
+
+CALENDAR_ENTRIES=""
+HOURS_HUMAN=""
+IFS=',' read -r -a HOUR_LIST <<<"$HOURS"
+for RAW_HOUR in "${HOUR_LIST[@]}"; do
+  HOUR="${RAW_HOUR//[[:space:]]/}"
+  [ -n "$HOUR" ] || continue
+  case "$HOUR" in
+  *[!0-9]*) die "invalid backup hour '$HOUR' in '$HOURS': use comma-separated hours 0-23" ;;
+  esac
+  # Base 10 explicitly, so a written-out 09 is nine and not an octal error.
+  HOUR="$((10#$HOUR))"
+  { [ "$HOUR" -ge 0 ] && [ "$HOUR" -le 23 ]; } ||
+    die "backup hour '$HOUR' is out of range 0-23"
+  CALENDAR_ENTRIES="$CALENDAR_ENTRIES
+    <dict>
+      <key>Hour</key><integer>$HOUR</integer>
+      <key>Minute</key><integer>0</integer>
+    </dict>"
+  HOURS_HUMAN="${HOURS_HUMAN:+$HOURS_HUMAN, }$(printf '%02d:00' "$HOUR")"
+done
+[ -n "$CALENDAR_ENTRIES" ] || die "no valid backup hours in '$HOURS'"
 
 # --- provision the runtime copy ----------------------------------------------
 
@@ -124,14 +161,14 @@ cat >"$PLIST" <<PLIST_EOF
     <string>$BACKUP_DIR</string>
   </dict>
 
-  <!-- Daily. Unlike cron, launchd remembers a missed occurrence and runs the
-       job once shortly after the next boot or wake, coalescing several missed
-       runs into one. A laptop that was off for weeks backs up on next start. -->
+  <!-- Several times a day, so one missed slot is retried a few hours later
+       instead of costing the whole day. Unlike cron, launchd remembers missed
+       occurrences and runs the job once shortly after the next boot or wake,
+       coalescing them - a laptop that was off for weeks backs up once on next
+       start, not once per slot it slept through. -->
   <key>StartCalendarInterval</key>
-  <dict>
-    <key>Hour</key><integer>$HOUR</integer>
-    <key>Minute</key><integer>0</integer>
-  </dict>
+  <array>$CALENDAR_ENTRIES
+  </array>
 
   <key>StandardOutPath</key>
   <string>$BACKUP_DIR/backup.log</string>
@@ -174,7 +211,7 @@ rm -f "$MARKER"
 
 if [ "$FRESH" -gt 0 ]; then
   cat "$BACKUP_DIR/backup.log"
-  printf '\nVerified: the agent produced a backup. It will run daily at %s:00.\n' "$HOUR"
+  printf '\nVerified: the agent produced a backup. It will run daily at %s.\n' "$HOURS_HUMAN"
   printf 'Log: %s\n' "$BACKUP_DIR/backup.log"
 else
   printf 'The agent did NOT produce a backup. Log follows:\n\n'


### PR DESCRIPTION
The backup agent was scheduled for a single daily slot at 10:00. That slot is missed whenever the laptop is asleep at that moment, and launchd then starts the job on wake — frequently before Wi-Fi is up. pg_dump cannot resolve the Neon host, the run dies, and no backup is written.

This is not hypothetical. It happened on 2026-07-29 and 07-30: two consecutive days with no backup at all, while the agent still looked installed and healthy. The only trace was in ~/LomirBackups/backup.log:


pg_dump: could not translate host name "ep-…-pooler.eu-central-1.aws.neon.tech"
ERROR: pg_dump failed. No backup was written.
The dangerous part is not the missed dump, it is the silence. An installed backup job that reports failure only into a log file nobody reads produces exactly the false confidence the install script was written to prevent.

What changed
scripts/install-backup-agent.sh

StartCalendarInterval is now an array of entries instead of a single one. Default schedule: 10:00, 14:00, 17:00.
HOUR became HOURS, configurable via LOMIR_BACKUP_HOURS as a comma-separated list. The older singular LOMIR_BACKUP_HOUR is still honoured, so an existing override does not silently change meaning.
Hours are validated before the plist is written — digits only, range 0–23, parsed with an explicit base so a written-out 09 is nine rather than an octal error. This matters because plutil -lint accepts an out-of-range hour and the agent then simply never fires, which is the same silent-failure class this PR is fixing.
The closing verification message lists all configured times instead of one.
README.md

The backup tooling shipped undocumented in #311/#312. Adds a Database Backups section covering both layers of the strategy — Neon PITR as the first line of defence, local pg_dump archives as the off-provider leg for losing access to Neon itself — the schedule and why there are three slots, the LOMIR_BACKUP_* variables, and the requirement to re-run backup:install after changing the script or rotating credentials. Two new Troubleshooting entries, including the fact that backup.log carries agent runs only and is therefore not a reliable status indicator; npm run backup:status is.

What this does not fix
The wake-up race itself. Whichever slot fires on wake can still fail — the later slots are a safety net, not a cure. This is a deliberate, probabilistic trade-off: these dumps are the off-provider leg, and one that succeeds most days is sufficient for that job. The real fix is a laptop-independent leg (encrypted upload to an EU object store with a DPA), which stays deferred until it is warranted.

Verification
Ran on the operator machine:

bash -n clean; the hour-parsing loop exercised in isolation for 10,14,17, whitespace, non-numeric input and leading zeros
npm run backup:install regenerated the plist; plutil -p confirms three StartCalendarInterval entries (10, 14, 17)
launchctl list com.lomir.backup last exit status went from 1 to 0
The install script's self-verification produced a real dump, independently checked with pg_restore --list: 19 tables with data, 240 TOC entries, 985 KB — same shape as the last known-good dumps from 07-28
Backward compatibility: LOMIR_BACKUP_HOUR=10 still yields a single 10:00 slot
Blast radius
Local operator tooling only. No server code, no runtime behaviour, no API surface, no database schema, no deployment. Nothing in this PR runs on Render or Vercel.

One operational note: merging this changes nothing on anyone's machine by itself. The agent runs from a copy at ~/.lomir/backup-db.sh with its own generated plist, so each operator has to re-run npm run backup:install after pulling to pick up the new schedule. Expected output ends with It will run daily at 10:00, 14:00, 17:00 — if it names only 10:00, the checkout predates this change.